### PR TITLE
Restore vanguard-blood-vessel-segmentation as a pinned git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,11 @@ _pip119/
 results/deepsets/
 analysis/deepsets_issue119/figures/
 analysis/issue121_figures/*.png
+sample_data/mri_images/
+sample_data/expert_tumors/
+repomix-output.xml
+gmon.out
+HANDOFF_2026-06-29.md
+.claude/
+CLAUDE.md
+/lab_notebook.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vanguard-blood-vessel-segmentation"]
+	path = vanguard-blood-vessel-segmentation
+	url = https://github.com/dsi-clinic/vanguard-blood-vessel-segmentation.git


### PR DESCRIPTION
Reverts an earlier regression where the submodule became an untracked/ gitignored bare clone, even though the README already documented `git clone --recursive` for it. Pinned to f8b0a3a.