### PR TITLE
Fix empty CONTRIBUTING.md with development workflow content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Cluster Safety Instructions for AI Agents
+You are working on a shared HPC/cluster environment. Your first responsibility is to avoid disrupting the cluster, other users, or user data.
+
+## Hard Rules
+- Never run compute-heavy work on the login/head node.
+- Do not run training, inference, benchmarking, large data processing, model evaluation, simulations, compilation-heavy builds, or multiprocessing jobs directly on the head node.
+- Do not start background jobs on the head node with `&`, `nohup`, `tmux`, `screen`, or long-running shell loops unless explicitly instructed and the task is clearly lightweight.
+- Do not run commands that are expected to use significant CPU, RAM, GPU, disk I/O, or network I/O outside a scheduler job.
+- If a command might run for more than ~30 seconds, use more than ~1 GB RAM, use multiple CPU cores, touch many files, or process large data, submit it through the scheduler.
+- Never use GPUs outside an allocated GPU job.
+- Never launch job arrays, large sweeps, or many parallel jobs without explicit user approval.
+
+## Head Node Usage
+The login/head node may only be used for lightweight coordination tasks, such as:
+- Inspecting files with `ls`, `find`, `rg`, `head`, `tail`, `sed`, `cat` on small files
+- Editing code
+- Checking git status or diffs
+- Reading small logs
+- Submitting, checking, or cancelling scheduler jobs
+- Inspecting environment/module availability
+- Creating small scripts or config files
+
+Before running anything potentially expensive, assume the current shell is on a login node unless proven otherwise.
+
+## Data and Filesystem Safety
+- Do not delete, overwrite, or move large datasets unless explicitly instructed.
+- Do not run broad destructive commands such as `rm -rf *`, `find ... -delete`, or mass renames without explicit confirmation.
+- Prefer writing large outputs to the appropriate scratch/work directory, not home.
+- Avoid generating large numbers of tiny files unless required.
+- Check disk usage before large writes using commands like `df -h` or quota tools if available.
+- Do not change permissions recursively with `chmod -R` or ownership recursively with `chown -R` unless explicitly instructed.
+- Do not modify shared reference data, shared environments, or other users' files.
+
+## When Unsure
+If there is any doubt about whether something is safe to run on the head node, do not run it there. Create a small scheduler job or ask the user for confirmation.
+
+Cluster stability and data safety take priority over speed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+## Development Checks
+
+  Before opening or updating a PR, run the same linting checks that GitHub Actions runs:
+
+  ```bash
+  pre-commit run --all-files
+
+  ### What pre-commit is doing
+
+  pre-commit is just a command-line tool that reads the repo's config file:
+
+  .pre-commit-config.yaml
+
+  That file lists the checks to run. In this repo, it runs:
+
+  - basic cleanup checks, like trailing whitespace, final newlines, YAML validity, and large-file checks
+  - Ruff linting, with some auto-fixes enabled
+  - Ruff formatting
+
+  Ruff's detailed rule settings live in:
+
+  pyproject.toml
+
+  So the flow is:
+
+  pre-commit command
+    -> reads .pre-commit-config.yaml
+    -> runs the listed hooks
+    -> Ruff uses pyproject.toml for lint/format rules
+
+  ### One-time setup
+
+  After activating the environment:
+
+  micromamba activate vanguard
+  pre-commit install
+
+  This adds a local git hook so the same checks run automatically when you commit.
+
+  ### Normal use
+
+  Run all checks before pushing:
+
+  pre-commit run --all-files
+
+  Many issues are auto-fixed. If that happens, inspect and stage the edits:
+
+  git diff
+  git status
+  git add path/to/changed_file.py
+
+  Then rerun:
+
+  pre-commit run --all-files
+
+  A PR should be pushed only after this passes locally.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,37 @@
+# Cluster Safety Instructions for AI Agents
+You are working on a shared HPC/cluster environment. Your first responsibility is to avoid disrupting the cluster, other users, or user data.
+
+## Hard Rules
+- Never run compute-heavy work on the login/head node.
+- Do not run training, inference, benchmarking, large data processing, model evaluation, simulations, compilation-heavy builds, or multiprocessing jobs directly on the head node.
+- Do not start background jobs on the head node with `&`, `nohup`, `tmux`, `screen`, or long-running shell loops unless explicitly instructed and the task is clearly lightweight.
+- Do not run commands that are expected to use significant CPU, RAM, GPU, disk I/O, or network I/O outside a scheduler job.
+- If a command might run for more than ~30 seconds, use more than ~1 GB RAM, use multiple CPU cores, touch many files, or process large data, submit it through the scheduler.
+- Never use GPUs outside an allocated GPU job.
+- Never launch job arrays, large sweeps, or many parallel jobs without explicit user approval.
+
+## Head Node Usage
+The login/head node may only be used for lightweight coordination tasks, such as:
+- Inspecting files with `ls`, `find`, `rg`, `head`, `tail`, `sed`, `cat` on small files
+- Editing code
+- Checking git status or diffs
+- Reading small logs
+- Submitting, checking, or cancelling scheduler jobs
+- Inspecting environment/module availability
+- Creating small scripts or config files
+
+Before running anything potentially expensive, assume the current shell is on a login node unless proven otherwise.
+
+## Data and Filesystem Safety
+- Do not delete, overwrite, or move large datasets unless explicitly instructed.
+- Do not run broad destructive commands such as `rm -rf *`, `find ... -delete`, or mass renames without explicit confirmation.
+- Prefer writing large outputs to the appropriate scratch/work directory, not home.
+- Avoid generating large numbers of tiny files unless required.
+- Check disk usage before large writes using commands like `df -h` or quota tools if available.
+- Do not change permissions recursively with `chmod -R` or ownership recursively with `chown -R` unless explicitly instructed.
+- Do not modify shared reference data, shared environments, or other users' files.
+
+## When Unsure
+If there is any doubt about whether something is safe to run on the head node, do not run it there. Create a small scheduler job or ask the user for confirmation.
+
+Cluster stability and data safety take priority over speed.


### PR DESCRIPTION
CONTRIBUTING.md was merged empty in #164. 
Adds the development workflow and pre-commit linting instructions.