### PR TITLE
Fix Installation Recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ micromamba config prepend channels conda-forge
 micromamba config set channel_priority strict
 git clone --recursive git@github.com:uchicago-dsi/vanguard.git
 cd vanguard
-micromamba env create -n vanguard -f environment.yml
+micromamba env create -y -n vanguard -f environment.yml
 micromamba activate vanguard
 ```
 
 To Update:
 ```bash
 micromamba activate vanguard
-micromamba env update -f environment.yml
+micromamba env update -y -f environment.yml
 ```
 
 (Be sure to clone this repo with `--recursive` so that submodules like [dsi-clinic/vanguard-blood-vessel-segmentation](https://github.com/dsi-clinic/vanguard-blood-vessel-segmentation) are included.)

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pytorch-gpu
   - torchvision
   - cuda-version
+  - numpy
   - vmtk
   - itk
   - libitk
@@ -15,6 +16,7 @@ dependencies:
   - imageio-ffmpeg
 
   - pip:
+    # Note that any packages that are listed in requirements.txt will override the ones listed here.
     - -r requirements.txt
     # The precompiled version of Pyradiomics does not work with Python > 3.9.
     # The master branch of the repository has a fix to allow for pip to install it using Python 3.10 and later.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,10 @@ numpy~=2.2
 joblib~=1.5
 PyYAML~=6.0
 SimpleITK~=2.5
-vtk~=9.2
+vtk==9.2.*
 numba~=0.62
 plotly~=6.5
 networkx~=3.4
 scikit-image~=0.25
 pyvista~=0.46
+torchio>=0.21.0


### PR DESCRIPTION
The current installation recipe does not work as written.

The pyradiomics package fails to find a compatible version of python. Currently, the pre-compiled versions available through pip and conda are constrained to Python <= 3.9. Our Github workflow uses Python 3.10 and our installation recipe uses Python 3.11. The current solution proposed in the [Pyradiomics Repository](https://github.com/AIM-Harvard/pyradiomics) is to have pip compile the package locally. However, this must use the master branch which is not ideal. However, having it compile after all other packages are installed does allow for the environment to be set up correctly.

**Note:** numpy is declared twice. Once in environment.yml and again in requirements.txt. This must be kept! There is a package in the micromamba environment that needs numpy 1.x. This will be installed when the micromamba environment is first created. Then other packages need numpy 2.x, pip will override the 1.x version. This overriding occurs when updating packages too.