### PR TITLE
Fix slurm sbatch wrappers to cd into REPO_ROOT before running python modules

### DIFF
--- a/slurm/submit_independent_signal_matrix_array.sh
+++ b/slurm/submit_independent_signal_matrix_array.sh
@@ -54,8 +54,8 @@ N_TASKS=$(( N_ARMS * N_SPLITS ))
 ARRAY_SPEC="0-$((N_TASKS - 1))"
 FEATURES_CSV="${OUT_ROOT}/features_full_labeled.csv"
 
-CACHE_WRAP="bash -lc 'source ~/.bashrc || true; if command -v micromamba >/dev/null 2>&1; then eval \"\$(micromamba shell hook -s bash)\"; micromamba activate vanguard; fi; python -m modeling.build_cached_table --config \"${CONFIG}\" --outdir \"${OUT_ROOT}\"'"
-MERGE_WRAP="bash -lc 'source ~/.bashrc || true; if command -v micromamba >/dev/null 2>&1; then eval \"\$(micromamba shell hook -s bash)\"; micromamba activate vanguard; fi; python -m modeling.merge_results --config \"${CONFIG}\" --features-csv \"${FEATURES_CSV}\" --out-root \"${OUT_ROOT}\"'"
+CACHE_WRAP="bash -lc 'source ~/.bashrc || true; if command -v micromamba >/dev/null 2>&1; then eval \"\$(micromamba shell hook -s bash)\"; micromamba activate vanguard; fi; cd \"${REPO_ROOT}\"; python -m modeling.build_cached_table --config \"${CONFIG}\" --outdir \"${OUT_ROOT}\"'"
+MERGE_WRAP="bash -lc 'source ~/.bashrc || true; if command -v micromamba >/dev/null 2>&1; then eval \"\$(micromamba shell hook -s bash)\"; micromamba activate vanguard; fi; cd \"${REPO_ROOT}\"; python -m modeling.merge_results --config \"${CONFIG}\" --features-csv \"${FEATURES_CSV}\" --out-root \"${OUT_ROOT}\"'"
 
 CACHE_JOB_ID="$(
   sbatch --parsable \


### PR DESCRIPTION
Fixes:
- Adds `cd "${REPO_ROOT}"` to the `CACHE_WRAP` and `MERGE_WRAP` sbatch commands in `submit_independent_signal_matrix_array.sh`

Why:
- Without this, `python -m` module resolution fails when the job's working directory is not the repo root (e.g. `ModuleNotFoundError`)