### PR TITLE
get main passing linting

### DIFF
--- a/Non-imaging baseline/baseline_pcr_simple.py
+++ b/Non-imaging baseline/baseline_pcr_simple.py
@@ -37,7 +37,7 @@ def get_patient_id(path: Path, js: dict[str, Any]) -> str:
     return js.get("patient_id", path.stem)
 
 
-def get_age(js) -> float | None:
+def get_age(js: dict) -> float | None:
     """Extract and return patient age as float from JSON or None if unavailable."""
     age = js.get("clinical_data", {}).get("age", None)
     try:
@@ -80,6 +80,7 @@ def get_bbox_volume(js: dict[str, Any]) -> float | None:
 
 def load_dataset(json_dir: Path, split_csv: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Loads train/test DataFrames.
+
     CSV only includes train/val, val is treated as test for now.
     """
     splits = pd.read_csv(split_csv, comment="#").dropna(how="all")
@@ -115,15 +116,17 @@ def load_dataset(json_dir: Path, split_csv: Path) -> tuple[pd.DataFrame, pd.Data
             }
         )
 
-    df = pd.DataFrame(rows)
+    df_all = pd.DataFrame(rows)
 
     # Use val as test
-    if not (df["split"] == "test").any():
-        warnings.warn("No explicit test split found — using val as test for now.")
-        df.loc[df["split"] == "val", "split"] = "test"
+    if not (df_all["split"] == "test").any():
+        warnings.warn(
+            "No explicit test split found — using val as test for now.", stacklevel=1
+        )
+        df_all.loc[df_all["split"] == "val", "split"] = "test"
 
-    df_train = df[df["split"] == "train"].copy()
-    df_test = df[df["split"] == "test"].copy()
+    df_train = df_all[df_all["split"] == "train"].copy()
+    df_test = df_all[df_all["split"] == "test"].copy()
     return df_train, df_test
 
 
@@ -159,7 +162,13 @@ def build_pipeline(C: float = 1.0, max_iter: int = 1000) -> Pipeline:
 
 
 # Model
-def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
+def train_and_test(
+    df_train: pd.DataFrame,
+    df_test: pd.DataFrame,
+    outdir: Path,
+    C: float = 1.0,
+    max_iter: int = 1000,
+) -> dict:
     """Train model, compute metrics, save outputs, and return metrics dict."""
     outdir.mkdir(parents=True, exist_ok=True)
     pipe = build_pipeline(C=C, max_iter=max_iter)
@@ -168,7 +177,7 @@ def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
     df_test_lab = df_test.dropna(subset=["y"]).copy()
 
     X_train = df_train_lab[["age", "bbox_volume", "tumor_subtype"]]
-    y_train = df_train_lab["y"].astype(int).values
+    y_train = df_train_lab["y"].astype(int).to_numpy()
     pipe.fit(X_train, y_train)
 
     # AUCs
@@ -177,7 +186,7 @@ def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
 
     if len(df_test_lab) != 0:
         X_test = df_test_lab[["age", "bbox_volume", "tumor_subtype"]]
-        y_test = df_test_lab["y"].astype(int).values
+        y_test = df_test_lab["y"].astype(int).to_numpy()
         test_scores = pipe.predict_proba(X_test)[:, 1]
         auc_test = float(roc_auc_score(y_test, test_scores))
     else:
@@ -189,9 +198,9 @@ def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
         preds.append(
             pd.DataFrame(
                 {
-                    "patient_id": df["patient_id"].values,
-                    "split": df["split"].values,
-                    "y_true": df["y"].values,
+                    "patient_id": df["patient_id"].to_numpy(),
+                    "split": df["split"].to_numpy(),
+                    "y_true": df["y"].to_numpy(),
                     "y_pred_score": pipe.predict_proba(
                         df[["age", "bbox_volume", "tumor_subtype"]]
                     )[:, 1],
@@ -228,7 +237,7 @@ def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
     return metrics
 
 
-def main():
+def main() -> None:
     """Parse arguments, load data, train model, print metrics."""
     ap = argparse.ArgumentParser(description="Minimal pCR baseline (fixed schema).")
     ap.add_argument("--json-dir", required=True, type=Path)


### PR DESCRIPTION
@isumme @julialuo02 @manucardona @RebeccaRuochunWu 

Starting from the `main` branch, running `pre-commit run -a` does three things: (1) it installs what it needs to, (2) it changes what it can to make the style conform to standards, and (3) it complains about what it can't change automatically.

Here's the output:

```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing Non-imaging baseline/baseline_pcr_simple.py

check yaml...............................................................Passed
check for added large files..............................................Passed
ruff.....................................................................Failed
- hook id: ruff
- exit code: 1
- files were modified by this hook

Non-imaging baseline/baseline_pcr_simple.py:35:5: D103 Missing docstring in public function
   |
35 | def get_patient_id(path: Path, js: dict[str, Any]) -> str:
   |     ^^^^^^^^^^^^^^ D103
36 |     return js.get("patient_id", path.stem)
   |

Non-imaging baseline/baseline_pcr_simple.py:38:5: D103 Missing docstring in public function
   |
36 |     return js.get("patient_id", path.stem)
37 | 
38 | def get_age(js) -> float | None:
   |     ^^^^^^^ D103
39 |     age = js.get("clinical_data", {}).get("age", None)
40 |     try:
   |

Non-imaging baseline/baseline_pcr_simple.py:38:13: ANN001 Missing type annotation for function argument `js`
   |
36 |     return js.get("patient_id", path.stem)
37 | 
38 | def get_age(js) -> float | None:
   |             ^^ ANN001
39 |     age = js.get("clinical_data", {}).get("age", None)
40 |     try:
   |

Non-imaging baseline/baseline_pcr_simple.py:45:5: D103 Missing docstring in public function
   |
43 |         return None
44 | 
45 | def get_subtype(js: dict[str, Any]) -> str:
   |     ^^^^^^^^^^^ D103
46 |     subtype = js.get("primary_lesion", {}).get("tumor_subtype", "")
47 |     s = str(subtype).strip().lower()
   |

Non-imaging baseline/baseline_pcr_simple.py:50:5: D103 Missing docstring in public function
   |
48 |     return s if s else "unknown"
49 | 
50 | def get_label_optional(js: dict[str, Any]) -> int | None:
   |     ^^^^^^^^^^^^^^^^^^ D103
51 |     lab = js.get("primary_lesion", {}).get("pcr", None)
52 |     if lab in (None, ""):
   |

Non-imaging baseline/baseline_pcr_simple.py:59:5: D103 Missing docstring in public function
   |
57 |         return None
58 | 
59 | def get_bbox_volume(js: dict[str, Any]) -> float | None:
   |     ^^^^^^^^^^^^^^^ D103
60 |     bc = js.get("primary_lesion", {}).get("breast_coordinates", {})
61 |     try:
   |

Non-imaging baseline/baseline_pcr_simple.py:73:5: D205 1 blank line required between summary line and description
   |
72 |   def load_dataset(json_dir: Path, split_csv: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
73 |       """Loads train/test DataFrames.
   |  _____^
74 | |     CSV only includes train/val, val is treated as test for now.
75 | |     """
   | |_______^ D205
76 |       splits = pd.read_csv(split_csv, comment="#").dropna(how="all")
77 |       if not {"patient_id", "split"}.issubset(set(splits.columns)):
   |
   = help: Insert single blank line

Non-imaging baseline/baseline_pcr_simple.py:107:5: PD901 Avoid using the generic variable name `df` for DataFrames
    |
105 |         })
106 | 
107 |     df = pd.DataFrame(rows)
    |     ^^ PD901
108 | 
109 |     # Use val as test
    |

Non-imaging baseline/baseline_pcr_simple.py:111:9: B028 No explicit `stacklevel` keyword argument found
    |
109 |     # Use val as test
110 |     if not (df["split"] == "test").any():
111 |         warnings.warn("No explicit test split found — using val as test for now.")
    |         ^^^^^^^^^^^^^ B028
112 |         df.loc[df["split"] == "val", "split"] = "test"
    |

Non-imaging baseline/baseline_pcr_simple.py:119:5: D103 Missing docstring in public function
    |
119 | def build_pipeline(C: float = 1.0, max_iter: int = 1000) -> Pipeline:
    |     ^^^^^^^^^^^^^^ D103
120 |     numeric_features = ["age", "bbox_volume"]
121 |     categorical_features = ["tumor_subtype"]
    |

Non-imaging baseline/baseline_pcr_simple.py:141:5: ANN201 Missing return type annotation for public function `train_and_test`
    |
140 | # Model
141 | def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
    |     ^^^^^^^^^^^^^^ ANN201
142 |     outdir.mkdir(parents=True, exist_ok=True)
143 |     pipe = build_pipeline(C=C, max_iter=max_iter)
    |
    = help: Add return type annotation

Non-imaging baseline/baseline_pcr_simple.py:141:5: D103 Missing docstring in public function
    |
140 | # Model
141 | def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
    |     ^^^^^^^^^^^^^^ D103
142 |     outdir.mkdir(parents=True, exist_ok=True)
143 |     pipe = build_pipeline(C=C, max_iter=max_iter)
    |

Non-imaging baseline/baseline_pcr_simple.py:141:20: ANN001 Missing type annotation for function argument `df_train`
    |
140 | # Model
141 | def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
    |                    ^^^^^^^^ ANN001
142 |     outdir.mkdir(parents=True, exist_ok=True)
143 |     pipe = build_pipeline(C=C, max_iter=max_iter)
    |

Non-imaging baseline/baseline_pcr_simple.py:141:30: ANN001 Missing type annotation for function argument `df_test`
    |
140 | # Model
141 | def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
    |                              ^^^^^^^ ANN001
142 |     outdir.mkdir(parents=True, exist_ok=True)
143 |     pipe = build_pipeline(C=C, max_iter=max_iter)
    |

Non-imaging baseline/baseline_pcr_simple.py:141:53: ANN001 Missing type annotation for function argument `C`
    |
140 | # Model
141 | def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
    |                                                     ^ ANN001
142 |     outdir.mkdir(parents=True, exist_ok=True)
143 |     pipe = build_pipeline(C=C, max_iter=max_iter)
    |

Non-imaging baseline/baseline_pcr_simple.py:141:60: ANN001 Missing type annotation for function argument `max_iter`
    |
140 | # Model
141 | def train_and_test(df_train, df_test, outdir: Path, C=1.0, max_iter=1000):
    |                                                            ^^^^^^^^ ANN001
142 |     outdir.mkdir(parents=True, exist_ok=True)
143 |     pipe = build_pipeline(C=C, max_iter=max_iter)
    |

Non-imaging baseline/baseline_pcr_simple.py:149:15: PD011 Use `.to_numpy()` instead of `.values`
    |
148 |     X_train = df_train_lab[["age", "bbox_volume", "tumor_subtype"]]
149 |     y_train = df_train_lab["y"].astype(int).values
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PD011
150 |     pipe.fit(X_train, y_train)
    |

Non-imaging baseline/baseline_pcr_simple.py:158:18: PD011 Use `.to_numpy()` instead of `.values`
    |
156 |     if len(df_test_lab) != 0:
157 |         X_test = df_test_lab[["age", "bbox_volume", "tumor_subtype"]]
158 |         y_test = df_test_lab["y"].astype(int).values
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PD011
159 |         test_scores = pipe.predict_proba(X_test)[:, 1]
160 |         auc_test = float(roc_auc_score(y_test, test_scores))
    |

Non-imaging baseline/baseline_pcr_simple.py:168:27: PD011 Use `.to_numpy()` instead of `.values`
    |
166 |     for df in [df_train, df_test]:
167 |         preds.append(pd.DataFrame({
168 |             "patient_id": df["patient_id"].values,
    |                           ^^^^^^^^^^^^^^^^^^^^^^^ PD011
169 |             "split": df["split"].values,
170 |             "y_true": df["y"].values,
    |

Non-imaging baseline/baseline_pcr_simple.py:169:22: PD011 Use `.to_numpy()` instead of `.values`
    |
167 |         preds.append(pd.DataFrame({
168 |             "patient_id": df["patient_id"].values,
169 |             "split": df["split"].values,
    |                      ^^^^^^^^^^^^^^^^^^ PD011
170 |             "y_true": df["y"].values,
171 |             "y_pred_score": pipe.predict_proba(df[["age","bbox_volume","tumor_subtype"]])[:, 1],
    |

Non-imaging baseline/baseline_pcr_simple.py:170:23: PD011 Use `.to_numpy()` instead of `.values`
    |
168 |             "patient_id": df["patient_id"].values,
169 |             "split": df["split"].values,
170 |             "y_true": df["y"].values,
    |                       ^^^^^^^^^^^^^^ PD011
171 |             "y_pred_score": pipe.predict_proba(df[["age","bbox_volume","tumor_subtype"]])[:, 1],
172 |         }))
    |

Non-imaging baseline/baseline_pcr_simple.py:202:5: ANN201 Missing return type annotation for public function `main`
    |
202 | def main():
    |     ^^^^ ANN201
203 |     ap = argparse.ArgumentParser(description="Minimal pCR baseline (fixed schema).")
204 |     ap.add_argument("--json-dir", required=True, type=Path)
    |
    = help: Add return type annotation: `None`

Non-imaging baseline/baseline_pcr_simple.py:202:5: D103 Missing docstring in public function
    |
202 | def main():
    |     ^^^^ D103
203 |     ap = argparse.ArgumentParser(description="Minimal pCR baseline (fixed schema).")
204 |     ap.add_argument("--json-dir", required=True, type=Path)
    |

Found 38 errors (15 fixed, 23 remaining).
No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).

ruff-format..............................................................Failed
- hook id: ruff-format
- files were modified by this hook

1 file reformatted, 1 file left unchanged
```

Since it has changed some files automatically, I'll start by pushing those changes.