### PR TITLE
Add toy experiment mode for Deep Sets pipeline sanity check

### DIFF
--- a/build_deepsets_dataset.py
+++ b/build_deepsets_dataset.py
@@ -188,6 +188,8 @@ def _build_case_set(
     spacing_mm_zyx: tuple[float, float, float],
     local_radius_mm: float,
     tumor_equiv_radius_mm: float,
+    toy_perfect_feature: bool = False,
+    toy_only: bool = False,
 ) -> dict[str, Any] | None:
     """Build one tumor-local point set for Deep Sets."""
     coords_xyz, neighbor_map = _build_neighbor_map(skeleton_mask_zyx)
@@ -209,7 +211,12 @@ def _build_case_set(
             neighbor_xyz=neighbors,
             spacing_mm_zyx=spacing_mm_zyx,
         )
-        row = [float(curvature_rad)]
+        if toy_only:
+            row = [float(label)]
+        else:
+            row = [float(curvature_rad)]
+            if toy_perfect_feature:
+                row.append(float(label))
         candidate_rows.append((float(signed_distance_mm), row))
         if signed_distance_mm <= float(local_radius_mm):
             feature_rows.append(row)
@@ -226,7 +233,12 @@ def _build_case_set(
         "x": torch.tensor(feature_rows, dtype=torch.float32),
         "y": torch.tensor([int(label)], dtype=torch.float32),
         "case_id": str(case_id),
-        "feature_names": list(POINT_FEATURE_NAMES),
+        "feature_names": (
+            ["toy_perfect_label"]
+            if toy_only
+            else list(POINT_FEATURE_NAMES)
+            + (["toy_perfect_label"] if toy_perfect_feature else [])
+        ),
         "local_radius_mm": float(local_radius_mm),
         "tumor_equiv_radius_mm": float(tumor_equiv_radius_mm),
         "num_points": int(len(feature_rows)),
@@ -271,6 +283,13 @@ def main() -> None:
     skeleton_pattern = str(toggles.centerline_file_pattern)
     dataset_include = toggles.dataset_include
     bilateral_filter = _as_optional_bool(toggles.bilateral_filter)
+    toy_perfect_feature = bool(getattr(toggles, "toy_perfect_feature", False))
+    toy_only = bool(getattr(toggles, "toy_only", False))
+    if toy_perfect_feature or toy_only:
+        logging.warning(
+            "TOY EXPERIMENT MODE: injecting perfect label feature into every point. "
+            "Results will be artificially perfect. Do NOT use for real experiments."
+        )
 
     labels_df = load_labels(
         Path(data_paths.labels_csv),
@@ -378,6 +397,8 @@ def main() -> None:
                 spacing_mm_zyx=spacing_mm_zyx,
                 local_radius_mm=local_radius_mm,
                 tumor_equiv_radius_mm=tumor_equiv_radius_mm,
+                toy_perfect_feature=toy_perfect_feature,
+                toy_only=toy_only,
             )
         except Exception as exc:  # noqa: BLE001
             failed_case_builds += 1

--- a/config.py
+++ b/config.py
@@ -71,6 +71,8 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "merge_how": "inner",
         "selected_features": None,
         "centerline_file_pattern": "{case_id}_skeleton_4d_exam_mask.npy",
+        "toy_perfect_feature": False,
+        "toy_only": False,
     },
     "experiment_setup": {
         "name": "vanguard_run",

--- a/configs/deepsets_ispy2_toy.yaml
+++ b/configs/deepsets_ispy2_toy.yaml
@@ -1,0 +1,34 @@
+feature_toggles:
+  dataset_include: ["ISPY2"]
+  toy_perfect_feature: true
+  toy_only: true
+
+experiment_setup:
+  name: "deepsets_ispy2_toy_perfect"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  batch_size: 8
+  epochs: 40
+  hidden_dim: 64
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  weight_decay: 0.0001
+  pooling: "mean_max_logcount"
+  deepsets_local_radius_floor_mm: 50.0
+  deepsets_local_radius_scale: 2.0
+  deepsets_local_radius_cap_mm: 60.0
+
+data_paths:
+  centerline_root: "/net/projects2/vanguard/centerlines_tc4d/studies"
+  tumor_mask_root: "/net/projects2/vanguard/MAMA-MIA-syn60868042/segmentations/expert"
+  patient_info_dir: "/net/projects2/vanguard/MAMA-MIA-syn60868042/patient_info_files"
+  clinical_excel: "/net/projects2/vanguard/MAMA-MIA-syn60868042/clinical_and_imaging_info.xlsx"
+  labels_csv: "/net/projects2/vanguard/MAMA-MIA-syn60868042/pcr_labels.csv"
+  label_column: "pcr"
+  id_column: "case_id"
+  deepsets_manifest_csv: ""
+  deepsets_label_column: "label"


### PR DESCRIPTION
## Summary
- Adds `toy_perfect_feature` and `toy_only` config flags to inject a 100% correlated binary feature into Deep Sets point sets, serving as a pipeline sanity check
- `toy_only` mode drops all real features (curvature) and uses only the synthetic label feature for the cleanest possible test
- Includes a dedicated toy config at `configs/deepsets_ispy2_toy.yaml` with a separate experiment name to avoid contaminating real results

## Testing

Ran the full Deep Sets pipeline end-to-end using the toy config (`configs/deepsets_ispy2_toy.yaml`) with a single perfect binary feature (`toy_perfect_label = pCR label`).

### What was tested
- **Config**: `toy_perfect_feature: true`, `toy_only: true`
- **Feature vector**: Each centerline point has a single feature — the ground-truth pCR label (0 or 1)
- **Pipeline**: 8-shard build → manifest merge → 5-fold cross-validation training (40 epochs)
- **Dataset**: 980 ISPY2 cases, `input_dim=1`

### Results

| Metric | Value |
|--------|-------|
| **AUC** | **1.0** (all 5 folds) |
| **Average Precision** | **1.0** (all 5 folds) |
| **Final train loss** | ~0.0000 |
| **Final val loss** | 0.0000 |

**Loss curve**: Drops from ~0.16 to effectively 0 within the first 2 epochs across all folds.

**Probability distribution**: Perfectly bimodal — pCR=0 cases clustered near 0.0, pCR=1 cases clustered near 1.0, with zero overlap.

**Feature names verified**: Only `['toy_perfect_label']` — no `curvature_rad` leakage.

### Conclusion

The pipeline successfully recovered the trivial signal. With a single perfect feature that exactly encodes the label, the model achieves perfect classification immediately. This confirms:
1. The dataset builder correctly injects the toy feature and excludes real features when `toy_only=true`
2. The training pipeline correctly reads `input_dim` from the data
3. The end-to-end Slurm pipeline (build → merge → train) works correctly
4. The evaluation metrics and plots are generated as expected

Closes #132