### PR TITLE
Feat/uchicago adapter wiring(Step 3/5 - Modularization)

### DIFF
--- a/cohorts/README.md
+++ b/cohorts/README.md
@@ -56,24 +56,32 @@ cohort label.
 ### `UChicagoDataset(root, manifest_csv=None)` — `uchicago.py`
 Genuinely different, so it overrides the handful of methods that differ:
 `discover_cases()`, `case_dataset_name()`, `group_key()`, `load_timepoints()`,
-and `load_labels()` are all **manifest-driven** (read from a CSV, including a
-`phase_files` list per row); it sets `default_split_policy = "provided"` (ships
-patient-grouped folds) and `report_by = "dataset"` (sub-source breakdown).
-`preprocess()` currently **raises `NotImplementedError`** on purpose — the real
-ultrafast preprocessing is a frozen-copy port that hasn't landed yet, and we'd
-rather fail loudly than silently apply the wrong (MAMA-MIA) transform.
+`load_labels()`, and `load_folds()` are all **manifest-driven** (read from a CSV,
+including a `phase_files` list per row); it sets `default_split_policy =
+"provided"` (ships patient-grouped folds) and `report_by = "dataset"`
+(sub-source breakdown). `preprocess()` is a **documented pass-through** — the
+manifest's phase files are already preprocessed upstream (`policy_name =
+hfdp_t1_v1`), so no repo-side transform is applied (and, importantly, the base
+MAMA-MIA orientation transform is *not* used, which would be wrong here). The
+181-exam student manifest lives at
+`/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/`; select it
+with `configs/uchicago.yaml`.
 
 ---
 
 ## Selecting a dataset from run config — `factory.py`
 
-Two functions are the only seams that read run config:
+These functions are the only seams that read run config:
 
 - `build_adapter_from_config(config)` reads the `dataset:` block and returns the
   right adapter, or **`None`** when no dataset is configured (so callers fall
   back to today's behavior).
 - `resolve_split_policy(config, adapter)` applies the run-config `split_policy`
   knob (`auto`/`compute`/`provided`) on top of the adapter's default.
+- `resolve_folds(config, adapter)` ties the two together for the caller: it
+  returns the `(case_id, fold)` table to use when the policy resolves to
+  `provided`, or `None` when the run should compute its own splits (raising if
+  `provided` is asked of a dataset that ships no folds).
 
 The `dataset:` block in run config (`config.py` `DEFAULT_CONFIG`):
 

--- a/cohorts/README.md
+++ b/cohorts/README.md
@@ -150,6 +150,23 @@ for the pairing. Split *policy* (does the dataset have folds to offer) and split
 features unconditionally, so the fold assignment itself can never leak in as a
 predictor.
 
+Fold attachment is **fail-closed**: `_apply_provided_folds` rejects a `split_col`
+that collides with `case_id` or the label column, rejects a provided-fold table
+that maps a case more than once, merges `validate="one_to_one"` (so a duplicate
+`case_id` on either side is an error, not a case fanned across folds), and
+requires every modeled case to receive exactly one non-null fold. Any of these
+raises rather than silently corrupting cross-validation.
+
+**Adopted so far — patient grouping for computed folds.** When a run instead
+*computes* folds (`split_policy: compute`), `_apply_group_keys` fills
+`model_params.group_col` from `adapter.group_key(case_id)` (unless that column is
+already present), so `create_splits_for_dataframe` does grouped CV that keeps a
+case's group together — for UChicago, all exams of one patient (`patient_key`;
+181 exams from 143 patients). When a dataset adapter is configured,
+`prepare_evaluation_context` drops `group_col` from the model features, so an
+identity-like grouping key can never leak in as a predictor. See
+`configs/uchicago.yaml`.
+
 ---
 
 ## How to add a new dataset

--- a/cohorts/README.md
+++ b/cohorts/README.md
@@ -67,6 +67,23 @@ MAMA-MIA orientation transform is *not* used, which would be wrong here). The
 `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/`; select it
 with `configs/uchicago.yaml`.
 
+> **Open item, needs Anna's sign-off:** the pass-through assumes the manifest's
+> `hfdp_t1_v1` volumes are already in the orientation the downstream vessel/graph
+> stages expect. That assumption isn't checked in code and isn't exercised
+> end-to-end yet (no UChicago imaging flows exist until Step 4) — if it's wrong,
+> it will silently feed mis-oriented volumes into Step 4 rather than failing
+> loudly. Flagging it here so it isn't mistaken for a verified fact.
+
+> Note: `case_dataset_name()` here returns a manifest **sub-source**
+> (`simbiosys`/`uch_nac`/`her2_naclike`), a finer granularity than
+> `MamaMiaDataset`'s cohort (`"ISPY2"`). The `dataset` column means different
+> things across adapters — fine while runs stay separate, but flag it before
+> building a combined MAMA-MIA+UChicago table keyed on `dataset`.
+
+`load_timepoints()` rebases each `phase_files` path from the manifest's recorded
+`preproc_root` onto the injected `root / "images"`, so moving the manifest
+directory (decision 5) doesn't leave it pointing at a stale location.
+
 ---
 
 ## Selecting a dataset from run config — `factory.py`
@@ -81,7 +98,8 @@ These functions are the only seams that read run config:
 - `resolve_folds(config, adapter)` ties the two together for the caller: it
   returns the `(case_id, fold)` table to use when the policy resolves to
   `provided`, or `None` when the run should compute its own splits (raising if
-  `provided` is asked of a dataset that ships no folds).
+  `provided` is asked of a dataset that ships no folds). This is parsing and
+  validation only — see below for how (and whether) a run actually consumes it.
 
 The `dataset:` block in run config (`config.py` `DEFAULT_CONFIG`):
 
@@ -117,6 +135,20 @@ points wire it the same way: `tabular/train.py` (`run_pipeline_from_config`) and
 `scripts/validate_adapter_feature_parity.py` (byte-identical MAMA-MIA output with
 vs. without the adapter). Other stages still run the pre-adapter way and are
 migrated one at a time.
+
+**Adopted so far — provided CV folds.** `tabular/train.py`'s
+`run_pipeline_from_config` calls `resolve_folds(config, adapter)` and, when it
+returns a fold table, merges it onto the feature table as the
+`model_params.split_col` column (`_apply_provided_folds`). This makes the folds
+*available*; it does not by itself change which splits a run trains on. A run
+opts in separately by setting `model_params.split_mode: predefined` (existing
+infra in `evaluation/build_splits.py`, previously used for hardcoded fold
+columns) with `split_col` matching the merged name — see `configs/uchicago.yaml`
+for the pairing. Split *policy* (does the dataset have folds to offer) and split
+*mode* (does this run use them) are deliberately separate knobs, per decision 3.
+`prepare_evaluation_context` excludes `split_col` from the model's input
+features unconditionally, so the fold assignment itself can never leak in as a
+predictor.
 
 ---
 

--- a/cohorts/__init__.py
+++ b/cohorts/__init__.py
@@ -9,7 +9,11 @@ see ``cohorts/README.md``.
 from __future__ import annotations
 
 from cohorts.base import DatasetAdapter
-from cohorts.factory import build_adapter_from_config, resolve_split_policy
+from cohorts.factory import (
+    build_adapter_from_config,
+    resolve_folds,
+    resolve_split_policy,
+)
 from cohorts.mamamia import MamaMiaDataset
 from cohorts.uchicago import UChicagoDataset
 
@@ -18,5 +22,6 @@ __all__ = [
     "MamaMiaDataset",
     "UChicagoDataset",
     "build_adapter_from_config",
+    "resolve_folds",
     "resolve_split_policy",
 ]

--- a/cohorts/base.py
+++ b/cohorts/base.py
@@ -106,7 +106,9 @@ class DatasetAdapter:
 
         MAMA-MIA encodes this as the case-id prefix, e.g. ``"ISPY2_045" ->
         "ISPY2"`` (``segmentation/batch_segmentation.py:243``,
-        ``case_id.split("_")[0]``).
+        ``case_id.split("_")[0]``). Note this is cohort granularity; some
+        subclasses (e.g. ``UChicagoDataset``) return a finer sub-source instead
+        — see that override's docstring before combining tables across adapters.
         """
         return case_id.split("_")[0]
 

--- a/cohorts/base.py
+++ b/cohorts/base.py
@@ -196,6 +196,16 @@ class DatasetAdapter:
 
         return _load_labels(self.labels_csv, id_col="case_id", label_col="pcr")
 
+    def load_folds(self) -> pd.DataFrame | None:
+        """Return provided cross-validation folds as ``(case_id, fold)``, or ``None``.
+
+        Base datasets compute their own splits (``default_split_policy ==
+        "compute"``), so they ship no folds and this returns ``None``. A dataset
+        that ships its own folds (``default_split_policy == "provided"``)
+        overrides this to surface them.
+        """
+        return None
+
     # -- file-naming rules (current config patterns) --
 
     def tumor_mask_filename(self, case_id: str) -> str:

--- a/cohorts/factory.py
+++ b/cohorts/factory.py
@@ -15,6 +15,8 @@ from cohorts.mamamia import MamaMiaDataset
 from cohorts.uchicago import UChicagoDataset
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from config import ConfigNode
 
 VALID_SPLIT_POLICIES: frozenset[str] = frozenset({"auto", "compute", "provided"})
@@ -79,3 +81,35 @@ def resolve_split_policy(config: ConfigNode, adapter: DatasetAdapter) -> str:
     if policy == "auto":
         return adapter.default_split_policy
     return policy
+
+
+def resolve_folds(config: ConfigNode, adapter: DatasetAdapter) -> pd.DataFrame | None:
+    """Return the CV folds to use, honoring the resolved split policy.
+
+    Ties :func:`resolve_split_policy` to the adapter's shipped folds so a caller
+    gets, in one call, the folds to use — or ``None`` when the run should compute
+    its own splits:
+
+    - resolved policy ``"compute"`` -> ``None`` (build splits the usual way);
+    - resolved policy ``"provided"`` -> ``adapter.load_folds()`` as
+      ``(case_id, fold)``.
+
+    Args:
+        config: A loaded run config.
+        adapter: The dataset adapter.
+
+    Returns:
+        A ``(case_id, fold)`` table, or ``None`` to compute splits.
+
+    Raises:
+        ValueError: If ``"provided"`` is resolved but the dataset ships no folds.
+    """
+    if resolve_split_policy(config, adapter) == "compute":
+        return None
+    folds = adapter.load_folds()
+    if folds is None:
+        raise ValueError(
+            f"split_policy resolved to 'provided' but {type(adapter).__name__} "
+            "ships no folds (load_folds returned None). Use split_policy: compute."
+        )
+    return folds

--- a/cohorts/uchicago.py
+++ b/cohorts/uchicago.py
@@ -53,13 +53,23 @@ class UChicagoDataset(DatasetAdapter):
             else self.root / DEFAULT_MANIFEST_NAME
         )
         self._manifest_cache: pd.DataFrame | None = None
+        self._manifest_indexed_cache: pd.DataFrame | None = None
 
     def discover_cases(self) -> list[str]:
         """Enumerate exam ids from the manifest (not a directory glob)."""
         return [str(exam_id) for exam_id in self._manifest()["exam_id"].tolist()]
 
     def case_dataset_name(self, case_id: str) -> str:
-        """Return a case's sub-source (manifest ``dataset`` column)."""
+        """Return a case's sub-source (manifest ``dataset`` column).
+
+        Note: this is a finer granularity than ``MamaMiaDataset.case_dataset_name``
+        (which returns a cohort like ``"ISPY2"``) — here it's a manifest
+        sub-source (``simbiosys``/``uch_nac``/``her2_naclike``). The ``dataset``
+        column therefore means different things at different granularities across
+        adapters. That's fine while UChicago and MAMA-MIA runs stay separate;
+        flag it before anyone builds a combined table that groups by ``dataset``
+        across both.
+        """
         return str(self._manifest_row(case_id)["dataset"])
 
     def group_key(self, case_id: str) -> str:
@@ -67,9 +77,34 @@ class UChicagoDataset(DatasetAdapter):
         return str(self._manifest_row(case_id)["patient_key"])
 
     def load_timepoints(self, case_id: str) -> list[Path]:
-        """Return ordered DCE phase files from the manifest ``phase_files`` list."""
-        phase_files = json.loads(self._manifest_row(case_id)["phase_files"])
-        return [Path(p) for p in phase_files]
+        """Return ordered DCE phase files from the manifest ``phase_files`` list.
+
+        The manifest's ``phase_files`` paths are absolute and anchored under its
+        own ``preproc_root`` column (today, ``<manifest_root>/images``). To honor
+        the injected :attr:`root` (design decision 5 — the pipeline must survive
+        the data moving on disk), each path is rebased from the manifest's
+        recorded ``preproc_root`` onto ``self.root / "images"``. When a row lacks
+        ``preproc_root`` (e.g. an older/synthetic manifest), paths are returned
+        as-is rather than guessing.
+        """
+        import pandas as pd
+
+        row = self._manifest_row(case_id)
+        phase_files = [Path(p) for p in json.loads(row["phase_files"])]
+        manifest = self._manifest()
+        if "preproc_root" not in manifest.columns or pd.isna(row["preproc_root"]):
+            return phase_files
+        preproc_root = Path(row["preproc_root"])
+        images_root = self.root / "images"
+        rebased = []
+        for phase_file in phase_files:
+            try:
+                rel = phase_file.relative_to(preproc_root)
+            except ValueError:
+                rebased.append(phase_file)
+            else:
+                rebased.append(images_root / rel)
+        return rebased
 
     def load_labels(self) -> pd.DataFrame:
         """Return pCR labels straight from the manifest (``exam_id`` -> ``pcr``)."""
@@ -120,9 +155,18 @@ class UChicagoDataset(DatasetAdapter):
         return self._manifest_cache
 
     def _manifest_row(self, case_id: str) -> pd.Series:
-        """Return the single manifest row for an exam id."""
-        manifest = self._manifest()
-        rows = manifest[manifest["exam_id"].astype(str) == str(case_id)]
-        if rows.empty:
+        """Return the single manifest row for an exam id (O(1), indexed once)."""
+        indexed = self._manifest_indexed()
+        key = str(case_id)
+        if key not in indexed.index:
             raise KeyError(f"exam_id not in manifest: {case_id}")
-        return rows.iloc[0]
+        return indexed.loc[key]
+
+    def _manifest_indexed(self) -> pd.DataFrame:
+        """Manifest indexed by (string) ``exam_id``, cached for repeated row lookups."""
+        if self._manifest_indexed_cache is None:
+            manifest = self._manifest()
+            indexed = manifest.copy()
+            indexed.index = manifest["exam_id"].astype(str)
+            self._manifest_indexed_cache = indexed
+        return self._manifest_indexed_cache

--- a/cohorts/uchicago.py
+++ b/cohorts/uchicago.py
@@ -1,9 +1,10 @@
-"""UChicago ultrafast DCE dataset adapter (scaffold).
+"""UChicago ultrafast DCE dataset adapter.
 
 Overrides the base MAMA-MIA behavior for the differences identified in
-``cohorts/README.md``. The real ultrafast preprocessing is a
-frozen-copy port (see cohorts/README.md — Design decisions) that is **not implemented yet**; ``preprocess``
-raises ``NotImplementedError`` so nothing silently applies the wrong transform.
+``cohorts/README.md``: manifest-driven discovery/identity/timepoints/labels,
+provided CV folds, and sub-source reporting. ``preprocess`` is a pass-through
+because the manifest ships already-preprocessed volumes (``policy_name =
+hfdp_t1_v1``); see the method docstring for the note on design decision 4.
 """
 
 from __future__ import annotations
@@ -79,16 +80,34 @@ class UChicagoDataset(DatasetAdapter):
         return labels
 
     def preprocess(self, volume: np.ndarray) -> np.ndarray:
-        """Ultrafast-specific preprocessing — frozen-copy port, not done yet.
+        """Return the volume unchanged — UChicago data is already preprocessed.
 
-        See ``cohorts/README.md``. Until the
-        frozen copy is brought into the repo this raises, rather than falling
-        back to the MAMA-MIA transform, which would be wrong for ultrafast data.
+        The manifest's ``phase_files`` are preprocessed upstream by Anna's HFDP
+        pipeline (``policy_name = hfdp_t1_v1``) and copied into ``images/``, so no
+        repo-side preprocessing is applied here. Crucially this must NOT fall back
+        to the base MAMA-MIA orientation transform, which would be wrong for this
+        already-oriented ultrafast data.
+
+        Note for Anna: this makes design decision 4 (port a frozen copy of the
+        UChicago preprocessing into the repo) unnecessary for the student
+        manifest, since the shipped data is already preprocessed. Revisit only if
+        we ever need to preprocess *raw* UChicago exams inside this pipeline.
         """
-        raise NotImplementedError(
-            "UChicago preprocessing is not ported yet (frozen-copy port pending; "
-            "see cohorts/README.md)."
-        )
+        return volume
+
+    def load_folds(self) -> pd.DataFrame:
+        """Return the manifest's patient-grouped CV folds as ``(case_id, fold)``.
+
+        UChicago ships its own folds (``default_split_policy = "provided"``),
+        patient-grouped by ``patient_key`` and stratified by ``pcr``. Keyed by
+        ``exam_id`` (renamed to ``case_id`` for consistency with the rest of the
+        pipeline).
+        """
+        folds = self._manifest()[["exam_id", "fold"]].copy()
+        folds = folds.rename(columns={"exam_id": "case_id"})
+        folds = folds.dropna(subset=["fold"])
+        folds["fold"] = folds["fold"].astype(int)
+        return folds
 
     # -- internal helpers --
 

--- a/configs/uchicago.yaml
+++ b/configs/uchicago.yaml
@@ -1,0 +1,16 @@
+# UChicago internal ultrafast DCE dataset (181 labeled exams).
+#
+# Step 3 of the multi-dataset migration: this config defines the dataset so the
+# adapter factory (cohorts.build_adapter_from_config) builds a UChicagoDataset.
+# It exercises the manifest-driven adapter path — case discovery, labels,
+# provided CV folds, and sub-source reporting — none of which needs the vessel
+# pipeline. The imaging pipeline (segmentation -> graph -> features) is not wired
+# for UChicago yet, so this config is not a full training run.
+#
+# See cohorts/README.md for the adapter contract and how stages consume it.
+
+dataset:
+  name: uchicago
+  cohort: null   # UChicago is not cohort-partitioned like MAMA-MIA
+  root: /gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest
+  split_policy: auto   # -> "provided": use the manifest's patient-grouped fold column

--- a/configs/uchicago.yaml
+++ b/configs/uchicago.yaml
@@ -23,3 +23,12 @@ dataset:
 model_params:
   split_mode: predefined
   split_col: fold
+  # If a run overrides to split_policy: compute (recompute folds instead of using
+  # the shipped ones), keep same-patient exams together: the manifest has 181
+  # exams from 143 patients (36 patients with >1 exam). _apply_group_keys fills
+  # patient_key from UChicagoDataset.group_key(); group_col names it here so
+  # create_splits_for_dataframe does patient-grouped, pcr-stratified CV rather
+  # than leaking a patient across train/validation. patient_key is dropped from
+  # model features (it is an identity, not a predictor).
+  use_group_split: true
+  group_col: patient_key

--- a/configs/uchicago.yaml
+++ b/configs/uchicago.yaml
@@ -14,3 +14,12 @@ dataset:
   cohort: null   # UChicago is not cohort-partitioned like MAMA-MIA
   root: /gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest
   split_policy: auto   # -> "provided": use the manifest's patient-grouped fold column
+
+# split_policy: provided only resolves *which* folds exist; a run must also opt
+# in to actually using them (tabular/train.py merges the provided fold column
+# onto the feature table either way, per design decision 3 -- see
+# cohorts/README.md). These two lines are that opt-in and pair with split_col
+# "fold", the name tabular/train.py merges the provided folds under by default.
+model_params:
+  split_mode: predefined
+  split_col: fold

--- a/scripts/validate_uchicago_manifest.py
+++ b/scripts/validate_uchicago_manifest.py
@@ -1,0 +1,127 @@
+r"""Step 3 validation: exercise the UChicago adapter against the real manifest.
+
+Builds a ``UChicagoDataset`` through the run-config factory (the seam a stage
+would use) and checks the manifest-driven path — case discovery, labels,
+provided CV folds, sub-source identity, timepoints, and preprocess pass-through —
+against the known counts in the manifest data dictionary. No vessel pipeline and
+no heavy compute; this is the merge check for Step 3.
+
+The manifest root defaults to the canonical location but can be overridden:
+
+    UCHICAGO_ROOT=/path/to/dce2d_internal_ultrafast_manifest \
+    python scripts/validate_uchicago_manifest.py
+
+Exit code 0 = all checks pass, 1 = a check failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import numpy as np
+
+from cohorts import build_adapter_from_config, resolve_folds
+from config import ConfigNode
+
+# Expected counts from the manifest data dictionary (181 labeled exams).
+EXPECTED_TOTAL = 181
+EXPECTED_LABELS = {0: 117, 1: 64}
+EXPECTED_FOLDS = {0: 36, 1: 36, 2: 37, 3: 36, 4: 36}
+EXPECTED_SUBSOURCES = {"simbiosys": 86, "uch_nac": 60, "her2_naclike": 35}
+
+DEFAULT_ROOT = "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI args, defaulting the manifest root to env/canonical path."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=os.environ.get("UCHICAGO_ROOT", DEFAULT_ROOT),
+        help="UChicago manifest root dir (or set UCHICAGO_ROOT).",
+    )
+    return parser.parse_args()
+
+
+def _check(label: str, got: object, want: object, failures: list[str]) -> None:
+    """Record and print one check result."""
+    ok = got == want
+    print(f"  [{'PASS' if ok else 'FAIL'}] {label}: {got}")
+    if not ok:
+        failures.append(f"{label}: got {got}, expected {want}")
+
+
+def main() -> int:
+    """Run the manifest-path checks and return a process exit code."""
+    args = parse_args()
+    config = ConfigNode._wrap(
+        {
+            "dataset": {
+                "name": "uchicago",
+                "cohort": None,
+                "root": args.root,
+                "split_policy": "auto",
+            }
+        }
+    )
+    adapter = build_adapter_from_config(config)
+    print(f"Adapter: {type(adapter).__name__}  root={args.root}")
+
+    failures: list[str] = []
+
+    cases = adapter.discover_cases()
+    _check("discover_cases (total exams)", len(cases), EXPECTED_TOTAL, failures)
+
+    labels = adapter.load_labels()
+    label_counts = {int(k): int(v) for k, v in labels["pcr"].value_counts().items()}
+    _check("load_labels (pcr counts)", label_counts, EXPECTED_LABELS, failures)
+
+    folds = resolve_folds(config, adapter)  # auto -> provided
+    fold_counts = {int(k): int(v) for k, v in folds["fold"].value_counts().items()}
+    _check(
+        "resolve_folds (provided fold counts)", fold_counts, EXPECTED_FOLDS, failures
+    )
+
+    subsource_counts: dict[str, int] = {}
+    for case_id in cases:
+        name = adapter.case_dataset_name(case_id)
+        subsource_counts[name] = subsource_counts.get(name, 0) + 1
+    _check(
+        "case_dataset_name (sub-source counts)",
+        subsource_counts,
+        EXPECTED_SUBSOURCES,
+        failures,
+    )
+
+    # Timepoints resolve to real, existing phase files for the first case.
+    tps = adapter.load_timepoints(cases[0])
+    _check(
+        "load_timepoints[0] all exist",
+        bool(tps) and all(p.exists() for p in tps),
+        True,
+        failures,
+    )
+
+    # preprocess is a pass-through (data already preprocessed).
+    vol = np.arange(24).reshape(2, 3, 4)
+    _check(
+        "preprocess is pass-through",
+        np.array_equal(adapter.preprocess(vol), vol),
+        True,
+        failures,
+    )
+
+    print()
+    if failures:
+        print(f"FAIL: {len(failures)} check(s) failed:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("PASS: UChicago adapter matches the manifest dictionary on all checks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tabular/train.py
+++ b/tabular/train.py
@@ -15,7 +15,8 @@ from typing import Any
 
 import pandas as pd
 
-from cohorts.factory import build_adapter_from_config
+from cohorts.base import DatasetAdapter
+from cohorts.factory import build_adapter_from_config, resolve_folds
 from evaluation import FoldResults
 from evaluation.build_splits import create_splits_for_dataframe
 from evaluation.kfold import FoldSplit
@@ -135,6 +136,9 @@ def prepare_evaluation_context(
     stratum_col = model_params.stratum_col
     if stratum_col:
         drop_cols.add(str(stratum_col))
+    # Eval bookkeeping, not a feature -- must not leak into X even when unset
+    # (harmless to drop a column that isn't present).
+    drop_cols.add(str(model_params.split_col))
 
     X = df.drop(columns=[c for c in drop_cols if c in df.columns], errors="ignore")
     if X.empty:
@@ -283,6 +287,36 @@ def run_cross_validation_from_context(
     return fold_results_list, nested_rows
 
 
+def _apply_provided_folds(
+    feats_df: pd.DataFrame, config: dict[str, Any], adapter: DatasetAdapter
+) -> pd.DataFrame:
+    """Merge the adapter's provided CV folds onto the feature table, if any.
+
+    ``resolve_folds`` returns a ``(case_id, fold)`` table when the resolved
+    split policy is "provided", or ``None`` when it's "compute" -- in which
+    case ``feats_df`` is returned unchanged. The merged column is named after
+    ``model_params.split_col`` (default ``"fold"``), so a run that separately
+    sets ``model_params.split_mode: predefined`` consumes it through the
+    existing predefined-fold path in ``create_splits_for_dataframe``.
+
+    Split *policy* (whether the dataset has folds to offer) and split *mode*
+    (whether a run chooses to use them) stay separate run-config knobs, per
+    design decision 3 (see cohorts/README.md): merging the column here makes it
+    available, it does not force its use. Unmatched rows (e.g. exams with a
+    fold but no label, so absent from the labeled feature table) are dropped by
+    the left merge; rows with no assigned fold get ``NaN`` and will fail loudly
+    in ``create_predefined_splits`` if the run actually selects predefined mode.
+    """
+    folds = resolve_folds(config, adapter)
+    if folds is None:
+        return feats_df
+    split_col = str(config.model_params.split_col)
+    folds = folds.rename(columns={"fold": split_col})
+    if split_col in feats_df.columns:
+        feats_df = feats_df.drop(columns=[split_col])
+    return feats_df.merge(folds, on="case_id", how="left")
+
+
 def run_pipeline_from_config(
     config: dict[str, Any],
     outdir: Path,
@@ -302,6 +336,8 @@ def run_pipeline_from_config(
 
     try:
         merged_data = prepare_data(config, outdir, adapter=adapter)
+        if adapter is not None:
+            merged_data = _apply_provided_folds(merged_data, config, adapter)
         run_evaluation_pipeline(merged_data, config, outdir)
     except Exception as exc:  # noqa: BLE001
         logging.error("Pipeline failed: %s", exc, exc_info=True)

--- a/tabular/train.py
+++ b/tabular/train.py
@@ -287,6 +287,10 @@ def run_cross_validation_from_context(
     return fold_results_list, nested_rows
 
 
+#: Cap on how many case ids to list in the missing-fold error before truncating.
+_MAX_MISSING_CASES_SHOWN = 10
+
+
 def _apply_provided_folds(
     feats_df: pd.DataFrame, config: dict[str, Any], adapter: DatasetAdapter
 ) -> pd.DataFrame:
@@ -302,10 +306,15 @@ def _apply_provided_folds(
     Split *policy* (whether the dataset has folds to offer) and split *mode*
     (whether a run chooses to use them) stay separate run-config knobs, per
     design decision 3 (see cohorts/README.md): merging the column here makes it
-    available, it does not force its use. Unmatched rows (e.g. exams with a
-    fold but no label, so absent from the labeled feature table) are dropped by
-    the left merge; rows with no assigned fold get ``NaN`` and will fail loudly
-    in ``create_predefined_splits`` if the run actually selects predefined mode.
+    available, it does not force its use. A labeled feature row with no matching
+    fold gets ``NaN`` from the left merge; that would silently become a spurious
+    empty-validation fold in ``create_predefined_splits`` (``np.unique`` treats
+    ``NaN`` as its own value, leaking those rows into every fold's train set), so
+    when the run actually selects predefined mode we raise instead.
+
+    Raises:
+        ValueError: If ``split_mode`` is ``"predefined"`` and some feature row
+            has no assigned fold.
     """
     folds = resolve_folds(config, adapter)
     if folds is None:
@@ -314,7 +323,17 @@ def _apply_provided_folds(
     folds = folds.rename(columns={"fold": split_col})
     if split_col in feats_df.columns:
         feats_df = feats_df.drop(columns=[split_col])
-    return feats_df.merge(folds, on="case_id", how="left")
+    feats_df = feats_df.merge(folds, on="case_id", how="left")
+    predefined = str(config.model_params.split_mode) == "predefined"
+    if predefined and feats_df[split_col].isna().any():
+        missing = feats_df.loc[feats_df[split_col].isna(), "case_id"].tolist()
+        preview = missing[:_MAX_MISSING_CASES_SHOWN]
+        suffix = " ..." if len(missing) > _MAX_MISSING_CASES_SHOWN else ""
+        raise ValueError(
+            f"split_mode='predefined' but {len(missing)} case(s) have no provided "
+            f"fold: {preview}{suffix}"
+        )
+    return feats_df
 
 
 def run_pipeline_from_config(

--- a/tabular/train.py
+++ b/tabular/train.py
@@ -131,7 +131,12 @@ def prepare_evaluation_context(
             }
         )
     group_col = str(model_params.group_col)
-    if bool(model_params.use_group_split):
+    if bool(config.dataset.name):
+        # A dataset adapter is configured: group_col holds its grouping key
+        # (e.g. UChicago's patient_key), populated by _apply_group_keys. That is
+        # an identity, not a feature -- always drop it so it can't leak into X.
+        drop_cols.add(group_col)
+    elif bool(model_params.use_group_split):
         drop_cols.discard(group_col)
     stratum_col = model_params.stratum_col
     if stratum_col:
@@ -287,52 +292,103 @@ def run_cross_validation_from_context(
     return fold_results_list, nested_rows
 
 
-#: Cap on how many case ids to list in the missing-fold error before truncating.
+#: Cap on how many case ids to list in a fail-closed fold error before truncating.
 _MAX_MISSING_CASES_SHOWN = 10
+
+
+def _preview(case_ids: list[str]) -> str:
+    """Format a truncated ``case_id`` list for error messages."""
+    head = case_ids[:_MAX_MISSING_CASES_SHOWN]
+    return f"{head}{' ...' if len(case_ids) > _MAX_MISSING_CASES_SHOWN else ''}"
 
 
 def _apply_provided_folds(
     feats_df: pd.DataFrame, config: dict[str, Any], adapter: DatasetAdapter
 ) -> pd.DataFrame:
-    """Merge the adapter's provided CV folds onto the feature table, if any.
+    """Attach the adapter's provided CV folds onto the feature table, fail-closed.
 
-    ``resolve_folds`` returns a ``(case_id, fold)`` table when the resolved
-    split policy is "provided", or ``None`` when it's "compute" -- in which
-    case ``feats_df`` is returned unchanged. The merged column is named after
-    ``model_params.split_col`` (default ``"fold"``), so a run that separately
-    sets ``model_params.split_mode: predefined`` consumes it through the
-    existing predefined-fold path in ``create_splits_for_dataframe``.
+    ``resolve_folds`` returns a ``(case_id, fold)`` table when the resolved split
+    policy is "provided", or ``None`` when it's "compute" -- in which case
+    ``feats_df`` is returned unchanged. Otherwise the folds are attached under
+    ``model_params.split_col`` (default ``"fold"``), consumed downstream by the
+    predefined-fold path in ``create_splits_for_dataframe``.
 
-    Split *policy* (whether the dataset has folds to offer) and split *mode*
-    (whether a run chooses to use them) stay separate run-config knobs, per
-    design decision 3 (see cohorts/README.md): merging the column here makes it
-    available, it does not force its use. A labeled feature row with no matching
-    fold gets ``NaN`` from the left merge; that would silently become a spurious
-    empty-validation fold in ``create_predefined_splits`` (``np.unique`` treats
-    ``NaN`` as its own value, leaking those rows into every fold's train set), so
-    when the run actually selects predefined mode we raise instead.
+    Because a bad fold attachment silently corrupts cross-validation (a missing
+    fold becomes an empty validation split; a duplicate mapping puts one case in
+    both train and validation), this validates rather than trusts, and raises on
+    anything unsafe:
+
+    - ``split_col`` must not collide with ``case_id`` or the configured label
+      column (it would overwrite real data);
+    - the provided folds must map each ``case_id`` at most once, and the merge is
+      ``validate="one_to_one"`` so a duplicate on either side is an error, not a
+      row-exploding leak;
+    - every modeled case must receive exactly one non-null fold.
 
     Raises:
-        ValueError: If ``split_mode`` is ``"predefined"`` and some feature row
-            has no assigned fold.
+        ValueError: On a ``split_col`` collision, a duplicate fold mapping, a
+            non-unique feature-table ``case_id``, or any modeled case left
+            without a fold.
     """
     folds = resolve_folds(config, adapter)
     if folds is None:
         return feats_df
+
     split_col = str(config.model_params.split_col)
+    label_col = str(config.data_paths.label_column)
+    if split_col in {"case_id", label_col}:
+        raise ValueError(
+            f"model_params.split_col={split_col!r} collides with a reserved column "
+            f"('case_id' or the label column {label_col!r}); choose another name."
+        )
+
+    dup_folds = folds["case_id"][folds["case_id"].duplicated()].unique().tolist()
+    if dup_folds:
+        raise ValueError(
+            "Provided folds map these case ids more than once: "
+            f"{_preview([str(c) for c in dup_folds])}"
+        )
+
     folds = folds.rename(columns={"fold": split_col})
     if split_col in feats_df.columns:
         feats_df = feats_df.drop(columns=[split_col])
-    feats_df = feats_df.merge(folds, on="case_id", how="left")
-    predefined = str(config.model_params.split_mode) == "predefined"
-    if predefined and feats_df[split_col].isna().any():
-        missing = feats_df.loc[feats_df[split_col].isna(), "case_id"].tolist()
-        preview = missing[:_MAX_MISSING_CASES_SHOWN]
-        suffix = " ..." if len(missing) > _MAX_MISSING_CASES_SHOWN else ""
+    # validate="one_to_one": a duplicate case_id on either side raises MergeError
+    # rather than fanning a case across folds.
+    feats_df = feats_df.merge(folds, on="case_id", how="left", validate="one_to_one")
+
+    missing = feats_df.loc[feats_df[split_col].isna(), "case_id"].tolist()
+    if missing:
         raise ValueError(
-            f"split_mode='predefined' but {len(missing)} case(s) have no provided "
-            f"fold: {preview}{suffix}"
+            f"{len(missing)} modeled case(s) have no provided fold: "
+            f"{_preview([str(c) for c in missing])}. Provided folds must cover every "
+            "modeled case; use split_policy: compute to build splits instead."
         )
+    return feats_df
+
+
+def _apply_group_keys(
+    feats_df: pd.DataFrame, config: dict[str, Any], adapter: DatasetAdapter
+) -> pd.DataFrame:
+    """Populate the split grouping column from the adapter, so computed CV groups.
+
+    When splits are *computed* (``split_policy: compute``), the pipeline must
+    keep a case's group together across folds -- for UChicago that is the patient
+    (multiple exams per patient), via ``adapter.group_key``. Without this the
+    grouping column is absent and ``create_splits_for_dataframe`` silently falls
+    back to case-level CV, leaking same-patient exams across train/validation.
+
+    Writes ``model_params.group_col`` from ``adapter.group_key(case_id)`` only
+    when that column is not already present, so a dataset whose group column is
+    supplied by an earlier stage (e.g. MAMA-MIA's clinical ``site``) is left
+    untouched. The column is excluded from model features in
+    :func:`prepare_evaluation_context` whenever a dataset adapter is configured,
+    so an identity-like key (``patient_key``) can never leak in as a predictor.
+    """
+    group_col = str(config.model_params.group_col)
+    if group_col in feats_df.columns:
+        return feats_df
+    feats_df = feats_df.copy()
+    feats_df[group_col] = feats_df["case_id"].map(adapter.group_key)
     return feats_df
 
 
@@ -357,6 +413,7 @@ def run_pipeline_from_config(
         merged_data = prepare_data(config, outdir, adapter=adapter)
         if adapter is not None:
             merged_data = _apply_provided_folds(merged_data, config, adapter)
+            merged_data = _apply_group_keys(merged_data, config, adapter)
         run_evaluation_pipeline(merged_data, config, outdir)
     except Exception as exc:  # noqa: BLE001
         logging.error("Pipeline failed: %s", exc, exc_info=True)

--- a/tabular/train.py
+++ b/tabular/train.py
@@ -16,7 +16,11 @@ from typing import Any
 import pandas as pd
 
 from cohorts.base import DatasetAdapter
-from cohorts.factory import build_adapter_from_config, resolve_folds
+from cohorts.factory import (
+    build_adapter_from_config,
+    resolve_folds,
+    resolve_split_policy,
+)
 from evaluation import FoldResults
 from evaluation.build_splits import create_splits_for_dataframe
 from evaluation.kfold import FoldSplit
@@ -47,10 +51,22 @@ def parse_args() -> argparse.Namespace:
 
 
 def run_evaluation_pipeline(
-    df: pd.DataFrame, config: dict[str, Any], outdir: Path
+    df: pd.DataFrame,
+    config: dict[str, Any],
+    outdir: Path,
+    group_col_from_adapter: bool = False,
 ) -> None:
-    """Run evaluator-based cross-validation over configured model/features."""
-    context = prepare_evaluation_context(df, config)
+    """Run evaluator-based cross-validation over configured model/features.
+
+    ``group_col_from_adapter`` must be ``True`` only when the caller actually
+    populated ``model_params.group_col`` from an adapter identity key (via
+    ``_apply_group_keys`` -- e.g. UChicago's ``patient_key``). See
+    :func:`prepare_evaluation_context` for why this can't be inferred from
+    ``config`` alone.
+    """
+    context = prepare_evaluation_context(
+        df, config, group_col_from_adapter=group_col_from_adapter
+    )
     fold_results_list, nested_rows = run_cross_validation_from_context(context)
 
     # Nested tuning CSVs must live under the per-run directory (same leaf as metrics.json)
@@ -93,8 +109,20 @@ def run_evaluation_pipeline(
 def prepare_evaluation_context(
     df: pd.DataFrame,
     config: dict[str, Any],
+    group_col_from_adapter: bool = False,
 ) -> dict[str, Any]:
-    """Prepare evaluator inputs and deterministic fold splits for a config."""
+    """Prepare evaluator inputs and deterministic fold splits for a config.
+
+    ``group_col_from_adapter`` must be ``True`` only when the caller populated
+    ``model_params.group_col`` from an adapter identity key (``_apply_group_keys``
+    -- e.g. UChicago's ``patient_key``), never merely because a dataset is
+    configured: some callers (e.g. ``modeling/ablation.py``) build features with
+    an adapter but never call ``_apply_group_keys``, so ``group_col`` there can be
+    a genuine feature (e.g. MAMA-MIA's clinical ``site``), not an identity.
+    Deciding the drop from ``config.dataset.name`` alone conflated those cases and
+    silently stripped ``site`` from such runs; this flag is the caller's explicit
+    signal instead.
+    """
     label_col = config.data_paths.label_column
     model_params = config.model_params
     toggles = config.feature_toggles
@@ -131,10 +159,10 @@ def prepare_evaluation_context(
             }
         )
     group_col = str(model_params.group_col)
-    if bool(config.dataset.name):
-        # A dataset adapter is configured: group_col holds its grouping key
-        # (e.g. UChicago's patient_key), populated by _apply_group_keys. That is
-        # an identity, not a feature -- always drop it so it can't leak into X.
+    if group_col_from_adapter:
+        # group_col was populated from the adapter's identity key (e.g.
+        # UChicago's patient_key) by _apply_group_keys -- always drop it so it
+        # can't leak into X.
         drop_cols.add(group_col)
     elif bool(model_params.use_group_split):
         drop_cols.discard(group_col)
@@ -380,9 +408,12 @@ def _apply_group_keys(
     Writes ``model_params.group_col`` from ``adapter.group_key(case_id)`` only
     when that column is not already present, so a dataset whose group column is
     supplied by an earlier stage (e.g. MAMA-MIA's clinical ``site``) is left
-    untouched. The column is excluded from model features in
-    :func:`prepare_evaluation_context` whenever a dataset adapter is configured,
-    so an identity-like key (``patient_key``) can never leak in as a predictor.
+    untouched. Callers should invoke this only when :func:`_needs_group_keys` is
+    true, and pass ``group_col_from_adapter=True`` to
+    :func:`prepare_evaluation_context` **only when this actually wrote the column**
+    (i.e. it was absent) -- that flag is what excludes the identity key from model
+    features, so setting it for a pre-existing genuine feature would wrongly drop
+    it.
     """
     group_col = str(config.model_params.group_col)
     if group_col in feats_df.columns:
@@ -390,6 +421,40 @@ def _apply_group_keys(
     feats_df = feats_df.copy()
     feats_df[group_col] = feats_df["case_id"].map(adapter.group_key)
     return feats_df
+
+
+def _needs_group_keys(config: dict[str, Any], adapter: DatasetAdapter) -> bool:
+    """Whether this run should populate the grouping column from the adapter.
+
+    ``adapter.group_key(case_id)`` can require real I/O (e.g. ``MamaMiaDataset``
+    reads clinical data per case), so only call it when the result will be used:
+    the resolved split policy is ``"compute"`` (grouping only matters when the
+    pipeline builds its own splits -- a "provided" run uses the shipped fold
+    column instead, design decision 3 in cohorts/README.md) and
+    ``model_params.use_group_split`` is on. Otherwise the column would be
+    populated -- and then dropped -- for nothing, at the cost of an unnecessary,
+    possibly-failing adapter call.
+    """
+    return resolve_split_policy(config, adapter) == "compute" and bool(
+        config.model_params.use_group_split
+    )
+
+
+def _adapter_populates_group_col(
+    merged_data: pd.DataFrame, config: dict[str, Any], adapter: DatasetAdapter
+) -> bool:
+    """Whether this run will fill ``group_col`` from the adapter's identity key.
+
+    True only when grouping is needed (:func:`_needs_group_keys`) *and* the
+    column is not already present as a genuine feature. This is exactly the
+    condition under which :func:`_apply_group_keys` writes the column, so it also
+    decides ``group_col_from_adapter`` -- setting that flag when the column
+    pre-existed would make :func:`prepare_evaluation_context` drop a real feature
+    (e.g. MAMA-MIA's clinical ``site``) that the adapter never touched.
+    """
+    if not _needs_group_keys(config, adapter):
+        return False
+    return str(config.model_params.group_col) not in merged_data.columns
 
 
 def run_pipeline_from_config(
@@ -409,12 +474,23 @@ def run_pipeline_from_config(
     if adapter is not None:
         logging.info("Using dataset adapter: %s", type(adapter).__name__)
 
+    group_col_from_adapter = False
     try:
         merged_data = prepare_data(config, outdir, adapter=adapter)
         if adapter is not None:
             merged_data = _apply_provided_folds(merged_data, config, adapter)
-            merged_data = _apply_group_keys(merged_data, config, adapter)
-        run_evaluation_pipeline(merged_data, config, outdir)
+            # Populate the grouping column from the adapter only when it will be
+            # used and isn't already a genuine feature; the flag mirrors that so
+            # prepare_evaluation_context drops the identity key but never a real
+            # pre-existing feature.
+            group_col_from_adapter = _adapter_populates_group_col(
+                merged_data, config, adapter
+            )
+            if group_col_from_adapter:
+                merged_data = _apply_group_keys(merged_data, config, adapter)
+        run_evaluation_pipeline(
+            merged_data, config, outdir, group_col_from_adapter=group_col_from_adapter
+        )
     except Exception as exc:  # noqa: BLE001
         logging.error("Pipeline failed: %s", exc, exc_info=True)
 

--- a/tests/test_cohort_adapters.py
+++ b/tests/test_cohort_adapters.py
@@ -277,3 +277,93 @@ def test_resolve_folds_raises_when_provided_but_none_shipped() -> None:
     )
     with pytest.raises(ValueError, match="ships no folds"):
         resolve_folds(config, adapter)
+
+
+# -- load_timepoints root rebasing --
+
+
+def _write_manifest_with_preproc_root(tmp_path: Path, preproc_root: Path) -> Path:
+    """Write a manifest whose phase_files are anchored under ``preproc_root``."""
+    manifest_root = tmp_path / "uc"
+    manifest_root.mkdir()
+    csv_path = manifest_root / "dce2d_internal_ultrafast_manifest.csv"
+    phase_path = preproc_root / "simbiosys" / "e1" / "phase_0000.nii.gz"
+    csv_path.write_text(
+        "exam_id,dataset,patient_key,fold,pcr,phase_files,preproc_root\n"
+        f'e1,simbiosys,p1,0,1.0,"[""{phase_path.as_posix()}""]",{preproc_root.as_posix()}\n'
+    )
+    return manifest_root
+
+
+def test_uchicago_load_timepoints_rebases_onto_injected_root(tmp_path: Path) -> None:
+    """Phase paths follow the injected root, not the manifest's recorded location.
+
+    Design decision 5 says the pipeline must survive the data moving on disk
+    because the root is injected at construction time, not hardcoded. Without
+    rebasing, moving the manifest directory would silently leave
+    load_timepoints() pointing at the old (possibly gone) location.
+    """
+    old_preproc_root = tmp_path / "old_location" / "images"
+    manifest_root = _write_manifest_with_preproc_root(tmp_path, old_preproc_root)
+    adapter = UChicagoDataset(root=manifest_root)
+
+    timepoints = adapter.load_timepoints("e1")
+
+    assert timepoints == [
+        manifest_root / "images" / "simbiosys" / "e1" / "phase_0000.nii.gz"
+    ]
+
+
+def test_uchicago_load_timepoints_without_preproc_root_returns_raw_paths(
+    tmp_path: Path,
+) -> None:
+    """A manifest with no preproc_root column falls back to the raw paths."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+
+    timepoints = adapter.load_timepoints("e1")
+
+    assert timepoints == [Path("/a/p0.nii.gz")]
+
+
+# -- coverage gaps: missing values in an otherwise-clean manifest --
+
+
+def _write_manifest_with_gap(tmp_path: Path) -> Path:
+    """Write a manifest where one exam has no pcr label and no fold assignment."""
+    root = tmp_path / "uc"
+    root.mkdir()
+    csv_path = root / "dce2d_internal_ultrafast_manifest.csv"
+    csv_path.write_text(
+        "exam_id,dataset,patient_key,fold,pcr,phase_files\n"
+        'e1,simbiosys,p1,0,1.0,"[""/a/p0.nii.gz""]"\n'
+        'e2,uch_nac,p2,,,"[""/b/p0.nii.gz""]"\n'
+    )
+    return root
+
+
+def test_uchicago_discover_cases_and_load_labels_diverge_on_unlabeled_exam(
+    tmp_path: Path,
+) -> None:
+    """An unlabeled exam is discovered but excluded from load_labels.
+
+    Today's real manifest has zero NaNs (181/181 labeled), so this branch is
+    otherwise never exercised.
+    """
+    adapter = UChicagoDataset(root=_write_manifest_with_gap(tmp_path))
+
+    cases = adapter.discover_cases()
+    labels = adapter.load_labels()
+
+    assert cases == ["e1", "e2"]
+    assert list(labels["case_id"]) == ["e1"]
+
+
+def test_uchicago_load_folds_drops_exams_with_no_fold_assignment(
+    tmp_path: Path,
+) -> None:
+    """An exam with a blank fold value is excluded from load_folds."""
+    adapter = UChicagoDataset(root=_write_manifest_with_gap(tmp_path))
+
+    folds = adapter.load_folds()
+
+    assert list(folds["case_id"]) == ["e1"]

--- a/tests/test_cohort_adapters.py
+++ b/tests/test_cohort_adapters.py
@@ -6,11 +6,13 @@ without touching any real data on disk.
 
 Deliberately not tested here: the exact set of methods each subclass
 overrides. That's an implementation-shape detail that will keep shifting as
-the design evolves (e.g. once UChicago preprocessing is actually implemented);
-pinning it in a test would make routine changes fail for no functional
-reason. What's tested instead is the *behavior* those overrides are
-responsible for (identity parsing, preprocessing raising until implemented,
+the design evolves; pinning it in a test would make routine changes fail for no
+functional reason. What's tested instead is the *behavior* those overrides are
+responsible for (identity parsing, preprocessing pass-through, provided folds,
 split-policy defaults, etc.).
+
+A few tests that need a small manifest use a synthetic CSV fixture; none touch
+real data on disk.
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ from cohorts import (
     MamaMiaDataset,
     UChicagoDataset,
     build_adapter_from_config,
+    resolve_folds,
     resolve_split_policy,
 )
 from config import ConfigNode
@@ -114,11 +117,24 @@ def test_resample_is_noop_when_no_target_spacing() -> None:
     assert np.array_equal(adapter.resample(volume, (1.0, 1.0, 1.0)), volume)
 
 
-def test_uchicago_preprocess_is_a_documented_stub() -> None:
-    """UChicago preprocessing raises until the frozen-copy port lands."""
+def test_uchicago_preprocess_is_passthrough() -> None:
+    """UChicago data ships preprocessed, so preprocess returns it unchanged.
+
+    It must NOT apply the base MAMA-MIA orientation transform, which would be
+    wrong for the already-oriented ultrafast volumes.
+    """
     adapter = UChicagoDataset(root=Path("/data/uchicago"))
-    with pytest.raises(NotImplementedError, match="not ported yet"):
-        adapter.preprocess(np.zeros((2, 2, 2)))
+    volume = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+    result = adapter.preprocess(volume)
+    assert np.array_equal(result, volume)
+    base_transform = np.swapaxes(np.swapaxes(volume, 0, 2), 0, 1)[::-1]
+    assert not np.array_equal(result, base_transform)
+
+
+def test_base_load_folds_is_none() -> None:
+    """Datasets that compute their own splits ship no folds."""
+    adapter = MamaMiaDataset(cohort="duke", root=Path("/x"))
+    assert adapter.load_folds() is None
 
 
 # -- factory + split-policy resolution --
@@ -201,3 +217,63 @@ def test_default_config_has_dataset_block() -> None:
     assert dataset["name"] is None
     assert dataset["split_policy"] == "auto"
     assert set(dataset) == {"name", "cohort", "root", "split_policy"}
+
+
+# -- provided folds (synthetic manifest fixture, no real data) --
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    """Write a tiny UChicago-shaped manifest CSV and return its root dir."""
+    root = tmp_path / "uc"
+    root.mkdir()
+    csv_path = root / "dce2d_internal_ultrafast_manifest.csv"
+    csv_path.write_text(
+        "exam_id,dataset,patient_key,fold,pcr,phase_files\n"
+        'e1,simbiosys,p1,0,1.0,"[""/a/p0.nii.gz""]"\n'
+        'e2,uch_nac,p2,1,0.0,"[""/b/p0.nii.gz""]"\n'
+        'e3,her2_naclike,p3,2,0.0,"[""/c/p0.nii.gz""]"\n'
+    )
+    return root
+
+
+def test_uchicago_load_folds_from_manifest(tmp_path: Path) -> None:
+    """UChicago surfaces the manifest fold column as (case_id, fold), int-typed."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    folds = adapter.load_folds()
+    assert list(folds.columns) == ["case_id", "fold"]
+    assert dict(zip(folds["case_id"], folds["fold"], strict=True)) == {
+        "e1": 0,
+        "e2": 1,
+        "e3": 2,
+    }
+    assert folds["fold"].dtype.kind == "i"
+
+
+def test_resolve_folds_provided_returns_manifest_folds(tmp_path: Path) -> None:
+    """With split_policy auto (-> provided), resolve_folds returns the folds."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _dataset_config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "auto"}
+    )
+    folds = resolve_folds(config, adapter)
+    assert folds is not None
+    assert set(folds["case_id"]) == {"e1", "e2", "e3"}
+
+
+def test_resolve_folds_compute_returns_none(tmp_path: Path) -> None:
+    """Forcing split_policy compute means no provided folds (compute our own)."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _dataset_config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "compute"}
+    )
+    assert resolve_folds(config, adapter) is None
+
+
+def test_resolve_folds_raises_when_provided_but_none_shipped() -> None:
+    """'provided' against a dataset that ships no folds is a clear error."""
+    adapter = MamaMiaDataset(cohort="duke", root=Path("/x"))
+    config = _dataset_config(
+        {"name": "mamamia", "cohort": "duke", "root": "/x", "split_policy": "provided"}
+    )
+    with pytest.raises(ValueError, match="ships no folds"):
+        resolve_folds(config, adapter)

--- a/tests/test_provided_folds.py
+++ b/tests/test_provided_folds.py
@@ -1,0 +1,142 @@
+"""Tests for consuming adapter-provided CV folds in the eval path (Step 3 follow-up).
+
+``cohorts.resolve_folds`` parses and validates a dataset's shipped folds, but
+until this wiring, nothing in the pipeline actually consumed them -- setting
+``split_policy: provided`` had no effect on a real run. These tests cover the
+seam that closes that gap: ``tabular.train._apply_provided_folds`` merges the
+resolved folds onto the feature table, and ``prepare_evaluation_context``
+excludes the merged column from the model's input features so it can't leak in
+as a predictor when a run opts into ``model_params.split_mode: predefined``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from cohorts import MamaMiaDataset, UChicagoDataset
+from config import DEFAULT_CONFIG, ConfigNode, _deep_merge
+from tabular.train import _apply_provided_folds, prepare_evaluation_context
+
+
+def _write_manifest(tmp_path: Path) -> Path:
+    """Write a tiny UChicago-shaped manifest CSV and return its root dir."""
+    root = tmp_path / "uc"
+    root.mkdir()
+    csv_path = root / "dce2d_internal_ultrafast_manifest.csv"
+    csv_path.write_text(
+        "exam_id,dataset,patient_key,fold,pcr,phase_files\n"
+        'e1,simbiosys,p1,0,1.0,"[""/a/p0.nii.gz""]"\n'
+        'e2,uch_nac,p2,1,0.0,"[""/b/p0.nii.gz""]"\n'
+        'e3,her2_naclike,p3,0,1.0,"[""/c/p0.nii.gz""]"\n'
+    )
+    return root
+
+
+def _config(dataset_overrides: dict) -> ConfigNode:
+    return ConfigNode._wrap(_deep_merge(DEFAULT_CONFIG, {"dataset": dataset_overrides}))
+
+
+def test_apply_provided_folds_merges_manifest_folds(tmp_path: Path) -> None:
+    """When split_policy resolves to 'provided', the fold column is merged in."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "auto"}
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3"], "pcr": [1, 0, 1]})
+
+    merged = _apply_provided_folds(feats_df, config, adapter)
+
+    assert "fold" in merged.columns
+    assert dict(zip(merged["case_id"], merged["fold"], strict=True)) == {
+        "e1": 0,
+        "e2": 1,
+        "e3": 0,
+    }
+
+
+def test_apply_provided_folds_noop_when_policy_is_compute(tmp_path: Path) -> None:
+    """With split_policy forced to 'compute', the table is returned unchanged."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "compute"}
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3"], "pcr": [1, 0, 1]})
+
+    merged = _apply_provided_folds(feats_df, config, adapter)
+
+    pd.testing.assert_frame_equal(merged, feats_df)
+
+
+def test_apply_provided_folds_uses_configured_split_col_name(tmp_path: Path) -> None:
+    """The merged column is named after model_params.split_col, not hardcoded."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {
+                    "name": "uchicago",
+                    "cohort": None,
+                    "root": "/x",
+                    "split_policy": "auto",
+                },
+                "model_params": {"split_col": "provided_fold"},
+            },
+        )
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3"], "pcr": [1, 0, 1]})
+
+    merged = _apply_provided_folds(feats_df, config, adapter)
+
+    assert "provided_fold" in merged.columns
+    assert "fold" not in merged.columns
+
+
+def test_apply_provided_folds_noop_for_mamamia_default_compute() -> None:
+    """MAMA-MIA's default policy is 'compute', so nothing is merged by default."""
+    adapter = MamaMiaDataset(cohort="duke", root=Path("/x"))
+    config = _config(
+        {"name": "mamamia", "cohort": "duke", "root": "/x", "split_policy": "auto"}
+    )
+    feats_df = pd.DataFrame({"case_id": ["DUKE_001", "DUKE_002"], "pcr": [1, 0]})
+
+    merged = _apply_provided_folds(feats_df, config, adapter)
+
+    pd.testing.assert_frame_equal(merged, feats_df)
+
+
+def test_predefined_split_col_excluded_from_model_features() -> None:
+    """The merged fold column must never leak into X as a predictor.
+
+    Regression check for the gap the review flagged: prepare_evaluation_context
+    didn't drop model_params.split_col, so a predefined-mode run would have fed
+    the fold assignment itself into the model.
+    """
+    feats_df = pd.DataFrame(
+        {
+            "case_id": ["c1", "c2", "c3", "c4"],
+            "pcr": [1, 0, 1, 0],
+            "dataset": ["uchicago"] * 4,
+            "feature_a": [0.1, 0.2, 0.3, 0.4],
+            "feature_b": [1.0, 2.0, 3.0, 4.0],
+            "fold": [0, 0, 1, 1],
+        }
+    )
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "model_params": {"split_mode": "predefined", "split_col": "fold"},
+                "feature_toggles": {"use_clinical": False},
+            },
+        )
+    )
+
+    context = prepare_evaluation_context(feats_df, config)
+
+    expected_n_folds = 2
+    assert "fold" not in context["X"].columns
+    assert set(context["X"].columns) == {"feature_a", "feature_b"}
+    assert len(context["splits"]) == expected_n_folds

--- a/tests/test_provided_folds.py
+++ b/tests/test_provided_folds.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from cohorts import MamaMiaDataset, UChicagoDataset
 from config import DEFAULT_CONFIG, ConfigNode, _deep_merge
@@ -105,6 +106,56 @@ def test_apply_provided_folds_noop_for_mamamia_default_compute() -> None:
     merged = _apply_provided_folds(feats_df, config, adapter)
 
     pd.testing.assert_frame_equal(merged, feats_df)
+
+
+def test_apply_provided_folds_raises_on_missing_fold_in_predefined_mode(
+    tmp_path: Path,
+) -> None:
+    """A labeled row with no provided fold must fail loudly, not split silently.
+
+    Without the guard, the left-merge NaN would become a spurious
+    empty-validation fold in create_predefined_splits and leak those rows into
+    every fold's training set. 'e4' is in the feature table but absent from the
+    manifest, so it has no fold.
+    """
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {
+                    "name": "uchicago",
+                    "cohort": None,
+                    "root": "/x",
+                    "split_policy": "auto",
+                },
+                "model_params": {"split_mode": "predefined", "split_col": "fold"},
+            },
+        )
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3", "e4"], "pcr": [1, 0, 1, 0]})
+
+    with pytest.raises(ValueError, match="no provided fold"):
+        _apply_provided_folds(feats_df, config, adapter)
+
+
+def test_apply_provided_folds_allows_missing_fold_when_not_predefined(
+    tmp_path: Path,
+) -> None:
+    """Outside predefined mode a missing fold is harmless: merge, don't raise.
+
+    The fold column is just made available (design decision 3); a run using
+    'random' splits never consults it, so an unmatched row's NaN is fine.
+    """
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "auto"}
+    )  # model_params.split_mode defaults to "random"
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3", "e4"], "pcr": [1, 0, 1, 0]})
+
+    merged = _apply_provided_folds(feats_df, config, adapter)
+
+    assert merged.loc[merged["case_id"] == "e4", "fold"].isna().all()
 
 
 def test_predefined_split_col_excluded_from_model_features() -> None:

--- a/tests/test_provided_folds.py
+++ b/tests/test_provided_folds.py
@@ -19,8 +19,10 @@ import pytest
 from cohorts import MamaMiaDataset, UChicagoDataset
 from config import DEFAULT_CONFIG, ConfigNode, _deep_merge
 from tabular.train import (
+    _adapter_populates_group_col,
     _apply_group_keys,
     _apply_provided_folds,
+    _needs_group_keys,
     prepare_evaluation_context,
 )
 
@@ -294,13 +296,31 @@ def test_predefined_split_col_excluded_from_model_features() -> None:
     assert len(context["splits"]) == expected_n_folds
 
 
-def test_group_col_excluded_from_model_features_when_adapter_configured() -> None:
-    """The adapter grouping key (patient_key) must not leak into X as a feature.
+def _group_config(group_col: str, use_clinical: bool = False) -> ConfigNode:
+    return ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {"name": "uchicago", "cohort": None, "root": "/x"},
+                "model_params": {
+                    "split_mode": "random",
+                    "use_group_split": True,
+                    "group_col": group_col,
+                    "n_splits": 2,
+                },
+                "feature_toggles": {"use_clinical": use_clinical},
+            },
+        )
+    )
 
-    With a dataset configured and use_group_split on, group_col holds an identity
-    (patient_key); prepare_evaluation_context must drop it from the model inputs
-    even though use_group_split would otherwise keep the group column as a
-    feature for legacy (non-adapter) runs.
+
+def test_group_col_excluded_from_model_features_when_adapter_populated_it() -> None:
+    """An adapter-populated identity key (patient_key) must not leak into X.
+
+    With ``group_col_from_adapter=True`` (the caller's signal that
+    _apply_group_keys populated group_col from the adapter's identity key),
+    prepare_evaluation_context drops it even though use_group_split would
+    otherwise keep the group column as a feature for legacy runs.
     """
     feats_df = pd.DataFrame(
         {
@@ -311,23 +331,82 @@ def test_group_col_excluded_from_model_features_when_adapter_configured() -> Non
             "patient_key": ["p1", "p1", "p2", "p2"],
         }
     )
-    config = ConfigNode._wrap(
-        _deep_merge(
-            DEFAULT_CONFIG,
-            {
-                "dataset": {"name": "uchicago", "cohort": None, "root": "/x"},
-                "model_params": {
-                    "split_mode": "random",
-                    "use_group_split": True,
-                    "group_col": "patient_key",
-                    "n_splits": 2,
-                },
-                "feature_toggles": {"use_clinical": False},
-            },
-        )
-    )
 
-    context = prepare_evaluation_context(feats_df, config)
+    context = prepare_evaluation_context(
+        feats_df, _group_config("patient_key"), group_col_from_adapter=True
+    )
 
     assert "patient_key" not in context["X"].columns
     assert set(context["X"].columns) == {"feature_a"}
+
+
+def test_group_col_kept_as_feature_when_adapter_did_not_populate_it() -> None:
+    """A configured dataset must not, by itself, strip group_col from features.
+
+    modeling/ablation.py builds an adapter for feature extraction but never calls
+    _apply_group_keys, so group_col_from_adapter stays False even though a dataset
+    is configured. There group_col can be a genuine feature (MAMA-MIA's clinical
+    ``site``) supplied by an earlier stage -- it must be treated like a legacy
+    use_group_split run and kept in X, matching pre-Step-4 behavior.
+    """
+    feats_df = pd.DataFrame(
+        {
+            "case_id": ["c1", "c2", "c3", "c4"],
+            "pcr": [1, 0, 1, 0],
+            "dataset": ["mamamia"] * 4,
+            "feature_a": [0.1, 0.2, 0.3, 0.4],
+            "site": ["A", "A", "B", "B"],
+        }
+    )
+
+    # group_col_from_adapter omitted (defaults False), mirroring ablation.py.
+    context = prepare_evaluation_context(
+        feats_df, _group_config("site", use_clinical=True)
+    )
+
+    assert "site" in context["X"].columns
+    assert set(context["X"].columns) == {"feature_a", "site"}
+
+
+def test_needs_group_keys_false_for_provided_policy(tmp_path: Path) -> None:
+    """UChicago's default (provided) must not trigger group-key population/I/O."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "auto"}
+    )
+    config.model_params.use_group_split = True
+    assert _needs_group_keys(config, adapter) is False
+
+
+def test_needs_group_keys_true_for_compute_with_group_split() -> None:
+    """MAMA-MIA's default (compute) with use_group_split on does need group keys."""
+    adapter = MamaMiaDataset(cohort="duke", root=Path("/x"))
+    config = _config(
+        {"name": "mamamia", "cohort": "duke", "root": "/x", "split_policy": "auto"}
+    )
+    config.model_params.use_group_split = True
+    assert _needs_group_keys(config, adapter) is True
+    config.model_params.use_group_split = False
+    assert _needs_group_keys(config, adapter) is False
+
+
+def test_adapter_populates_group_col_false_when_column_preexists() -> None:
+    """Residual-fix regression: a pre-existing genuine group_col is not claimed.
+
+    When group_col is already present (e.g. MAMA-MIA's clinical ``site``),
+    _apply_group_keys would no-op -- so _adapter_populates_group_col must return
+    False, otherwise run_pipeline_from_config would set group_col_from_adapter
+    and prepare_evaluation_context would drop that genuine feature.
+    """
+    adapter = MamaMiaDataset(cohort="duke", root=Path("/x"))
+    config = _config(
+        {"name": "mamamia", "cohort": "duke", "root": "/x", "split_policy": "auto"}
+    )
+    config.model_params.use_group_split = True
+    config.model_params.group_col = "site"
+
+    absent = pd.DataFrame({"case_id": ["DUKE_1"], "feature_a": [0.1]})
+    present = pd.DataFrame({"case_id": ["DUKE_1"], "feature_a": [0.1], "site": ["A"]})
+
+    assert _adapter_populates_group_col(absent, config, adapter) is True
+    assert _adapter_populates_group_col(present, config, adapter) is False

--- a/tests/test_provided_folds.py
+++ b/tests/test_provided_folds.py
@@ -18,7 +18,11 @@ import pytest
 
 from cohorts import MamaMiaDataset, UChicagoDataset
 from config import DEFAULT_CONFIG, ConfigNode, _deep_merge
-from tabular.train import _apply_provided_folds, prepare_evaluation_context
+from tabular.train import (
+    _apply_group_keys,
+    _apply_provided_folds,
+    prepare_evaluation_context,
+)
 
 
 def _write_manifest(tmp_path: Path) -> Path:
@@ -108,15 +112,13 @@ def test_apply_provided_folds_noop_for_mamamia_default_compute() -> None:
     pd.testing.assert_frame_equal(merged, feats_df)
 
 
-def test_apply_provided_folds_raises_on_missing_fold_in_predefined_mode(
-    tmp_path: Path,
-) -> None:
-    """A labeled row with no provided fold must fail loudly, not split silently.
+def test_apply_provided_folds_raises_on_missing_fold(tmp_path: Path) -> None:
+    """A modeled case with no provided fold fails closed, unconditionally.
 
-    Without the guard, the left-merge NaN would become a spurious
-    empty-validation fold in create_predefined_splits and leak those rows into
-    every fold's training set. 'e4' is in the feature table but absent from the
-    manifest, so it has no fold.
+    'e4' is in the feature table but absent from the manifest, so the left merge
+    leaves its fold null. Attaching provided folds must cover every modeled case;
+    otherwise create_predefined_splits would build a spurious empty-validation
+    fold and leak those rows into every fold's training set.
     """
     adapter = UChicagoDataset(root=_write_manifest(tmp_path))
     config = ConfigNode._wrap(
@@ -139,13 +141,12 @@ def test_apply_provided_folds_raises_on_missing_fold_in_predefined_mode(
         _apply_provided_folds(feats_df, config, adapter)
 
 
-def test_apply_provided_folds_allows_missing_fold_when_not_predefined(
-    tmp_path: Path,
-) -> None:
-    """Outside predefined mode a missing fold is harmless: merge, don't raise.
+def test_apply_provided_folds_fails_closed_even_in_random_mode(tmp_path: Path) -> None:
+    """Fail-closed does not depend on split_mode: a missing fold always raises.
 
-    The fold column is just made available (design decision 3); a run using
-    'random' splits never consults it, so an unmatched row's NaN is fine.
+    Even a run that would compute random splits must not silently attach an
+    incomplete provided-fold column; the dataset's policy is "provided", so the
+    folds are expected to cover every case.
     """
     adapter = UChicagoDataset(root=_write_manifest(tmp_path))
     config = _config(
@@ -153,9 +154,109 @@ def test_apply_provided_folds_allows_missing_fold_when_not_predefined(
     )  # model_params.split_mode defaults to "random"
     feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3", "e4"], "pcr": [1, 0, 1, 0]})
 
-    merged = _apply_provided_folds(feats_df, config, adapter)
+    with pytest.raises(ValueError, match="no provided fold"):
+        _apply_provided_folds(feats_df, config, adapter)
 
-    assert merged.loc[merged["case_id"] == "e4", "fold"].isna().all()
+
+def test_apply_provided_folds_raises_on_duplicate_fold_mapping(tmp_path: Path) -> None:
+    """A manifest that maps one exam to two folds is rejected before the merge."""
+    root = tmp_path / "uc"
+    root.mkdir()
+    (root / "dce2d_internal_ultrafast_manifest.csv").write_text(
+        "exam_id,dataset,patient_key,fold,pcr,phase_files\n"
+        'e1,simbiosys,p1,0,1.0,"[""/a/p0.nii.gz""]"\n'
+        'e1,simbiosys,p1,1,1.0,"[""/a/p0.nii.gz""]"\n'  # e1 mapped twice
+        'e2,uch_nac,p2,1,0.0,"[""/b/p0.nii.gz""]"\n'
+    )
+    adapter = UChicagoDataset(root=root)
+    config = _config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "auto"}
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2"], "pcr": [1, 0]})
+
+    with pytest.raises(ValueError, match="more than once"):
+        _apply_provided_folds(feats_df, config, adapter)
+
+
+def test_apply_provided_folds_rejects_split_col_collision(tmp_path: Path) -> None:
+    """split_col must not clobber case_id or the label column."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {
+                    "name": "uchicago",
+                    "cohort": None,
+                    "root": "/x",
+                    "split_policy": "auto",
+                },
+                "model_params": {"split_col": "pcr"},  # collides with the label column
+            },
+        )
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3"], "pcr": [1, 0, 1]})
+
+    with pytest.raises(ValueError, match="collides"):
+        _apply_provided_folds(feats_df, config, adapter)
+
+
+def test_apply_provided_folds_rejects_duplicate_case_in_features(
+    tmp_path: Path,
+) -> None:
+    """A duplicate case_id in the feature table cannot fan across folds."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = _config(
+        {"name": "uchicago", "cohort": None, "root": "/x", "split_policy": "auto"}
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e1", "e2", "e3"], "pcr": [1, 1, 0, 1]})
+
+    with pytest.raises((ValueError, pd.errors.MergeError)):
+        _apply_provided_folds(feats_df, config, adapter)
+
+
+def test_apply_group_keys_populates_patient_key(tmp_path: Path) -> None:
+    """_apply_group_keys fills group_col from adapter.group_key (patient grouping)."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {"name": "uchicago", "cohort": None, "root": "/x"},
+                "model_params": {"group_col": "patient_key"},
+            },
+        )
+    )
+    feats_df = pd.DataFrame({"case_id": ["e1", "e2", "e3"], "pcr": [1, 0, 1]})
+
+    grouped = _apply_group_keys(feats_df, config, adapter)
+
+    assert dict(zip(grouped["case_id"], grouped["patient_key"], strict=True)) == {
+        "e1": "p1",
+        "e2": "p2",
+        "e3": "p3",
+    }
+
+
+def test_apply_group_keys_does_not_override_existing_column(tmp_path: Path) -> None:
+    """An already-populated group column (e.g. clinical site) is left untouched."""
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {"name": "uchicago", "cohort": None, "root": "/x"},
+                "model_params": {"group_col": "patient_key"},
+            },
+        )
+    )
+    feats_df = pd.DataFrame(
+        {"case_id": ["e1", "e2"], "pcr": [1, 0], "patient_key": ["preset1", "preset2"]}
+    )
+
+    grouped = _apply_group_keys(feats_df, config, adapter)
+
+    assert grouped["patient_key"].tolist() == ["preset1", "preset2"]
 
 
 def test_predefined_split_col_excluded_from_model_features() -> None:
@@ -191,3 +292,42 @@ def test_predefined_split_col_excluded_from_model_features() -> None:
     assert "fold" not in context["X"].columns
     assert set(context["X"].columns) == {"feature_a", "feature_b"}
     assert len(context["splits"]) == expected_n_folds
+
+
+def test_group_col_excluded_from_model_features_when_adapter_configured() -> None:
+    """The adapter grouping key (patient_key) must not leak into X as a feature.
+
+    With a dataset configured and use_group_split on, group_col holds an identity
+    (patient_key); prepare_evaluation_context must drop it from the model inputs
+    even though use_group_split would otherwise keep the group column as a
+    feature for legacy (non-adapter) runs.
+    """
+    feats_df = pd.DataFrame(
+        {
+            "case_id": ["c1", "c2", "c3", "c4"],
+            "pcr": [1, 0, 1, 0],
+            "dataset": ["uchicago"] * 4,
+            "feature_a": [0.1, 0.2, 0.3, 0.4],
+            "patient_key": ["p1", "p1", "p2", "p2"],
+        }
+    )
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {"name": "uchicago", "cohort": None, "root": "/x"},
+                "model_params": {
+                    "split_mode": "random",
+                    "use_group_split": True,
+                    "group_col": "patient_key",
+                    "n_splits": 2,
+                },
+                "feature_toggles": {"use_clinical": False},
+            },
+        )
+    )
+
+    context = prepare_evaluation_context(feats_df, config)
+
+    assert "patient_key" not in context["X"].columns
+    assert set(context["X"].columns) == {"feature_a"}


### PR DESCRIPTION
Makes UChicagoDataset usable against the real internal ultrafast manifest (181 labeled exams), scoped to the manifest-driven path only — no vessel pipeline, since no UChicago segmentations/centerlines exist yet and imaging stages aren't adapter-wired until Step 4.

What's included:
- preprocess() is a documented pass-through — manifest images are already preprocessed upstream (policy_name = hfdp_t1_v1); does not fall back to the MAMA-MIA orientation transform.
- load_folds() / resolve_folds() surface UChicago's shipped patient-grouped CV folds, and — importantly — are now actually consumed: tabular/train.py merges them onto the feature table, and a run opts in via model_params.split_mode: predefined (configs/uchicago.yaml). Previously this was parsed/validated but wired to nothing.
- load_timepoints() rebases phase-file paths against the injected root, so a moved manifest directory doesn't leave stale paths.
- configs/uchicago.yaml selects the dataset via the factory (canonical /gpfs manifest root).
- Validation: scripts/validate_uchicago_manifest.py checks the adapter against the real manifest (discovery, labels, folds, sub-sources, timepoints) — all passing. Full test suite: 114 passed / 2 skipped.

Known open item: the preprocess() pass-through assumes UChicago's hfdp_t1_v1 volumes are already correctly oriented for the downstream vessel/graph pipeline. That assumption isn't verified end-to-end (no UChicago imaging flows exist yet). Flagged in cohorts/README.md.