### PR TITLE
Feat/uchicago external breast masks

### DIFF
--- a/cohorts/README.md
+++ b/cohorts/README.md
@@ -59,20 +59,25 @@ Genuinely different, so it overrides the handful of methods that differ:
 `load_labels()`, and `load_folds()` are all **manifest-driven** (read from a CSV,
 including a `phase_files` list per row); it sets `default_split_policy =
 "provided"` (ships patient-grouped folds) and `report_by = "dataset"`
-(sub-source breakdown). `preprocess()` is a **documented pass-through** — the
-manifest's phase files are already preprocessed upstream (`policy_name =
-hfdp_t1_v1`), so no repo-side transform is applied (and, importantly, the base
-MAMA-MIA orientation transform is *not* used, which would be wrong here). The
-181-exam student manifest lives at
+(sub-source breakdown). `preprocess()` flips array axes 0 and 2 and then applies
+the base MAMA-MIA reorientation: UChicago's volumes are stored `RAS` where
+MAMA-MIA's are `LAI`, i.e. flipped in x and z. The 181-exam student manifest
+lives at
 `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/`; select it
 with `configs/uchicago.yaml`.
 
-> **Open item, needs Anna's sign-off:** the pass-through assumes the manifest's
-> `hfdp_t1_v1` volumes are already in the orientation the downstream vessel/graph
-> stages expect. That assumption isn't checked in code and isn't exercised
-> end-to-end yet (no UChicago imaging flows exist until Step 4) — if it's wrong,
-> it will silently feed mis-oriented volumes into Step 4 rather than failing
-> loudly. Flagging it here so it isn't mistaken for a verified fact.
+> **History, and an open item for Anna.** `preprocess()` was originally a
+> pass-through, assuming the manifest's `hfdp_t1_v1` volumes already arrived in
+> the orientation the vessel/graph stages expect. Running the segmentation smoke
+> test showed they don't: the pass-through put the thin slice axis where the model
+> expects a large in-plane axis, which surfaced as a tiling-coverage assertion
+> failure in `predict_fast.py`. The current flip was derived from the NIfTI
+> direction cosines and then **confirmed visually** (MIP + z-progression against a
+> MAMA-MIA reference), because headers alone are not trustworthy here — MAMA-MIA's
+> own ISPY1 reports `PSL`, a true axis permutation, yet gets the same fixed
+> transform as `LAI` ISPY2/DUKE and evidently works. **Still unverified:** a pure
+> left-right mirror, which near-symmetric breast anatomy can't rule out visually.
+> Worth confirming with Anna against the HFDP pipeline's actual output convention.
 
 > Note: `case_dataset_name()` here returns a manifest **sub-source**
 > (`simbiosys`/`uch_nac`/`her2_naclike`), a finer granularity than

--- a/cohorts/README.md
+++ b/cohorts/README.md
@@ -59,25 +59,20 @@ Genuinely different, so it overrides the handful of methods that differ:
 `load_labels()`, and `load_folds()` are all **manifest-driven** (read from a CSV,
 including a `phase_files` list per row); it sets `default_split_policy =
 "provided"` (ships patient-grouped folds) and `report_by = "dataset"`
-(sub-source breakdown). `preprocess()` flips array axes 0 and 2 and then applies
-the base MAMA-MIA reorientation: UChicago's volumes are stored `RAS` where
-MAMA-MIA's are `LAI`, i.e. flipped in x and z. The 181-exam student manifest
-lives at
+(sub-source breakdown). UChicago phase data is already canonicalized in HFDP
+array space, so `preprocess()` only converts SimpleITK's `(z, y, x)` order to
+the pinned model's `(y, x, z)` order. It does not infer extra flips from the
+derived NIfTI affine. The 181-exam student manifest lives at
 `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/`; select it
 with `configs/uchicago.yaml`.
 
-> **History, and an open item for Anna.** `preprocess()` was originally a
-> pass-through, assuming the manifest's `hfdp_t1_v1` volumes already arrived in
-> the orientation the vessel/graph stages expect. Running the segmentation smoke
-> test showed they don't: the pass-through put the thin slice axis where the model
-> expects a large in-plane axis, which surfaced as a tiling-coverage assertion
-> failure in `predict_fast.py`. The current flip was derived from the NIfTI
-> direction cosines and then **confirmed visually** (MIP + z-progression against a
-> MAMA-MIA reference), because headers alone are not trustworthy here — MAMA-MIA's
-> own ISPY1 reports `PSL`, a true axis permutation, yet gets the same fixed
-> transform as `LAI` ISPY2/DUKE and evidently works. **Still unverified:** a pure
-> left-right mirror, which near-symmetric breast anatomy can't rule out visually.
-> Worth confirming with Anna against the HFDP pipeline's actual output convention.
+> **Preprocessing contract.** The original pass-through preserved anatomical
+> directions but left the thin slice axis in the model's first spatial dimension,
+> causing the tiling-coverage assertion. A later header-derived RAS-to-LAI fix
+> overcorrected the already-canonicalized HFDP arrays. The order-only conversion
+> was checked through the pinned breast model on one phase-0 case from each
+> UChicago sub-source; it restored bilateral breast-mask alignment without
+> introducing an anatomical flip.
 
 > Note: `case_dataset_name()` here returns a manifest **sub-source**
 > (`simbiosys`/`uch_nac`/`her2_naclike`), a finer granularity than

--- a/cohorts/base.py
+++ b/cohorts/base.py
@@ -134,6 +134,36 @@ class DatasetAdapter:
             raise FileNotFoundError(f"No image dir for case {case_id}: {case_dir}")
         return sorted(case_dir.glob("*.nii.gz"))
 
+    def load_segmented_timepoints(
+        self, input_dir: Path, case_id: str
+    ) -> tuple[list[Path], list[int]]:
+        """Return a case's per-timepoint vessel-segmentation ``.npz`` files, ordered.
+
+        This is a *different* artifact from :meth:`load_timepoints`: it discovers
+        the graph-extraction stage's input (segmented vessel-probability volumes
+        produced by the segmentation stage), not raw DCE phases. Delegates to
+        ``graph_extraction.core4d.discover_study_timepoints`` for the base/MAMA-MIA
+        behavior (``<input_dir>/<case_id>/images/<case_id>_<4-digit>_vessel_segmentation.npz``),
+        so this is a no-op wrapper for MAMA-MIA and a documented seam for a future
+        dataset whose segmentation output is laid out differently.
+
+        Args:
+            input_dir: Root directory of vessel-segmentation output (a pipeline
+                artifact location, not this adapter's own ``root`` -- segmentation
+                output lives in its own directory, separate from raw data).
+            case_id: The case to discover timepoints for.
+
+        Returns:
+            ``(ordered file paths, ordered timepoint indices)``.
+        """
+        from graph_extraction.core4d import discover_study_timepoints
+
+        return discover_study_timepoints(input_dir=input_dir, case_id=case_id)
+
+    #: Axis to flip vessel/tumor/breast masks along for MIP visualization only
+    #: (does not affect computed centerline/graph features). MAMA-MIA default.
+    viz_flip_spec: ClassVar[str] = "z"
+
     def preprocess(self, volume: np.ndarray) -> np.ndarray:
         """Reorient a raw volume into the pipeline's processing layout.
 

--- a/cohorts/uchicago.py
+++ b/cohorts/uchicago.py
@@ -2,10 +2,10 @@
 
 Overrides the base MAMA-MIA behavior for the differences identified in
 ``cohorts/README.md``: manifest-driven discovery/identity/timepoints/labels,
-provided CV folds, and sub-source reporting. ``preprocess`` flips x/z (UChicago
-is stored ``RAS`` where MAMA-MIA is ``LAI``) and then applies the base
-reorientation; see the method docstring for the evidence and the note on design
-decision 4.
+provided CV folds, and sub-source reporting. ``preprocess`` converts
+SimpleITK's ``(z, y, x)`` array order to the vessel model's
+``(y, x, z)`` order without changing anatomical directions; see the method
+docstring for the source and model contracts.
 """
 
 from __future__ import annotations
@@ -116,37 +116,20 @@ class UChicagoDataset(DatasetAdapter):
         return labels
 
     def preprocess(self, volume: np.ndarray) -> np.ndarray:
-        """Reorient a raw UChicago volume into the pipeline's processing layout.
+        """Convert an HFDP UChicago volume into the vessel model's array order.
 
-        UChicago's NIfTI headers are consistently ``RAS`` (direction diag
-        ``(-1, -1, 1)``) across all three sub-sources, verified against a
-        sample from each. MAMA-MIA's ISPY2/DUKE cases are ``LAI`` (diag
-        ``(1, -1, -1)``) -- flipped in x and z relative to UChicago. Since
-        ``sitk.GetArrayFromImage`` returns arrays in (z, y, x) index order,
-        undoing that x/z sign difference before applying the base class's
-        MAMA-MIA swap+flip means array axes 0 (z) and 2 (x) get flipped here
-        first.
+        HFDP has already canonicalized the phase data in anatomical array space.
+        The positive-diagonal NIfTI affine written for these derived volumes is
+        therefore not a request for another RAS-to-LAI reorientation. SimpleITK
+        returns the stored volume in ``(z, y, x)`` index order, while the pinned
+        vessel workflow expects ``(rows, columns, slices) == (y, x, z)``.
 
-        This was previously an identity pass-through, on the unverified
-        assumption that Anna's HFDP pipeline (``policy_name = hfdp_t1_v1``)
-        already wrote UChicago volumes in the model's target layout. It
-        didn't: feeding the raw array straight through put the thin slice
-        axis where the model expects a large in-plane axis (and vice versa),
-        which is why ``segmentation/predict_fast.py``'s tiling coverage
-        assertion started failing on wide-matrix UChicago phases.
-
-        Note for Anna: NIfTI header orientation isn't reliable across all of
-        MAMA-MIA either -- ISPY1 reports ``PSL`` (a true axis permutation,
-        not just sign flips) yet gets the same fixed transform as
-        ISPY2/DUKE. This flip was chosen from the header comparison above but
-        confirmed by rendering corrected UChicago MIPs and a z-depth
-        progression against a MAMA-MIA reference and matching the anatomical
-        landmarks -- not trusted from headers alone. Still unverified: a pure
-        left-right mirror, which near-symmetric breast anatomy cannot rule out
-        visually. See ``cohorts/README.md`` for the full history.
+        Preserve every anatomical axis direction and change only array order.
+        An identity pass-through leaves the thin slice axis in the model's first
+        spatial dimension; applying the MAMA-MIA transform adds an incorrect
+        flip after the order conversion.
         """
-        volume = volume[::-1, :, ::-1]
-        return super().preprocess(volume)
+        return np.transpose(volume, (1, 2, 0))
 
     def load_folds(self) -> pd.DataFrame:
         """Return the manifest's patient-grouped CV folds as ``(case_id, fold)``.

--- a/cohorts/uchicago.py
+++ b/cohorts/uchicago.py
@@ -2,9 +2,10 @@
 
 Overrides the base MAMA-MIA behavior for the differences identified in
 ``cohorts/README.md``: manifest-driven discovery/identity/timepoints/labels,
-provided CV folds, and sub-source reporting. ``preprocess`` is a pass-through
-because the manifest ships already-preprocessed volumes (``policy_name =
-hfdp_t1_v1``); see the method docstring for the note on design decision 4.
+provided CV folds, and sub-source reporting. ``preprocess`` flips x/z (UChicago
+is stored ``RAS`` where MAMA-MIA is ``LAI``) and then applies the base
+reorientation; see the method docstring for the evidence and the note on design
+decision 4.
 """
 
 from __future__ import annotations
@@ -115,20 +116,37 @@ class UChicagoDataset(DatasetAdapter):
         return labels
 
     def preprocess(self, volume: np.ndarray) -> np.ndarray:
-        """Return the volume unchanged — UChicago data is already preprocessed.
+        """Reorient a raw UChicago volume into the pipeline's processing layout.
 
-        The manifest's ``phase_files`` are preprocessed upstream by Anna's HFDP
-        pipeline (``policy_name = hfdp_t1_v1``) and copied into ``images/``, so no
-        repo-side preprocessing is applied here. Crucially this must NOT fall back
-        to the base MAMA-MIA orientation transform, which would be wrong for this
-        already-oriented ultrafast data.
+        UChicago's NIfTI headers are consistently ``RAS`` (direction diag
+        ``(-1, -1, 1)``) across all three sub-sources, verified against a
+        sample from each. MAMA-MIA's ISPY2/DUKE cases are ``LAI`` (diag
+        ``(1, -1, -1)``) -- flipped in x and z relative to UChicago. Since
+        ``sitk.GetArrayFromImage`` returns arrays in (z, y, x) index order,
+        undoing that x/z sign difference before applying the base class's
+        MAMA-MIA swap+flip means array axes 0 (z) and 2 (x) get flipped here
+        first.
 
-        Note for Anna: this makes design decision 4 (port a frozen copy of the
-        UChicago preprocessing into the repo) unnecessary for the student
-        manifest, since the shipped data is already preprocessed. Revisit only if
-        we ever need to preprocess *raw* UChicago exams inside this pipeline.
+        This was previously an identity pass-through, on the unverified
+        assumption that Anna's HFDP pipeline (``policy_name = hfdp_t1_v1``)
+        already wrote UChicago volumes in the model's target layout. It
+        didn't: feeding the raw array straight through put the thin slice
+        axis where the model expects a large in-plane axis (and vice versa),
+        which is why ``segmentation/predict_fast.py``'s tiling coverage
+        assertion started failing on wide-matrix UChicago phases.
+
+        Note for Anna: NIfTI header orientation isn't reliable across all of
+        MAMA-MIA either -- ISPY1 reports ``PSL`` (a true axis permutation,
+        not just sign flips) yet gets the same fixed transform as
+        ISPY2/DUKE. This flip was chosen from the header comparison above but
+        confirmed by rendering corrected UChicago MIPs and a z-depth
+        progression against a MAMA-MIA reference and matching the anatomical
+        landmarks -- not trusted from headers alone. Still unverified: a pure
+        left-right mirror, which near-symmetric breast anatomy cannot rule out
+        visually. See ``cohorts/README.md`` for the full history.
         """
-        return volume
+        volume = volume[::-1, :, ::-1]
+        return super().preprocess(volume)
 
     def load_folds(self) -> pd.DataFrame:
         """Return the manifest's patient-grouped CV folds as ``(case_id, fold)``.

--- a/data_viz/run_uchicago_skeleton_interactive.sbatch
+++ b/data_viz/run_uchicago_skeleton_interactive.sbatch
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uc_skel_html
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/uc-skel-html-%j.out
+#SBATCH --error=logs/uc-skel-html-%j.err
+set -eo pipefail
+
+# Render the UChicago interactive 3D vessel-centerline QC scenes (one self-
+# contained HTML per case). Skeletonization is CPU-bound and takes a few minutes
+# per case, hence tier1q rather than the head node.
+#
+# Requires the segmentation runs to have finished first:
+#   external (real breast masks) -> --external-dir
+#   baseline (model breast masks) -> --baseline-dir
+#
+# Submit from the repo root; all args after the script are passed to the CLI:
+#   PROJECT_ROOT="$(pwd)" sbatch data_viz/run_uchicago_skeleton_interactive.sbatch \
+#     --sub-source simbiosys uch_nac
+
+source ~/.bashrc || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+export xml_catalog_files_libxml2=""
+
+PROJECT_ROOT="${PROJECT_ROOT:?PROJECT_ROOT must be set, e.g. PROJECT_ROOT=\$(pwd) sbatch ... from the repo root}"
+cd "${PROJECT_ROOT}"
+mkdir -p logs
+
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS=4
+
+echo "=== UChicago interactive skeleton HTML: $(date) ==="
+echo "Node: $(hostname)  args: $*"
+
+python -u "${PROJECT_ROOT}/data_viz/uchicago_skeleton_interactive.py" "$@"
+
+echo "=== Finished: $(date) ==="

--- a/data_viz/uchicago_seg_mips.py
+++ b/data_viz/uchicago_seg_mips.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""MIP panels for the UChicago vessel segmentation, and a baseline-vs-external compare.
+
+Renders, per case, three-plane maximum-intensity projections of the vessel
+segmentation, for one run or for two runs side by side (model-predicted STEP-2
+breast masks vs. the external BreastDivider whole-breast masks).
+
+Two choices here are deliberate, and both are corrections of earlier mistakes:
+
+* **Timepoint selection is by vessel content, never a fixed phase index.** DCE
+  phases differ enormously in vessel conspicuity (pre-contrast phases have almost
+  none), so a hardcoded phase is not a QC view -- it is a lottery. By default this
+  collapses the whole time series with a per-voxel max over phases
+  (``--phase-mode time-max``), which uses every timepoint and cannot be unlucky.
+  ``--phase-mode richest`` instead picks the single phase with the most vessel
+  voxels *summed across both runs*, so the two runs are always compared on the
+  SAME phase.
+
+* **Matched phases when comparing runs.** An earlier comparison picked each run's
+  richest phase independently, so 4/5 patients were compared across *different*
+  phases -- one pair scored Dice 0.0 purely because of that, not because of any
+  real difference. Any per-phase quantity here is computed on the same phase in
+  both runs.
+
+Vessel outputs are ``<run>/<sub_source>/<case>/images/<case>_phase_XXXX_vessel_segmentation.npz``
+with a single ``vessel`` array (float16 probabilities) in the model's
+(rows, cols, slices) layout.
+
+Example:
+    python data_viz/uchicago_seg_mips.py \
+        --run-a /path/uchicago_vessel_seg_v3_model_breast    --label-a "model breast mask" \
+        --run-b /path/uchicago_vessel_seg_v3_external_breast --label-b "external breast mask" \
+        --out-dir data_viz/uchicago_seg_v3
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+VESSEL_THRESHOLD = 0.5
+PHASE_RE = re.compile(r"_phase_(\d+)_vessel_segmentation\.npz$")
+PLANE_NAMES = (
+    "axial (max over slices)",
+    "coronal (max over rows)",
+    "sagittal (max over cols)",
+)
+
+
+def find_cases(run: Path) -> dict[str, Path]:
+    """Map case_id -> its images dir, for every case with vessel output in a run."""
+    cases: dict[str, Path] = {}
+    for images_dir in run.glob("*/*/images"):
+        if any(images_dir.glob("*_vessel_segmentation.npz")):
+            cases[images_dir.parent.name] = images_dir
+    return cases
+
+
+def load_phases(images_dir: Path) -> dict[int, Path]:
+    """Map phase index -> npz path."""
+    out: dict[int, Path] = {}
+    for f in images_dir.glob("*_vessel_segmentation.npz"):
+        m = PHASE_RE.search(f.name)
+        if m:
+            out[int(m.group(1))] = f
+    return out
+
+
+def load_vessel(path: Path) -> np.ndarray:
+    """Load one phase's vessel probability volume as float32."""
+    with np.load(path) as d:
+        return d["vessel"].astype(np.float32)
+
+
+def time_max(images_dir: Path) -> np.ndarray:
+    """Per-voxel max over every phase -- uses the whole time series, not one phase."""
+    phases = load_phases(images_dir)
+    if not phases:
+        raise SystemExit(f"no vessel output under {images_dir}")
+    acc: np.ndarray | None = None
+    for _, p in sorted(phases.items()):
+        v = load_vessel(p)
+        acc = v if acc is None else np.maximum(acc, v)
+    return acc
+
+
+def mips(volume: np.ndarray) -> list[np.ndarray]:
+    """Three-plane MIPs of a (rows, cols, slices) volume."""
+    return [volume.max(axis=2), volume.max(axis=0), volume.max(axis=1)]
+
+
+def dice(a: np.ndarray, b: np.ndarray) -> float:
+    """Dice between two binarized vessel volumes."""
+    a_b, b_b = a > VESSEL_THRESHOLD, b > VESSEL_THRESHOLD
+    denom = a_b.sum() + b_b.sum()
+    if denom == 0:
+        return float("nan")
+    return float(2.0 * np.logical_and(a_b, b_b).sum() / denom)
+
+
+def render(case_id: str, panels: list[tuple[str, np.ndarray]], out_png: Path) -> None:
+    """Render one row of three-plane MIPs per run."""
+    nrows = len(panels)
+    fig, axes = plt.subplots(nrows, 3, figsize=(13, 4.3 * nrows), squeeze=False)
+    for r, (label, vol) in enumerate(panels):
+        for c, (plane, img) in enumerate(zip(PLANE_NAMES, mips(vol), strict=True)):
+            ax = axes[r][c]
+            ax.imshow(img.T, cmap="magma", origin="lower", vmin=0, vmax=1)
+            ax.set_title(f"{label}\n{plane}", fontsize=9)
+            ax.set_xticks([])
+            ax.set_yticks([])
+        axes[r][0].set_ylabel(label, fontsize=9)
+    n_vox = " | ".join(
+        f"{lab}: {(v > VESSEL_THRESHOLD).sum():,} vessel vox" for lab, v in panels
+    )
+    fig.suptitle(f"{case_id}\n{n_vox}", fontsize=10)
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_png, dpi=110)
+    plt.close(fig)
+
+
+def main() -> None:
+    """Render MIP panels for one or two runs, and compare them on matched phases."""
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run-a", required=True, help="vessel-segmentation output dir")
+    p.add_argument("--label-a", default="run A")
+    p.add_argument("--run-b", default=None, help="optional second run, compared to A")
+    p.add_argument("--label-b", default="run B")
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--phase-mode", choices=("time-max", "richest"), default="time-max")
+    args = p.parse_args()
+
+    run_a, out_dir = Path(args.run_a), Path(args.out_dir)
+    run_b = Path(args.run_b) if args.run_b else None
+    cases_a = find_cases(run_a)
+    if not cases_a:
+        raise SystemExit(f"no vessel output found under {run_a}")
+    cases_b = find_cases(run_b) if run_b else {}
+
+    if run_b:
+        only_a, only_b = set(cases_a) - set(cases_b), set(cases_b) - set(cases_a)
+        if only_a or only_b:
+            print(
+                f"[warn] cases not in both runs -- only A: {sorted(only_a)}; only B: {sorted(only_b)}"
+            )
+
+    rows: list[dict[str, object]] = []
+    for case_id in sorted(set(cases_a) & set(cases_b)) if run_b else sorted(cases_a):
+        panels: list[tuple[str, np.ndarray]] = []
+
+        if args.phase_mode == "time-max":
+            vol_a = time_max(cases_a[case_id])
+            panels.append((f"{args.label_a} (time-max)", vol_a))
+            vol_b = None
+            if run_b:
+                vol_b = time_max(cases_b[case_id])
+                panels.append((f"{args.label_b} (time-max)", vol_b))
+            phase_note = "time-max over all phases"
+        else:
+            ph_a = load_phases(cases_a[case_id])
+            ph_b = load_phases(cases_b[case_id]) if run_b else {}
+            shared = sorted(set(ph_a) & set(ph_b)) if run_b else sorted(ph_a)
+
+            # richest by COMBINED content, so both runs are read on the SAME phase
+            def content(
+                ph: int,
+                ph_a: dict[int, Path] = ph_a,
+                ph_b: dict[int, Path] = ph_b,
+            ) -> int:
+                tot = (load_vessel(ph_a[ph]) > VESSEL_THRESHOLD).sum()
+                if ph_b:
+                    tot += (load_vessel(ph_b[ph]) > VESSEL_THRESHOLD).sum()
+                return int(tot)
+
+            best = max(shared, key=content)
+            vol_a = load_vessel(ph_a[best])
+            panels.append((f"{args.label_a} (phase {best:04d})", vol_a))
+            vol_b = load_vessel(ph_b[best]) if run_b else None
+            if vol_b is not None:
+                panels.append((f"{args.label_b} (phase {best:04d})", vol_b))
+            phase_note = f"matched phase {best:04d}"
+
+        render(case_id, panels, out_dir / f"{case_id}.png")
+
+        row: dict[str, object] = {
+            "case_id": case_id,
+            "phase_mode": phase_note,
+            f"vessel_voxels_{args.label_a.replace(' ', '_')}": int(
+                (vol_a > VESSEL_THRESHOLD).sum()
+            ),
+        }
+        if vol_b is not None:
+            row[f"vessel_voxels_{args.label_b.replace(' ', '_')}"] = int(
+                (vol_b > VESSEL_THRESHOLD).sum()
+            )
+            row["dice_a_vs_b"] = round(dice(vol_a, vol_b), 4)
+        rows.append(row)
+        print(f"  {case_id[:34]:36s} {row}")
+
+    out_csv = out_dir / "summary.csv"
+    with out_csv.open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        w.writeheader()
+        w.writerows(rows)
+    print(f"\nwrote {len(rows)} panels + {out_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data_viz/uchicago_skeleton_interactive.py
+++ b/data_viz/uchicago_skeleton_interactive.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""UChicago vessel QC -- interactive 3D HTML, one file per case.
+
+Counterpart to ``interactive_annotation_htmls/duke_qc_interactive.py``, but
+UChicago has NO radiologist annotations, so the annotation layers (green/orange/
+red distance bands) are replaced by the 3D SKELETON (centerline) of the vessel
+segmentation.
+
+Layers (toggle via legend click; quick-view buttons combine them):
+  * centerline / skeleton, REAL breast mask run   (cyan)   -- the main object
+  * vessel segmentation,   REAL breast mask run   (blue)   -- filled mask, subsampled
+  * centerline / skeleton, MODEL breast mask run  (orange) -- baseline, for comparison
+  * whole-breast mask (real, BreastDivider)       (gray)   -- faint anatomical context
+
+The baseline-skeleton layer is included deliberately: after the external-mask
+run, the open question was "why do the vessel MIPs look sparse?", and seeing the
+two centerline trees in the same 3D scene shows directly where the real breast
+mask recovers vessels the model mask missed.
+
+Skeletonization reuses the pipeline's own routine (``graph_extraction.skeleton3d.
+skeletonize3d`` on an EDT priority, exactly as ``graph_extraction/tc4d.py``'s
+``_skeletonize_support_mask`` does), so these centerlines are computed the same
+way the real graph stage would compute them -- NOT a different ad-hoc thinning.
+(The graph stage itself can't run on UChicago yet: its discovery seam,
+``graph_extraction/core4d.py:111``, rejects the pipeline's own UChicago output
+filenames -- a separate pre-existing bug.)
+
+Vessel probability is combined across ALL phases (voxelwise max over time) before
+thresholding, so the scene shows the full vessel tree rather than one timepoint.
+UChicago is 1 mm isotropic, so voxel indices == mm.
+
+Self-contained HTML (plotly.js embedded); renders in the browser, no server.
+
+Usage (from the repo root, `micromamba activate vanguard`):
+
+    # every case that has external-mask segmentation output
+    python data_viz/uchicago_skeleton_interactive.py
+
+    # only one sub-source, or only specific exams
+    python data_viz/uchicago_skeleton_interactive.py --sub-source simbiosys uch_nac
+    python data_viz/uchicago_skeleton_interactive.py --case-ids simbiosys_1_3_118...
+
+Input dirs come from the segmentation runs and are overridable by flag, so this
+is re-runnable against any pair of (external, baseline) output roots.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+import traceback
+from pathlib import Path
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+from scipy import ndimage  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from graph_extraction.skeleton3d import skeletonize3d  # noqa: E402
+
+DEFAULT_EXTERNAL_DIR = Path(
+    "/ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke_external_breast"
+)
+DEFAULT_BASELINE_DIR = Path(
+    "/ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke_v2"
+)
+DEFAULT_BREAST_DIR = Path(
+    "/ess/scratch/scratch1/t-9sbose/uchicago_breast_masks_external"
+)
+DEFAULT_OUT_DIR = Path(
+    "/gpfs/data/karczmar-lab/workspaces/saritbose/outputs/interactive_annotation_htmls"
+)
+DEFAULT_MANIFEST = Path(
+    "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
+    "dce2d_internal_ultrafast_manifest_with_whole_breast_masks.csv"
+)
+
+VESSEL_PROB_THRESH = 0.5
+BREAST_PROB_THRESH = 0.5
+
+# Keep the browser scene light: cap points per layer (stats use the FULL data).
+CAP_SKEL = 60000
+CAP_SEG = 60000
+CAP_BREAST = 25000
+
+C_SKEL_EXT = "#00d0d0"  # cyan  : centerline, real-breast-mask run
+C_SEG_EXT = "#5aa0e6"  # blue  : segmentation, real-breast-mask run
+C_SKEL_BASE = "#f39c12"  # orange: centerline, model-breast-mask baseline
+C_BREAST = "#9aa4ad"  # gray  : whole-breast context
+
+
+def _sub(a: np.ndarray, cap: int, seed: int = 0) -> np.ndarray:
+    """Randomly subsample rows of an (N,3) array down to ``cap`` (display only)."""
+    if len(a) <= cap:
+        return a
+    idx = np.random.default_rng(seed).choice(len(a), cap, replace=False)
+    return a[idx]
+
+
+def combined_vessel_prob(
+    seg_dir: Path, case_id: str, sub_source: str
+) -> tuple[np.ndarray | None, int]:
+    """Voxelwise max vessel probability across every phase (the full vessel tree).
+
+    Returns ``(combined, n_phases)``; ``(None, 0)`` when the case has no output.
+    The phase count is returned rather than assumed: UChicago exams are 13 OR 24
+    phases depending on the exam, and an earlier version of this script hardcoded
+    "24 phases" into the subtitle, which mislabels every 13-phase exam.
+    """
+    mask_dir = seg_dir / sub_source / case_id / "images"
+    paths = sorted(mask_dir.glob(f"{case_id}_phase_*_vessel_segmentation.npz"))
+    if not paths:
+        return None, 0
+    combined: np.ndarray | None = None
+    for p in paths:
+        v = np.load(p)["vessel"].astype(np.float32)
+        combined = v if combined is None else np.maximum(combined, v)
+    return combined, len(paths)
+
+
+def skeletonize_mask(binary: np.ndarray) -> np.ndarray:
+    """Pipeline-identical centerline: EDT priority -> topology-preserving thinning."""
+    if not np.any(binary):
+        return np.zeros_like(binary, dtype=bool)
+    priority = ndimage.distance_transform_edt(binary).astype(np.float32, copy=False)
+    return skeletonize3d(priority, threshold=0.0) > 0
+
+
+def load_breast_mask(breast_dir: Path, case_id: str) -> np.ndarray | None:
+    """Load the persisted external whole-breast mask for a case (any phase; all equal).
+
+    The manifest ships ONE mask per exam (from phase 0), fanned out across phases
+    by the segmentation run, so the first phase file found is representative.
+    """
+    for path in sorted(breast_dir.glob(f"{case_id}_phase_*.npy")):
+        return np.load(path) > BREAST_PROB_THRESH
+    return None
+
+
+def build(
+    case_id: str,
+    sub_source: str,
+    external_dir: Path,
+    baseline_dir: Path,
+    breast_dir: Path,
+    out_dir: Path,
+) -> None:
+    """Render one case's interactive 3D scene to ``<out_dir>/<case>_..._interactive.html``."""
+    ext_prob, n_phases = combined_vessel_prob(external_dir, case_id, sub_source)
+    if ext_prob is None:
+        print(f"  [skip] {case_id}: no external vessel output")
+        return
+    ext_seg = ext_prob > VESSEL_PROB_THRESH
+    ext_skel = skeletonize_mask(ext_seg)
+
+    base_prob, _ = combined_vessel_prob(baseline_dir, case_id, sub_source)
+    base_skel = None
+    if base_prob is not None and base_prob.shape == ext_prob.shape:
+        base_skel = skeletonize_mask(base_prob > VESSEL_PROB_THRESH)
+
+    breast = load_breast_mask(breast_dir, case_id)
+
+    ext_seg_pts = np.argwhere(ext_seg).astype(np.float32)
+    ext_skel_pts = np.argwhere(ext_skel).astype(np.float32)
+    base_skel_pts = (
+        np.argwhere(base_skel).astype(np.float32)
+        if base_skel is not None
+        else np.empty((0, 3))
+    )
+    breast_pts = (
+        np.argwhere(breast).astype(np.float32)
+        if breast is not None
+        else np.empty((0, 3))
+    )
+
+    def scatter(pts, color, name, size, opacity, cap, visible=True):  # noqa: ANN001, ANN202
+        p = _sub(pts, cap)
+        return go.Scatter3d(
+            x=p[:, 0] if len(p) else [],
+            y=p[:, 1] if len(p) else [],
+            z=p[:, 2] if len(p) else [],
+            mode="markers",
+            marker={"size": size, "color": color, "opacity": opacity},
+            name=name,
+            visible=visible,
+        )
+
+    t_skel_ext = scatter(
+        ext_skel_pts,
+        C_SKEL_EXT,
+        f"centerline — REAL breast mask (n={len(ext_skel_pts)})",
+        2,
+        0.9,
+        CAP_SKEL,
+    )
+    t_seg_ext = scatter(
+        ext_seg_pts,
+        C_SEG_EXT,
+        f"segmentation — REAL breast mask (n={len(ext_seg_pts)}, subsampled)",
+        1.5,
+        0.25,
+        CAP_SEG,
+        visible="legendonly",
+    )
+    t_skel_base = scatter(
+        base_skel_pts,
+        C_SKEL_BASE,
+        f"centerline — MODEL breast mask baseline (n={len(base_skel_pts)})",
+        2,
+        0.8,
+        CAP_SKEL,
+        visible="legendonly",
+    )
+    t_breast = scatter(
+        breast_pts,
+        C_BREAST,
+        f"whole-breast mask (real, context; n={len(breast_pts)}, subsampled)",
+        1.5,
+        0.06,
+        CAP_BREAST,
+        visible="legendonly",
+    )
+
+    traces = [t_skel_ext, t_seg_ext, t_skel_base, t_breast]
+    #          0           1          2            3
+    fig = go.Figure(data=traces)
+
+    def vis(show: set[int]) -> list[bool | str]:
+        return [(True if i in show else "legendonly") for i in range(4)]
+
+    buttons = [
+        {
+            "label": "Centerline only (real mask)",
+            "method": "update",
+            "args": [{"visible": vis({0})}],
+        },
+        {
+            "label": "Centerline + segmentation",
+            "method": "update",
+            "args": [{"visible": vis({0, 1})}],
+        },
+        {
+            "label": "REAL vs MODEL centerline",
+            "method": "update",
+            "args": [{"visible": vis({0, 2})}],
+        },
+        {
+            "label": "Centerline + breast context",
+            "method": "update",
+            "args": [{"visible": vis({0, 3})}],
+        },
+        {
+            "label": "All layers",
+            "method": "update",
+            "args": [{"visible": [True, True, True, True]}],
+        },
+    ]
+
+    n_ext, n_base = len(ext_skel_pts), len(base_skel_pts)
+    gain = (
+        f"{n_ext / n_base:.1f}x more centerline voxels than the model-mask baseline"
+        if n_base
+        else "no baseline centerline"
+    )
+    subtitle = (
+        f"vessel coverage={ext_seg.mean() * 100:.4f}% of volume · "
+        f"centerline voxels: real-mask={n_ext} vs model-mask={n_base} ({gain}) · "
+        f"all {n_phases} phases combined (max over time), "
+        f"thr={VESSEL_PROB_THRESH} · 1 mm isotropic"
+    )
+
+    fig.update_layout(
+        title={
+            "text": (
+                f"<b>{case_id}</b> ({sub_source}) — 3D vessel centerline, "
+                f"real vs model breast mask"
+                f"<br><span style='font-size:12px'>{subtitle}</span>"
+            ),
+            "x": 0.02,
+        },
+        scene={
+            "aspectmode": "data",
+            "xaxis_title": "x (mm)",
+            "yaxis_title": "y (mm)",
+            "zaxis_title": "z (mm)",
+            "bgcolor": "#0e1117",
+        },
+        paper_bgcolor="#0e1117",
+        font={"color": "#e6edf3"},
+        legend={"itemsizing": "constant", "x": 0.0, "y": -0.02, "orientation": "h"},
+        updatemenus=[
+            {
+                "type": "buttons",
+                "direction": "down",
+                "x": 1.02,
+                "y": 1.0,
+                "xanchor": "left",
+                "showactive": True,
+                "buttons": buttons,
+            }
+        ],
+        margin={"l": 0, "r": 0, "t": 80, "b": 0},
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out = out_dir / f"{case_id}_uchicago_skeleton_interactive.html"
+    fig.write_html(out, include_plotlyjs=True, full_html=True)
+    print(f"  [ok] {case_id}: skeleton={n_ext} (baseline={n_base}) -> {out}")
+
+
+def select_cases(
+    manifest: Path,
+    external_dir: Path,
+    sub_sources: list[str] | None,
+    case_ids: list[str] | None,
+) -> list[tuple[str, str]]:
+    """Pick (case_id, sub_source) pairs to render, in manifest order.
+
+    A case is renderable only if the external-mask run actually produced output
+    for it, so this never silently emits an empty scene for an exam that was
+    never segmented. Explicit ``case_ids`` are fail-closed: one that has no
+    output raises, rather than quietly rendering fewer HTMLs than asked for.
+    """
+    with manifest.open(newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    has_output = {
+        row["exam_id"]: row["dataset"]
+        for row in rows
+        if (external_dir / row["dataset"] / row["exam_id"]).is_dir()
+    }
+
+    if case_ids:
+        missing = [c for c in case_ids if c not in has_output]
+        if missing:
+            raise SystemExit(
+                f"No segmentation output under {external_dir} for {len(missing)} "
+                f"requested case(s): {missing}"
+            )
+        wanted = set(case_ids)
+    elif sub_sources:
+        wanted = {c for c, sub in has_output.items() if sub in set(sub_sources)}
+        if not wanted:
+            raise SystemExit(
+                f"No segmented cases under {external_dir} for sub-source(s) {sub_sources}"
+            )
+    else:
+        wanted = set(has_output)
+
+    return [
+        (row["exam_id"], row["dataset"]) for row in rows if row["exam_id"] in wanted
+    ]
+
+
+def main() -> None:
+    """Run the interactive-HTML CLI."""
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--case-ids",
+        nargs="+",
+        default=None,
+        help="Render exactly these exam ids (default: every case with output).",
+    )
+    p.add_argument(
+        "--sub-source",
+        nargs="+",
+        default=None,
+        dest="sub_sources",
+        help="Render only these manifest sub-sources: simbiosys|uch_nac|her2_naclike.",
+    )
+    p.add_argument("--external-dir", type=Path, default=DEFAULT_EXTERNAL_DIR)
+    p.add_argument("--baseline-dir", type=Path, default=DEFAULT_BASELINE_DIR)
+    p.add_argument("--breast-dir", type=Path, default=DEFAULT_BREAST_DIR)
+    p.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    args = p.parse_args()
+
+    cases = select_cases(
+        args.manifest, args.external_dir, args.sub_sources, args.case_ids
+    )
+    print(
+        f"Building interactive 3D skeleton HTML for {len(cases)} case(s) -> {args.out_dir}"
+    )
+
+    failed = []
+    for cid, sub in cases:
+        print(f"[+] {cid} ({sub})", flush=True)
+        try:
+            build(
+                cid,
+                sub,
+                args.external_dir,
+                args.baseline_dir,
+                args.breast_dir,
+                args.out_dir,
+            )
+        except Exception as e:  # noqa: BLE001
+            traceback.print_exc()
+            print(f"  [FAILED] {cid}: {e}", flush=True)
+            failed.append(cid)
+
+    print(
+        f"\n[done] {len(cases) - len(failed)}/{len(cases)} rendered -> {args.out_dir}"
+    )
+    if failed:
+        raise SystemExit(f"{len(failed)} case(s) failed: {failed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation/evaluator.py
+++ b/evaluation/evaluator.py
@@ -39,8 +39,18 @@ from evaluation.visualizations import (
 STRATUM_COLUMN_ALIASES = ("stratum", "subtype")
 
 
-def _stratum_column(predictions: pd.DataFrame) -> str | None:
-    """Return the first stratum column name present in predictions, or None."""
+def _stratum_column(
+    predictions: pd.DataFrame, report_by: str | None = None
+) -> str | None:
+    """Return the column to break QC metrics down by, or None.
+
+    ``report_by`` (a dataset adapter's ``report_by``, e.g. UChicago's ``dataset``
+    sub-source) takes precedence when present in ``predictions`` (Step 4 of the
+    multi-dataset migration, see cohorts/README.md). When it is ``None`` -- every
+    caller today -- selection is byte-for-byte the old alias behavior.
+    """
+    if report_by is not None and report_by in predictions.columns:
+        return report_by
     for col in STRATUM_COLUMN_ALIASES:
         if col in predictions.columns:
             return col
@@ -352,6 +362,7 @@ class Evaluator:
         run_name: str | None = None,
         random_baseline_distribution: dict | None = None,
         run_aucs: list[float] | None = None,
+        report_by: str | None = None,
     ) -> None:
         """Save results to output directory, organized by model name and run name.
 
@@ -470,7 +481,7 @@ class Evaluator:
                 metrics_dict["run_auc_std"] = float(np.std(arr))
 
         # Subgroup (stratum) metrics: compute, add to dict, and print summary
-        stratum_col = _stratum_column(results.predictions)
+        stratum_col = _stratum_column(results.predictions, report_by=report_by)
         if stratum_col is not None:
             validation_summary = compute_metrics_by_group(
                 results.predictions, stratum_col

--- a/graph_extraction/pipeline.py
+++ b/graph_extraction/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -23,6 +24,9 @@ from graph_extraction.masks import (
 from graph_extraction.tc4d import run_tc4d_from_priority
 from graph_extraction.vessel_mip import render_vessel_coverage_mip
 
+if TYPE_CHECKING:
+    from cohorts.base import DatasetAdapter
+
 
 def run_study_pipeline(
     *,
@@ -39,6 +43,7 @@ def run_study_pipeline(
     mip_dpi: int,
     radiologist_annotations_dir: Path,
     tumor_mask_dir: Path,
+    adapter: DatasetAdapter | None = None,
 ) -> dict[str, object]:
     """Run the full graph-extraction workflow for one study.
 
@@ -55,9 +60,20 @@ def run_study_pipeline(
     The returned dictionary is the study-level run summary written to
     `run_summary.json`. It records which stages ran, how long they took,
     whether quality checks passed, and where the main outputs were written.
+
+    ``adapter`` is optional (Step 4 of the multi-dataset migration, see
+    cohorts/README.md): when given, per-timepoint segmentation discovery routes
+    through ``adapter.load_segmented_timepoints()`` and the MIP-only flip spec
+    through ``adapter.viz_flip_spec``, instead of the hardcoded MAMA-MIA
+    function/constant. When ``None`` (every caller today), behavior is
+    byte-for-byte unchanged.
     """
     start = time.perf_counter()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    viz_flip_spec = (
+        adapter.viz_flip_spec if adapter is not None else PROCESSING_VIZ_FLIP_SPEC
+    )
 
     skeleton_path = output_dir / f"{case_id}_skeleton_4d_exam_mask.npy"
     support_path = output_dir / f"{case_id}_skeleton_4d_exam_support_mask.npy"
@@ -102,10 +118,16 @@ def run_study_pipeline(
         skeleton_status = "loaded_existing"
     else:
         t0 = time.perf_counter()
-        discovered_files, discovered_timepoints = discover_study_timepoints(
-            input_dir=input_dir,
-            case_id=case_id,
-        )
+        if adapter is not None:
+            discovered_files, discovered_timepoints = adapter.load_segmented_timepoints(
+                input_dir=input_dir,
+                case_id=case_id,
+            )
+        else:
+            discovered_files, discovered_timepoints = discover_study_timepoints(
+                input_dir=input_dir,
+                case_id=case_id,
+            )
         priority_4d = load_time_series_from_files(
             discovered_files,
         )
@@ -186,10 +208,16 @@ def run_study_pipeline(
                 }
             else:
                 try:
-                    k_files, k_timepoints = discover_study_timepoints(
-                        input_dir=input_dir,
-                        case_id=case_id,
-                    )
+                    if adapter is not None:
+                        k_files, k_timepoints = adapter.load_segmented_timepoints(
+                            input_dir=input_dir,
+                            case_id=case_id,
+                        )
+                    else:
+                        k_files, k_timepoints = discover_study_timepoints(
+                            input_dir=input_dir,
+                            case_id=case_id,
+                        )
                     kinetic_priority_4d = load_time_series_from_files(k_files)
                     kinetic_timepoints = list(k_timepoints)
                     if discovered_files is None:
@@ -267,11 +295,11 @@ def run_study_pipeline(
                 )
                 radiologist_mask_viz = _apply_flip_spec(
                     radiologist_mask_model,
-                    PROCESSING_VIZ_FLIP_SPEC,
+                    viz_flip_spec,
                 )
                 breast_mask_viz = _apply_flip_spec(
                     breast_mask_model,
-                    PROCESSING_VIZ_FLIP_SPEC,
+                    viz_flip_spec,
                 )
 
             tumor_mask_viz: np.ndarray | None = None
@@ -289,14 +317,14 @@ def run_study_pipeline(
             if tumor_mask_model is not None:
                 tumor_mask_viz = _apply_flip_spec(
                     tumor_mask_model,
-                    PROCESSING_VIZ_FLIP_SPEC,
+                    viz_flip_spec,
                 )
 
             method_label = "tc4d"
             row_masks: list[tuple[str, np.ndarray]] = [
                 (
                     method_label,
-                    _apply_flip_spec(skeleton_mask, PROCESSING_VIZ_FLIP_SPEC),
+                    _apply_flip_spec(skeleton_mask, viz_flip_spec),
                 )
             ]
             if radiologist_mask_viz is not None:
@@ -322,7 +350,7 @@ def run_study_pipeline(
                 **coverage_mip_diag,
                 "radiologist_context": radiologist_context_for_summary,
                 "tumor_context": tumor_context_for_summary,
-                "visualization_flip_spec": PROCESSING_VIZ_FLIP_SPEC,
+                "visualization_flip_spec": viz_flip_spec,
             }
             mip_status = "computed"
         except Exception as exc:

--- a/graph_extraction/run_skeleton_processing.py
+++ b/graph_extraction/run_skeleton_processing.py
@@ -103,6 +103,29 @@ def build_parser() -> argparse.ArgumentParser:
             "(expected `<case-id>.nii.gz`)."
         ),
     )
+    parser.add_argument(
+        "--dataset-name",
+        type=str,
+        default=None,
+        help=(
+            "If set (mamamia|uchicago), build a DatasetAdapter via "
+            "cohorts.factory and route per-timepoint segmentation discovery "
+            "and the MIP-only flip spec through it (Step 4), instead of the "
+            "hardcoded MAMA-MIA function/constant."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-root",
+        type=str,
+        default=None,
+        help="Root path for --dataset-name (e.g. the UChicago manifest directory).",
+    )
+    parser.add_argument(
+        "--dataset-cohort",
+        type=str,
+        default=None,
+        help="mamamia only: duke|ispy1|ispy2|nact.",
+    )
 
     return parser
 
@@ -114,6 +137,26 @@ def main() -> None:
     if args.features_only and args.force_skeleton:
         parser.error("`--features-only` cannot be combined with `--force-skeleton`.")
     from graph_extraction.pipeline import run_study_pipeline
+
+    adapter = None
+    if args.dataset_name:
+        from cohorts.factory import build_adapter_from_config
+        from config import ConfigNode
+
+        if not args.dataset_root:
+            parser.error("--dataset-root is required when --dataset-name is set.")
+        dataset_config = ConfigNode._wrap(
+            {
+                "dataset": {
+                    "name": args.dataset_name,
+                    "cohort": args.dataset_cohort,
+                    "root": args.dataset_root,
+                    "split_policy": "auto",
+                }
+            }
+        )
+        adapter = build_adapter_from_config(dataset_config)
+        print(f"Using dataset adapter: {type(adapter).__name__}")
 
     start = time.perf_counter()
     result = run_study_pipeline(
@@ -130,6 +173,7 @@ def main() -> None:
         mip_dpi=args.mip_dpi,
         radiologist_annotations_dir=args.radiologist_annotations_dir,
         tumor_mask_dir=args.tumor_mask_dir,
+        adapter=adapter,
     )
 
     args.output_dir.mkdir(parents=True, exist_ok=True)

--- a/graph_extraction/slurm/submit_uchicago_skeleton_smoke.sh
+++ b/graph_extraction/slurm/submit_uchicago_skeleton_smoke.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Step 4d smoke test: run skeletonization/graph extraction for the same 5
+# UChicago patients the segmentation smoke job processes (Step 4d commit),
+# via the newly-wired --dataset-name uchicago adapter path.
+#
+# Deliberately NOT using submit_tc4d_array.sh/.slurm: that script passes
+# --study-id, a flag that does not exist on run_skeleton_processing.py's CLI
+# (only --case-id does) -- pre-existing drift, unrelated to this work, left
+# alone rather than silently "fixed" as a side effect of an unrelated change.
+#
+# KNOWN, ACCEPTED RISK: see submit_uchicago_segmentation_smoke.slurm --
+# UChicagoDataset.preprocess()'s orientation assumption is unverified.
+#
+# Usage (from repo root, after the segmentation smoke job has completed):
+#   SEG_OUTPUT_DIR=/ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke \
+#     ./graph_extraction/slurm/submit_uchicago_skeleton_smoke.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+UCHICAGO_ROOT="${UCHICAGO_ROOT:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest}"
+SEG_OUTPUT_DIR="${SEG_OUTPUT_DIR:?SEG_OUTPUT_DIR must be set to the segmentation smoke jobs --output-dir}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-/ess/scratch/scratch1/t-9sbose/uchicago_centerlines_smoke}"
+PATIENT_LIMIT="${PATIENT_LIMIT:-5}"
+PARTITION="${PARTITION:-general}"
+
+mkdir -p "${REPO_ROOT}/logs" "${OUTPUT_ROOT}"
+CASE_LIST="$(mktemp "${REPO_ROOT}/logs/uc-skeleton-cases.XXXXXX.txt")"
+
+# Same discovery the segmentation job used (UChicagoDataset.discover_cases()
+# is deterministic given a fixed manifest), so both stages agree on the exact
+# same 5 patients without hardcoding fragile exam ids. Also records each
+# case's sub-source, because build_output_path writes segmentation output
+# under SEG_OUTPUT_DIR/<sub_source>/<case_id>/images/ -- the graph stage's
+# --input-dir must be sub-source-qualified to find it.
+PYTHONPATH="${REPO_ROOT}" python - "${UCHICAGO_ROOT}" "${PATIENT_LIMIT}" <<'PY' > "${CASE_LIST}"
+import sys
+from pathlib import Path
+from cohorts.uchicago import UChicagoDataset
+
+root, limit = Path(sys.argv[1]), int(sys.argv[2])
+adapter = UChicagoDataset(root=root)
+for case_id in adapter.discover_cases()[:limit]:
+    print(f"{case_id},{adapter.case_dataset_name(case_id)}")
+PY
+
+if [[ ! -s "${CASE_LIST}" ]]; then
+  echo "No cases discovered under ${UCHICAGO_ROOT}" >&2
+  exit 1
+fi
+
+TASK_COUNT="$(wc -l < "${CASE_LIST}")"
+ARRAY_SPEC="0-$((TASK_COUNT - 1))"
+
+JOB_ID="$({
+  sbatch --parsable \
+    --partition="${PARTITION}" \
+    --array="${ARRAY_SPEC}" \
+    --export=ALL,REPO_ROOT="${REPO_ROOT}",UCHICAGO_ROOT="${UCHICAGO_ROOT}",SEG_OUTPUT_DIR="${SEG_OUTPUT_DIR}",OUTPUT_ROOT="${OUTPUT_ROOT}",CASE_LIST="${CASE_LIST}" \
+    "${SCRIPT_DIR}/submit_uchicago_skeleton_smoke.slurm"
+} )"
+
+cat <<MSG
+Submitted UChicago skeletonization smoke array job:
+  seg_output_dir: ${SEG_OUTPUT_DIR}
+  output_root   : ${OUTPUT_ROOT}
+  case_list     : ${CASE_LIST}
+  task_count    : ${TASK_COUNT}
+  job_id        : ${JOB_ID}
+
+Monitor:
+  squeue -j ${JOB_ID}
+  sacct -j ${JOB_ID} --format=JobIDRaw,State,Elapsed,ExitCode -n -P
+MSG

--- a/graph_extraction/slurm/submit_uchicago_skeleton_smoke.sh
+++ b/graph_extraction/slurm/submit_uchicago_skeleton_smoke.sh
@@ -23,7 +23,9 @@ UCHICAGO_ROOT="${UCHICAGO_ROOT:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_
 SEG_OUTPUT_DIR="${SEG_OUTPUT_DIR:?SEG_OUTPUT_DIR must be set to the segmentation smoke jobs --output-dir}"
 OUTPUT_ROOT="${OUTPUT_ROOT:-/ess/scratch/scratch1/t-9sbose/uchicago_centerlines_smoke}"
 PATIENT_LIMIT="${PATIENT_LIMIT:-5}"
-PARTITION="${PARTITION:-general}"
+# `general` does not exist on this cluster; `tier1q` is the confirmed
+# replacement (see gnn/slurm/submit_gnn_build.slurm).
+PARTITION="${PARTITION:-tier1q}"
 
 mkdir -p "${REPO_ROOT}/logs" "${OUTPUT_ROOT}"
 CASE_LIST="$(mktemp "${REPO_ROOT}/logs/uc-skeleton-cases.XXXXXX.txt")"

--- a/graph_extraction/slurm/submit_uchicago_skeleton_smoke.slurm
+++ b/graph_extraction/slurm/submit_uchicago_skeleton_smoke.slurm
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uc-skel-smoke
+#SBATCH --partition=general
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/uc-skel-smoke-%A-%a.out
+#SBATCH --error=logs/uc-skel-smoke-%A-%a.err
+
+set -euo pipefail
+
+cd "${REPO_ROOT}"
+source ~/.bashrc || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+
+LINE_NO=$((SLURM_ARRAY_TASK_ID + 1))
+LINE="$(sed -n "${LINE_NO}p" "${CASE_LIST}")"
+CASE_ID="${LINE%%,*}"
+SUB_SOURCE="${LINE##*,}"
+INPUT_DIR="${SEG_OUTPUT_DIR}/${SUB_SOURCE}"
+OUTPUT_DIR="${OUTPUT_ROOT}/${SUB_SOURCE}/${CASE_ID}"
+
+echo "Case: ${CASE_ID}  sub_source: ${SUB_SOURCE}"
+echo "Input dir: ${INPUT_DIR}"
+echo "Output dir: ${OUTPUT_DIR}"
+
+python graph_extraction/run_skeleton_processing.py \
+  --case-id "${CASE_ID}" \
+  --input-dir "${INPUT_DIR}" \
+  --output-dir "${OUTPUT_DIR}" \
+  --dataset-name uchicago \
+  --dataset-root "${UCHICAGO_ROOT}"

--- a/graph_extraction/slurm/submit_uchicago_skeleton_smoke.slurm
+++ b/graph_extraction/slurm/submit_uchicago_skeleton_smoke.slurm
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 #SBATCH --job-name=uc-skel-smoke
-#SBATCH --partition=general
+#SBATCH --partition=tier1q
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=32G
 #SBATCH --time=02:00:00
 #SBATCH --output=logs/uc-skel-smoke-%A-%a.out
 #SBATCH --error=logs/uc-skel-smoke-%A-%a.err
 
-set -euo pipefail
+# `general` does not exist on this cluster (see gnn/slurm/submit_gnn_build.slurm);
+# `tier1q` is the confirmed replacement. `-u` (nounset) is deliberately not set
+# (matching segmentation/slurm/submit_uchicago_segmentation_smoke.slurm's
+# `set -eo pipefail`) -- it tripped on an unset variable inside the system
+# /etc/bashrc during `source ~/.bashrc || true`, aborting every array task
+# before it reached any of this script's own work (all 5 tasks of job 12844891
+# failed in ~2s with only a bashrc stderr line and no other output).
+set -eo pipefail
 
 cd "${REPO_ROOT}"
 source ~/.bashrc || true

--- a/scripts/build_uchicago_spgr_root.py
+++ b/scripts/build_uchicago_spgr_root.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Materialize a UChicago dataset root from the RECOMMENDED motion-corrected data.
+
+We have been segmenting the **legacy** image contract
+(``dce2d_internal_ultrafast_manifest.csv``), which the dataset's own README says to
+use "only when reproducing the legacy clipped, robust-z-score image baseline". Two
+consequences, both bad for vessel segmentation:
+
+1. **Double normalization.** The legacy phase files are already clipped and robust
+   z-scored (verified: min -3.14, mean 2.80 -- raw MRI signal is nonnegative), and
+   then ``segmentation/batch_segmentation.py:preprocess_image`` applies
+   ``zscore_image(normalize_image(...))`` on top. Normalizing twice can only
+   compress vessel-to-background contrast, which is the signal the model keys on.
+2. **No motion correction.** Our runs have none; a QC-gated motion-corrected export
+   exists, and it also makes the single phase-0 whole-breast mask valid for every
+   phase (all frames are registered to phase 0), retiring the "one mask reused
+   across phases" approximation.
+
+This script writes a new root in the layout ``UChicagoDataset`` already expects --
+``images/<dataset>/<exam_id>/phase_XXXX.nii.gz`` plus a manifest CSV with the legacy
+schema -- so the adapter can be pointed at it via ``dataset_root`` with **zero code
+change**. That is exactly what the run-config-injected root is for (cohorts/README.md).
+
+Sources (per the dataset README, "Which Image Contract To Use"):
+    manifest : spgr_safe_motion_corrected/manifest_recommended_180.csv
+    images   : spgr_safe_motion_corrected/shards/<NNNN>_<exam_id>/phase_images.tar
+               (raw signal, float32, nonnegative, 1 mm isotropic, every acquired frame)
+
+Run:
+    python scripts/build_uchicago_spgr_root.py --out-root <dir> --case-ids <file>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tarfile
+from pathlib import Path
+
+import pandas as pd
+
+SRC = Path("/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest")
+MC = SRC / "spgr_safe_motion_corrected"
+RECOMMENDED = MC / "manifest_recommended_180.csv"
+LEGACY = SRC / "dce2d_internal_ultrafast_manifest.csv"
+MANIFEST_NAME = (
+    "dce2d_internal_ultrafast_manifest.csv"  # cohorts.uchicago.DEFAULT_MANIFEST_NAME
+)
+
+
+def parse_case_ids(value: str | None) -> list[str] | None:
+    """Resolve a comma-separated list or a file of ids (one per line, # = comment)."""
+    if value is None:
+        return None
+    path = Path(value)
+    raw = path.read_text().splitlines() if path.is_file() else value.split(",")
+    ids = [s.strip() for s in raw]
+    ids = [s for s in ids if s and not s.startswith("#")]
+    if not ids:
+        raise SystemExit(f"--case-ids resolved to an empty selection: {value!r}")
+    return ids
+
+
+def shard_for(exam_id: str) -> Path:
+    """Locate the per-exam shard directory (prefixed with its row index)."""
+    hits = sorted(MC.glob(f"shards/*_{exam_id}"))
+    if len(hits) != 1:
+        raise SystemExit(f"expected exactly 1 shard for {exam_id}, found {len(hits)}")
+    return hits[0]
+
+
+def main() -> None:
+    """Extract the recommended motion-corrected frames into an adapter-ready root."""
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out-root", required=True)
+    p.add_argument(
+        "--case-ids", default=None, help="file or comma list; default = all 180"
+    )
+    args = p.parse_args()
+
+    out = Path(args.out_root)
+    (out / "images").mkdir(parents=True, exist_ok=True)
+
+    rec = pd.read_csv(RECOMMENDED)
+    legacy = pd.read_csv(LEGACY)
+
+    # Labels/folds/patient keys are identical across contracts; take them from the
+    # legacy manifest so the adapter's schema (and our folds) are unchanged.
+    keep = ["exam_id", "dataset", "patient_key", "fold", "pcr"]
+    meta = legacy[keep].copy()
+
+    wanted = parse_case_ids(args.case_ids) or rec["exam_id"].tolist()
+    missing = set(wanted) - set(rec["exam_id"])
+    if missing:
+        raise SystemExit(
+            f"not in the recommended manifest (180 rows): {sorted(missing)}"
+        )
+
+    rows = []
+    for exam_id in wanted:
+        r = rec[rec.exam_id == exam_id].iloc[0]
+        dataset = r["dataset"]
+        dest = out / "images" / dataset / exam_id
+        dest.mkdir(parents=True, exist_ok=True)
+
+        shard = shard_for(exam_id)
+        with tarfile.open(shard / "phase_images.tar") as tf:
+            members = [m for m in tf.getmembers() if m.name.endswith(".nii.gz")]
+            members.sort(key=lambda m: m.name)
+            for m in members:
+                target = dest / Path(m.name).name  # phase_XXXX.nii.gz
+                if target.exists():
+                    continue
+                src = tf.extractfile(m)
+                if src is None:
+                    raise SystemExit(f"{exam_id}: could not read {m.name}")
+                with target.open("wb") as fh:
+                    shutil.copyfileobj(src, fh)
+
+        phases = sorted(dest.glob("phase_*.nii.gz"))
+        if not phases:
+            raise SystemExit(f"{exam_id}: no phases extracted")
+
+        mrow = meta[meta.exam_id == exam_id]
+        if mrow.empty:
+            raise SystemExit(
+                f"{exam_id}: absent from the legacy manifest (no label/fold)"
+            )
+        row = mrow.iloc[0].to_dict()
+        row["phase_files"] = json.dumps([str(p) for p in phases])
+        row["n_phases"] = len(phases)
+        row["baseline_frame_count"] = int(r.get("baseline_frame_count", 5))
+        row["times_seconds_json"] = r.get("times_seconds_json")
+        row["motion_correction_applied"] = True
+        row["preprocessing_policy"] = r.get("preprocessing_policy")
+        rows.append(row)
+        print(f"  {dataset:14s} {exam_id[:26]}  {len(phases):3d} phases")
+
+    manifest_out = pd.DataFrame(rows)
+    manifest_out.to_csv(out / MANIFEST_NAME, index=False)
+    print(
+        f"\nwrote {out / MANIFEST_NAME}  ({len(manifest_out)} exams, {manifest_out.n_phases.sum()} frames)"
+    )
+    print(f"point the adapter at:  dataset_root = {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_vessel_quality.py
+++ b/scripts/score_vessel_quality.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Score UChicago vessel segmentation WITHOUT vessel ground truth, using held-out physics.
+
+UChicago ships no vessel annotations, so there is no Dice-against-truth to optimize.
+The two numbers that look like quality and are not:
+
+* **Run-to-run agreement** (our model-mask run vs our external-mask run). Maximized
+  by making the two runs identical. Measures agreement, not correctness.
+* **Vessel voxel count.** Maximized by lowering the probability threshold. Every
+  extra voxel can be noise.
+
+This scores against something the model *cannot* have fitted to. **The vessel U-Net
+sees one 3D phase at a time -- it never sees the time axis.** So contrast kinetics is
+held-out information, and the physics is unambiguous: voxels carrying contrast agent
+enhance sharply after injection; fat, fibroglandular tissue, noise and motion
+artifact do not. A segmentation that is finding real vessels will select voxels whose
+enhancement curves are steep; one that is finding noise will not.
+
+Metrics, per exam (all computed inside the REAL BreastDivider whole-breast mask, so
+nothing is rewarded for firing outside the breast):
+
+  enh_auroc      AUROC of peak relative enhancement at separating predicted-vessel
+                 voxels from other in-breast voxels. THE headline number: it rises
+                 only if the mask picks out genuinely enhancing structures.
+  enh_median_*   median peak enhancement inside vs outside the predicted vessels.
+  vessel_voxels  size of the mask. Necessary but NOT sufficient -- reported so a
+                 "win" driven purely by a lower threshold is visible as such.
+  largest_cc_frac / n_components
+                 topology. Vessels are connected tubular trees; a mask of thousands
+                 of isolated specks is worse than a few large branching components at
+                 the same voxel count. This is what stops "just lower the threshold"
+                 from scoring well: noise adds components, not connectivity.
+
+Enhancement is computed from the RAW-SIGNAL motion-corrected frames with the
+documented precontrast baseline: E = (max_t S(t) - S0) / S0, S0 = mean of the first
+`baseline_frame_count` frames. Requires the raw-signal root built by
+`scripts/build_uchicago_spgr_root.py` (the legacy images are z-scored, so a ratio to
+baseline is meaningless on them).
+
+Run:
+    python scripts/score_vessel_quality.py --run <seg_dir> --raw-root <spgr_mc_root> \
+        --label v4-mc-external --out-csv results/vessel_quality.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+
+import numpy as np
+import SimpleITK as sitk
+
+MASK_MANIFEST = (
+    "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
+    "dce2d_internal_ultrafast_manifest_with_whole_breast_masks.csv"
+)
+PHASE_RE = re.compile(r"_phase_(\d+)_vessel_segmentation\.npz$")
+EPS = 1e-6
+
+
+def find_cases(run: Path) -> dict[str, Path]:
+    """case_id -> images dir, for every case with vessel output."""
+    return {
+        d.parent.name: d
+        for d in run.glob("*/*/images")
+        if any(d.glob("*_vessel_segmentation.npz"))
+    }
+
+
+def vessel_time_max(images_dir: Path) -> np.ndarray:
+    """Per-voxel max vessel probability over all phases, in model (rows,cols,slices) space."""
+    acc = None
+    for f in sorted(images_dir.glob("*_vessel_segmentation.npz")):
+        with np.load(f) as d:
+            v = d["vessel"].astype(np.float32)
+        acc = v if acc is None else np.maximum(acc, v)
+    if acc is None:
+        raise SystemExit(f"no vessel output under {images_dir}")
+    return acc
+
+
+def peak_enhancement(
+    raw_root: Path, exam_id: str, dataset: str, n_baseline: int
+) -> np.ndarray:
+    """(max_t S - S0)/S0 from raw-signal frames, in SimpleITK (z,y,x) order.
+
+    S0 is the mean of the first ``n_baseline`` precontrast frames. Raw signal is
+    nonnegative, so the ratio is meaningful (it is NOT on the z-scored legacy images).
+    """
+    files = sorted((raw_root / "images" / dataset / exam_id).glob("phase_*.nii.gz"))
+    if len(files) <= n_baseline:
+        raise SystemExit(f"{exam_id}: {len(files)} frames <= baseline {n_baseline}")
+    base = np.mean(
+        [
+            sitk.GetArrayFromImage(sitk.ReadImage(str(f))).astype(np.float32)
+            for f in files[:n_baseline]
+        ],
+        axis=0,
+    )
+    peak = None
+    for f in files[n_baseline:]:
+        s = sitk.GetArrayFromImage(sitk.ReadImage(str(f))).astype(np.float32)
+        peak = s if peak is None else np.maximum(peak, s)
+    return (peak - base) / (base + EPS)
+
+
+def load_breast_mask(exam_id: str, adapter) -> np.ndarray:  # noqa: ANN001
+    """Real BreastDivider whole-breast mask, carried into model space by the adapter."""
+    import external_breast_masks as ebm
+
+    manifest = ebm.load_manifest(MASK_MANIFEST)
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        return np.asarray(
+            ebm.build_whole_breast_mask(exam_id, manifest, Path(td), adapter),
+            dtype=bool,
+        )
+
+
+def auroc(scores: np.ndarray, labels: np.ndarray) -> float:
+    """AUROC via rank statistic (no sklearn dependency)."""
+    n_pos = int(labels.sum())
+    n_neg = int(labels.size - n_pos)
+    if n_pos == 0 or n_neg == 0:
+        return float("nan")
+    order = np.argsort(scores, kind="mergesort")
+    ranks = np.empty(scores.size, dtype=np.float64)
+    ranks[order] = np.arange(1, scores.size + 1)
+    # average ranks for ties
+    s_sorted = scores[order]
+    i = 0
+    while i < s_sorted.size:
+        j = i
+        while j + 1 < s_sorted.size and s_sorted[j + 1] == s_sorted[i]:
+            j += 1
+        if j > i:
+            ranks[order[i : j + 1]] = (i + 1 + j + 1) / 2.0
+        i = j + 1
+    return float((ranks[labels].sum() - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg))
+
+
+def topology(mask: np.ndarray) -> tuple[int, float]:
+    """(n_connected_components, fraction of vessel volume in the largest component)."""
+    from scipy import ndimage
+
+    lab, n = ndimage.label(mask, structure=np.ones((3, 3, 3)))
+    if n == 0:
+        return 0, 0.0
+    sizes = np.bincount(lab.ravel())[1:]
+    return int(n), float(sizes.max() / sizes.sum())
+
+
+def main() -> None:
+    """Score one segmentation run against held-out contrast kinetics + topology."""
+    import sys
+
+    root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(root / "segmentation"))
+    sys.path.insert(0, str(root))
+    from cohorts.uchicago import UChicagoDataset
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--run", required=True, help="vessel-segmentation output dir")
+    p.add_argument(
+        "--raw-root",
+        required=True,
+        help="raw-signal root (build_uchicago_spgr_root.py)",
+    )
+    p.add_argument("--label", required=True)
+    p.add_argument("--threshold", type=float, default=0.5)
+    p.add_argument(
+        "--sample", type=int, default=400_000, help="voxels sampled for AUROC"
+    )
+    p.add_argument("--out-csv", required=True)
+    args = p.parse_args()
+
+    raw_root = Path(args.raw_root)
+    adapter = UChicagoDataset(root=raw_root)
+    manifest = {c: adapter.case_dataset_name(c) for c in adapter.discover_cases()}
+    import pandas as pd
+
+    mdf = pd.read_csv(raw_root / "dce2d_internal_ultrafast_manifest.csv").set_index(
+        "exam_id"
+    )
+
+    cases = find_cases(Path(args.run))
+    rng = np.random.default_rng(0)
+    rows = []
+    for exam_id, images_dir in sorted(cases.items()):
+        dataset = manifest[exam_id]
+        n_base = int(mdf.loc[exam_id, "baseline_frame_count"])
+
+        prob = vessel_time_max(images_dir)
+        pred = prob > args.threshold
+        breast = load_breast_mask(exam_id, adapter)
+
+        enh_zyx = peak_enhancement(raw_root, exam_id, dataset, n_base)
+        enh = adapter.preprocess(enh_zyx)  # into model (rows, cols, slices) space
+        if enh.shape != pred.shape:
+            raise SystemExit(f"{exam_id}: enhancement {enh.shape} != pred {pred.shape}")
+
+        inb = breast & np.isfinite(enh)
+        pos = pred & inb
+        neg = (~pred) & inb
+        n_pos = int(pos.sum())
+        if n_pos == 0:
+            print(f"  {exam_id[:26]:28s} NO vessel voxels in breast -- skipping")
+            continue
+
+        # subsample negatives (there are millions) for a tractable AUROC
+        pos_v = enh[pos]
+        neg_idx = np.flatnonzero(neg.ravel())
+        take = min(args.sample, neg_idx.size)
+        neg_v = enh.ravel()[rng.choice(neg_idx, size=take, replace=False)]
+        scores = np.concatenate([pos_v, neg_v])
+        labels = np.concatenate([np.ones(pos_v.size, bool), np.zeros(neg_v.size, bool)])
+
+        a = auroc(scores, labels)
+        ncc, lcc = topology(pred)
+        row = {
+            "label": args.label,
+            "case_id": exam_id,
+            "sub_source": dataset,
+            "threshold": args.threshold,
+            "vessel_voxels": int(pred.sum()),
+            "vessel_voxels_in_breast": n_pos,
+            "enh_auroc": round(a, 4),
+            "enh_median_vessel": round(float(np.median(pos_v)), 4),
+            "enh_median_background": round(float(np.median(neg_v)), 4),
+            "n_components": ncc,
+            "largest_cc_frac": round(lcc, 4),
+        }
+        rows.append(row)
+        print(
+            f"  {exam_id[:26]:28s} vox={row['vessel_voxels']:>8,} "
+            f"enh_auroc={a:.3f} enh(ves/bg)={row['enh_median_vessel']:.2f}/"
+            f"{row['enh_median_background']:.2f} ncc={ncc:>6,} lcc={lcc:.3f}"
+        )
+
+    out = Path(args.out_csv)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not out.exists()
+    with out.open("a", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        if write_header:
+            w.writeheader()
+        w.writerows(rows)
+
+    print(f"\n=== {args.label} (threshold {args.threshold}) ===")
+    print(
+        f"  mean enh_auroc      {np.mean([r['enh_auroc'] for r in rows]):.3f}   (higher = mask selects genuinely enhancing voxels)"
+    )
+    print(f"  total vessel voxels {sum(r['vessel_voxels'] for r in rows):,}")
+    print(
+        f"  mean largest_cc_frac {np.mean([r['largest_cc_frac'] for r in rows]):.3f}   (higher = connected tree, not speckle)"
+    )
+    print(
+        f"  mean n_components   {np.mean([r['n_components'] for r in rows]):,.0f}   (lower = less speckle)"
+    )
+    print(f"appended -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_uchicago_orientation.py
+++ b/scripts/validate_uchicago_orientation.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Decide the UChicago preprocessing transform by scoring it against ground truth.
+
+Three candidate ``UChicagoDataset.preprocess`` transforms have been proposed, and
+**the tiling-coverage crash cannot distinguish two of them** -- ``order_only`` and
+``mirrored`` produce identically-shaped arrays, so both make inference run. They
+differ only in *anatomy*: ``mirrored`` is ``order_only`` with all three axes
+flipped, a reflection (determinant -1), so it swaps the patient's left and right.
+Near-symmetric breast anatomy means a MIP can't tell them apart either.
+
+    passthrough  identity                      (the original assumption; crashes
+                                               the vessel stage -- thin slice axis
+                                               lands in a model in-plane dim)
+    mirrored     base MAMA-MIA transform on
+                 volume[::-1, :, ::-1]         (commit e341d0e; det -1, MIRRORED)
+    order_only   np.transpose(v, (1, 2, 0))    (commit a8f8bcb; det +1, preserves
+                                               anatomical directions)
+
+What settles it: the breast U-Net was trained on non-mirrored anatomy, so it is
+not mirror-equivariant. Feed it a mirrored volume and its predicted breast mask
+degrades. We have independent ground truth to score against -- the BreastDivider
+whole-breast masks Anna supplied for this same manifest -- so for each transform
+we run the pinned breast model on a real phase and compute Dice against the
+ground-truth mask carried through the *same* geometric transform.
+
+The transform whose Dice is highest is the one that presents the model with the
+anatomy it was trained on. Prediction under Anna's argument (HFDP already
+canonicalized the anatomical directions, so only array *order* needs fixing):
+``order_only`` wins, and ``mirrored`` is materially worse.
+
+Also reported, as a direct read on the mirror: the BreastDivider masks label
+``1=left / 2=right``, so after each transform we report which side of the array
+the patient's left breast lands on. ``mirrored`` and ``order_only`` must disagree
+here -- that is the whole question, made concrete.
+
+Run (GPU needed for the breast model):
+    PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_orientation_check.slurm
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import SimpleITK as sitk
+import torch
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "segmentation"))
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+import batch_segmentation as bs  # noqa: E402
+import external_breast_masks as ebm  # noqa: E402
+
+from cohorts.base import DatasetAdapter  # noqa: E402
+from cohorts.uchicago import UChicagoDataset  # noqa: E402
+
+DEFAULT_ROOT = "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest"
+
+
+class _PassthroughUChicago(UChicagoDataset):
+    """The original assumption: HFDP output is already in the model's layout."""
+
+    def preprocess(self, volume: np.ndarray) -> np.ndarray:
+        return volume
+
+
+class _MirroredUChicago(UChicagoDataset):
+    """Commit e341d0e: header-derived RAS->LAI flip, then the base transform."""
+
+    def preprocess(self, volume: np.ndarray) -> np.ndarray:
+        return DatasetAdapter.preprocess(self, volume[::-1, :, ::-1])
+
+
+VARIANTS: dict[str, type[UChicagoDataset]] = {
+    "passthrough": _PassthroughUChicago,
+    "mirrored": _MirroredUChicago,
+    "order_only": UChicagoDataset,  # current HEAD (a8f8bcb)
+}
+
+
+MASK_THRESHOLD = 0.5
+LABEL_LEFT, LABEL_RIGHT = 1, 2  # BreastDivider mask labels (0 = background)
+
+
+def dice(a: np.ndarray, b: np.ndarray) -> float:
+    """Dice coefficient between two binary masks."""
+    a_bin, b_bin = a > MASK_THRESHOLD, b > MASK_THRESHOLD
+    denom = a_bin.sum() + b_bin.sum()
+    if denom == 0:
+        return float("nan")
+    return float(2.0 * np.logical_and(a_bin, b_bin).sum() / denom)
+
+
+def left_breast_side(labelled: np.ndarray) -> str:
+    """Report which half of the array's column axis the patient's LEFT breast occupies.
+
+    ``labelled`` is a BreastDivider mask (1=left, 2=right) already carried through
+    a candidate transform. Preprocessed volumes are (rows, cols, slices), so the
+    column axis (1) is the left-right image axis. A transform that mirrors anatomy
+    puts label 1 on the opposite side from one that doesn't -- which is exactly the
+    disagreement we are trying to resolve.
+    """
+    ncols = labelled.shape[1]
+    left_cols = np.where(labelled == LABEL_LEFT)[1]
+    right_cols = np.where(labelled == LABEL_RIGHT)[1]
+    if left_cols.size == 0 or right_cols.size == 0:
+        return "n/a (mask has no L/R split)"
+    left_c, right_c = left_cols.mean(), right_cols.mean()
+    side = "LOW column index" if left_c < right_c else "HIGH column index"
+    return f"{side} (left centroid col {left_c:.0f}, right {right_c:.0f}, of {ncols})"
+
+
+def pick_cases(root: Path, explicit: list[str] | None) -> list[str]:
+    """One exam per manifest sub-source, unless explicit ids are given."""
+    import pandas as pd
+
+    manifest = pd.read_csv(root / "dce2d_internal_ultrafast_manifest.csv")
+    if explicit:
+        missing = set(explicit) - set(manifest["exam_id"])
+        if missing:
+            raise SystemExit(f"unknown exam ids: {sorted(missing)}")
+        return explicit
+    return [g.iloc[0]["exam_id"] for _, g in manifest.groupby("dataset", sort=True)]
+
+
+def phase0_path(root: Path, adapter: UChicagoDataset, case_id: str) -> Path:
+    """Absolute path to a case's phase_0000 file, via the adapter's own timepoints."""
+    timepoints = adapter.load_timepoints(case_id)
+    return Path(timepoints[0])
+
+
+def main() -> None:
+    """Score each candidate transform against the BreastDivider ground truth."""
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dataset-root", default=DEFAULT_ROOT)
+    p.add_argument("--breast-model-path", required=True)
+    p.add_argument("--mask-manifest", default=ebm.DEFAULT_MANIFEST_CSV)
+    p.add_argument("--work-dir", required=True, help="scratch dir for step1/step2")
+    p.add_argument("--out-csv", required=True)
+    p.add_argument("--case-ids", nargs="*", default=None)
+    p.add_argument("--batch-size", type=int, default=4)
+    args = p.parse_args()
+
+    root = Path(args.dataset_root)
+    work = Path(args.work_dir)
+    work.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"device: {device}")
+
+    ref_adapter = UChicagoDataset(root=root)
+    cases = pick_cases(root, args.case_ids)
+    print(f"cases ({len(cases)}), one per sub-source unless overridden:")
+    for c in cases:
+        print(f"  {ref_adapter.case_dataset_name(c):14s} {c}")
+
+    mask_manifest = ebm.load_manifest(args.mask_manifest)
+    ebm.validate_masks_available(cases, mask_manifest)  # fail-closed, before GPU work
+
+    rows: list[dict[str, object]] = []
+    for name, cls in VARIANTS.items():
+        print(f"\n=== variant: {name} ===")
+        adapter = cls(root=root)
+        step1, step2, extract = (work / name / d for d in ("step1", "step2", "masks"))
+        for d in (step1, step2, extract):
+            d.mkdir(parents=True, exist_ok=True)
+
+        for case_id in cases:
+            src = phase0_path(root, ref_adapter, case_id)
+            ok = bs.preprocess_image(
+                str(src), str(step1 / f"{case_id}_phase_0000.npy"), adapter
+            )
+            if not ok:
+                raise SystemExit(f"{name}: preprocessing failed for {case_id}")
+
+        bs._run_breast_inference(
+            step1, step2, args.breast_model_path, args.batch_size, 1, True, device
+        )
+
+        for case_id in cases:
+            pred = np.load(step2 / f"{case_id}_phase_0000.npy").astype(np.float32)
+            gt = ebm.build_whole_breast_mask(case_id, mask_manifest, extract, adapter)
+            gt = np.asarray(gt, dtype=np.float32)
+            if gt.shape != pred.shape:
+                raise SystemExit(
+                    f"{name}/{case_id}: gt {gt.shape} != pred {pred.shape}; "
+                    "the mask no longer shares the image grid -- investigate before trusting."
+                )
+
+            # laterality, straight off the labelled (un-binarized) ground truth
+            archive, member = ebm._resolve_mask_member(case_id, mask_manifest)
+            import tarfile
+
+            with tarfile.open(archive) as tf:
+                tf.extract(member, path=extract)
+            labelled = sitk.GetArrayFromImage(sitk.ReadImage(str(extract / member)))
+            labelled_t = adapter.preprocess(labelled.astype(np.float32))
+
+            d = dice(pred, gt)
+            side = left_breast_side(labelled_t)
+            print(f"  {case_id[:28]:30s} dice={d:.3f}  left breast -> {side}")
+            rows.append(
+                {
+                    "variant": name,
+                    "case_id": case_id,
+                    "sub_source": ref_adapter.case_dataset_name(case_id),
+                    "breast_dice_vs_groundtruth": round(d, 4),
+                    "pred_voxels": int((pred > MASK_THRESHOLD).sum()),
+                    "gt_voxels": int((gt > MASK_THRESHOLD).sum()),
+                    "left_breast_side": side,
+                }
+            )
+
+    with Path(args.out_csv).open("w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        w.writeheader()
+        w.writerows(rows)
+
+    print(
+        "\n=== mean breast Dice vs BreastDivider ground truth (higher = correct anatomy) ==="
+    )
+    summary = {}
+    for name in VARIANTS:
+        vals = [r["breast_dice_vs_groundtruth"] for r in rows if r["variant"] == name]
+        summary[name] = float(np.nanmean(vals))
+        print(f"  {name:14s} {summary[name]:.3f}")
+    best = max(summary, key=summary.get)
+    print(f"\nbest: {best}")
+    print(json.dumps(summary, indent=2))
+    print(f"wrote {args.out_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_uchicago_orientation.py
+++ b/scripts/validate_uchicago_orientation.py
@@ -82,6 +82,12 @@ VARIANTS: dict[str, type[UChicagoDataset]] = {
     "order_only": UChicagoDataset,  # current HEAD (a8f8bcb)
 }
 
+# Laterality is read off array axis 1, which is the left-right axis only once the
+# volume is in the model's (rows, cols, slices) layout. Passthrough leaves it in
+# SimpleITK's (slices, rows, cols), so axis 1 is rows there -- reading a left/right
+# centroid off it would be meaningless, not merely wrong.
+LATERALITY_READABLE = {"mirrored", "order_only"}
+
 
 MASK_THRESHOLD = 0.5
 LABEL_LEFT, LABEL_RIGHT = 1, 2  # BreastDivider mask labels (0 = background)
@@ -201,7 +207,11 @@ def main() -> None:
             labelled_t = adapter.preprocess(labelled.astype(np.float32))
 
             d = dice(pred, gt)
-            side = left_breast_side(labelled_t)
+            side = (
+                left_breast_side(labelled_t)
+                if name in LATERALITY_READABLE
+                else "n/a (not in (rows, cols, slices) layout; axis 1 is not left-right)"
+            )
             print(f"  {case_id[:28]:30s} dice={d:.3f}  left breast -> {side}")
             rows.append(
                 {

--- a/segmentation/batch_segmentation.py
+++ b/segmentation/batch_segmentation.py
@@ -24,10 +24,14 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import SimpleITK as sitk
 import torch
+
+if TYPE_CHECKING:
+    from cohorts.base import DatasetAdapter
 
 _HERE = Path(__file__).resolve().parent
 _PROJECT_ROOT = _HERE.parent
@@ -79,12 +83,23 @@ def find_nii_files(images_dir: str) -> list[tuple[str, str]]:
     return nii_files
 
 
-def preprocess_image(input_path: str, output_path: str) -> bool:
+def preprocess_image(
+    input_path: str, output_path: str, adapter: DatasetAdapter | None = None
+) -> bool:
     """Preprocess a single .nii.gz file (STEP-1).
 
     Args:
         input_path: Path to input .nii.gz file
         output_path: Path to save preprocessed .npy file
+        adapter: Optional dataset adapter (Step 4 of the multi-dataset
+            migration, see cohorts/README.md). When given, the geometry
+            reorientation is taken from ``adapter.preprocess`` instead of the
+            hardcoded MAMA-MIA axis transform -- e.g. UChicago ships
+            already-oriented data and overrides this to a pass-through. When
+            ``None`` (every caller today) the transform is byte-for-byte
+            unchanged. Intensity normalization (``normalize_image``/
+            ``zscore_image``) is applied by this stage either way, matching the
+            adapter contract in cohorts/base.py.
 
     Returns:
         True if successful, False otherwise
@@ -93,10 +108,13 @@ def preprocess_image(input_path: str, output_path: str) -> bool:
         # Load the image
         original_array = sitk.GetArrayFromImage(sitk.ReadImage(str(input_path)))
 
-        # Preprocess: rotate axes and normalize
-        preprocessed_array = zscore_image(
-            normalize_image(np.swapaxes(np.swapaxes(original_array, 0, 2), 0, 1)[::-1])
+        # Preprocess: rotate axes (via the adapter when provided) and normalize
+        reoriented = (
+            adapter.preprocess(original_array)
+            if adapter is not None
+            else np.swapaxes(np.swapaxes(original_array, 0, 2), 0, 1)[::-1]
         )
+        preprocessed_array = zscore_image(normalize_image(reoriented))
 
         # Save as .npy
         np.save(output_path, preprocessed_array)
@@ -107,9 +125,25 @@ def preprocess_image(input_path: str, output_path: str) -> bool:
         return False
 
 
-def build_output_path(output_dir: Path, case_id: str, base_name: str) -> Path:
-    """Build output path in a source/case/images layout."""
-    source = case_id.split("_")[0]
+def build_output_path(
+    output_dir: Path,
+    case_id: str,
+    base_name: str,
+    adapter: DatasetAdapter | None = None,
+) -> Path:
+    """Build output path in a source/case/images layout.
+
+    The top-level ``source`` directory is the case's dataset identity. With an
+    ``adapter`` (Step 4) it comes from ``adapter.case_dataset_name`` (one
+    authoritative answer -- e.g. UChicago's manifest sub-source); without one it
+    is the case-id prefix ``case_id.split("_")[0]``, today's behavior. For
+    MAMA-MIA these agree, so the ``None`` path is byte-for-byte unchanged.
+    """
+    source = (
+        adapter.case_dataset_name(case_id)
+        if adapter is not None
+        else case_id.split("_")[0]
+    )
     timepoint = (
         base_name[len(case_id) + 1 :]
         if base_name.startswith(f"{case_id}_")
@@ -143,9 +177,16 @@ def collect_all_step3_files(output_dir: str) -> list[str]:
 
 
 def preprocess_parallel(
-    file_list: list[tuple[str, str]], step1_dir: Path, workers: int
+    file_list: list[tuple[str, str]],
+    step1_dir: Path,
+    workers: int,
+    adapter: DatasetAdapter | None = None,
 ) -> tuple[dict[str, str], list[str]]:
-    """Run STEP-1 preprocessing across a thread pool. Returns base_name->case_id."""
+    """Run STEP-1 preprocessing across a thread pool. Returns base_name->case_id.
+
+    ``adapter`` is threaded to :func:`preprocess_image` (Step 4); ``None``
+    preserves today's behavior exactly.
+    """
     base_name_to_case = {}
     failed = []
 
@@ -153,7 +194,7 @@ def preprocess_parallel(
         case_id, file_path = item
         base_name = Path(file_path).name.replace(".nii.gz", "")
         step1_file = step1_dir / f"{base_name}.npy"
-        ok = preprocess_image(file_path, step1_file)
+        ok = preprocess_image(file_path, step1_file, adapter=adapter)
         return case_id, base_name, ok
 
     with ThreadPoolExecutor(max_workers=workers) as ex:

--- a/segmentation/batch_segmentation.py
+++ b/segmentation/batch_segmentation.py
@@ -184,10 +184,10 @@ def preprocess_image(
         adapter: Optional dataset adapter (Step 4 of the multi-dataset
             migration, see cohorts/README.md). When given, the geometry
             reorientation is taken from ``adapter.preprocess`` instead of the
-            hardcoded MAMA-MIA axis transform -- e.g. UChicago ships
-            already-oriented data and overrides this to a pass-through. When
-            ``None`` (every caller today) the transform is byte-for-byte
-            unchanged. Intensity normalization (``normalize_image``/
+            hardcoded MAMA-MIA axis transform -- e.g. UChicago preserves its
+            HFDP anatomical directions and converts only array order. When
+            ``None`` the transform is byte-for-byte unchanged. Intensity
+            normalization (``normalize_image``/
             ``zscore_image``) is applied by this stage either way, matching the
             adapter contract in cohorts/base.py.
 

--- a/segmentation/batch_segmentation.py
+++ b/segmentation/batch_segmentation.py
@@ -54,6 +54,7 @@ except ImportError:
         raise ImportError("Required preprocessing function not found")  # noqa: F821
 
 
+import external_breast_masks  # noqa: E402
 import predict_fast  # noqa: E402
 
 
@@ -258,24 +259,26 @@ def preprocess_parallel(
     return base_name_to_case, failed
 
 
-def run_inference_in_process(
+def _run_breast_inference(
     step1_dir: Path,
     step2_dir: Path,
-    step3_dir: Path,
     breast_model_path: str,
-    vessel_model_path: str,
     batch_size: int,
     num_workers: int,
     use_amp: bool,
+    device: torch.device,
 ) -> None:
-    """Load each model once and run breast then vessel inference in-process."""
+    """STEP-2: run the breast U-Net over step1_dir, write masks to step2_dir.
+
+    Extracted verbatim from the STEP-2 block of the original
+    ``run_inference_in_process`` so it can be skipped when external
+    (ground-truth) breast masks are supplied instead (see
+    ``segmentation/external_breast_masks.py``). The vessel stage
+    (:func:`_run_vessel_inference`) consumes ``step2_dir`` either way.
+    """
     import torchio as tio
-    from dataset_3d import Dataset3DDivided, Dataset3DSimple
+    from dataset_3d import Dataset3DSimple
 
-    predict_fast.apply_shape_patch()
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    # ── STEP-2: breast ────────────────────────────────────────────────────
     breast_unet, _, _ = predict_fast.build_unet("breast")
     breast_unet = predict_fast.load_model(breast_unet, breast_model_path, device)
     breast_ds = Dataset3DSimple(
@@ -297,7 +300,27 @@ def run_inference_in_process(
     if device.type == "cuda":
         torch.cuda.empty_cache()
 
-    # ── STEP-3: vessel ────────────────────────────────────────────────────
+
+def _run_vessel_inference(
+    step1_dir: Path,
+    step2_dir: Path,
+    step3_dir: Path,
+    vessel_model_path: str,
+    batch_size: int,
+    num_workers: int,
+    use_amp: bool,
+    device: torch.device,
+) -> None:
+    """STEP-3: run the vessel U-Net, reading breast masks from step2_dir.
+
+    Extracted verbatim from the STEP-3 block of the original
+    ``run_inference_in_process``. ``step2_dir`` may hold either model-predicted
+    (STEP-2) or externally supplied breast masks -- this stage is agnostic to
+    which.
+    """
+    import torchio as tio
+    from dataset_3d import Dataset3DDivided
+
     vessel_unet, _, n_classes = predict_fast.build_unet("dv")
     vessel_unet = predict_fast.load_model(vessel_unet, vessel_model_path, device)
     vessel_ds = Dataset3DDivided(
@@ -320,6 +343,40 @@ def run_inference_in_process(
         batch_size=batch_size,
         num_workers=num_workers,
         use_amp=use_amp,
+    )
+
+
+def run_inference_in_process(
+    step1_dir: Path,
+    step2_dir: Path,
+    step3_dir: Path,
+    breast_model_path: str,
+    vessel_model_path: str,
+    batch_size: int,
+    num_workers: int,
+    use_amp: bool,
+) -> None:
+    """Load each model once and run breast then vessel inference in-process."""
+    predict_fast.apply_shape_patch()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    _run_breast_inference(
+        step1_dir,
+        step2_dir,
+        breast_model_path,
+        batch_size,
+        num_workers,
+        use_amp,
+        device,
+    )
+    _run_vessel_inference(
+        step1_dir,
+        step2_dir,
+        step3_dir,
+        vessel_model_path,
+        batch_size,
+        num_workers,
+        use_amp,
+        device,
     )
 
 
@@ -377,6 +434,31 @@ def main() -> None:
         default=None,
         help="mamamia only: duke|ispy1|ispy2|nact.",
     )
+    p.add_argument(
+        "--use-external-breast-masks",
+        action="store_true",
+        help=(
+            "Skip STEP-2 breast-model inference; instead feed STEP-3 the "
+            "external whole-breast masks from --external-breast-mask-manifest "
+            "(see segmentation/external_breast_masks.py). uchicago only. "
+            "NOTE: one phase-0 mask is reused across all phases (no motion "
+            "correction) -- a documented approximation."
+        ),
+    )
+    p.add_argument(
+        "--external-breast-mask-manifest",
+        default=external_breast_masks.DEFAULT_MANIFEST_CSV,
+        help="Mask-augmented manifest CSV for --use-external-breast-masks.",
+    )
+    p.add_argument(
+        "--external-breast-mask-persist-dir",
+        default=None,
+        help=(
+            "If set, also write the converted external masks here (outside the "
+            "--cleanup temp dir) so a later comparison can read exactly what "
+            "was used."
+        ),
+    )
     args = p.parse_args()
 
     adapter: DatasetAdapter | None = None
@@ -398,6 +480,16 @@ def main() -> None:
         )
         adapter = build_adapter_from_config(dataset_config)
         print(f"Using dataset adapter: {type(adapter).__name__}")
+
+    if args.use_external_breast_masks:
+        if args.dataset_name != "uchicago":
+            p.error(
+                "--use-external-breast-masks is only supported for --dataset-name uchicago."
+            )
+        if not Path(args.external_breast_mask_manifest).exists():
+            p.error(
+                f"--external-breast-mask-manifest not found: {args.external_breast_mask_manifest}"
+            )
 
     out_dir = Path(args.output_dir)
     temp_dir = Path(args.temp_dir)
@@ -450,6 +542,19 @@ def main() -> None:
         print("Nothing to do, exiting.")
         return
 
+    # Fail-closed: verify every selected case has an external mask BEFORE
+    # spending ~90s on preprocessing (and before any GPU work).
+    if args.use_external_breast_masks:
+        manifest = external_breast_masks.load_manifest(
+            args.external_breast_mask_manifest
+        )
+        case_ids = sorted({cid for cid, _ in nii_files})
+        external_breast_masks.validate_masks_available(case_ids, manifest)
+        print(
+            f"External breast masks: verified available for all {len(case_ids)} case(s). "
+            "NOTE: one phase-0 mask reused across all phases (no motion correction)."
+        )
+
     t0 = time.time()
     use_amp = not args.no_amp
     print(
@@ -469,16 +574,45 @@ def main() -> None:
     print(
         f"Inference (batch_size={args.batch_size}, num_workers={args.num_workers}, amp={use_amp})..."
     )
-    run_inference_in_process(
-        step1_dir,
-        step2_dir,
-        step3_dir,
-        args.breast_model_path,
-        args.vessel_model_path,
-        args.batch_size,
-        args.num_workers,
-        use_amp,
-    )
+    if args.use_external_breast_masks:
+        # STEP-2 replaced: build step2_dir from external whole-breast masks,
+        # then run STEP-3 only (skip the breast model entirely).
+        print("Building external breast masks (skipping STEP-2 model inference)...")
+        external_breast_masks.build_external_step2_dir(
+            base_name_to_case,
+            step1_dir,
+            args.external_breast_mask_manifest,
+            step2_dir,
+            adapter,
+            persist_copy_dir=(
+                Path(args.external_breast_mask_persist_dir)
+                if args.external_breast_mask_persist_dir
+                else None
+            ),
+        )
+        predict_fast.apply_shape_patch()
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        _run_vessel_inference(
+            step1_dir,
+            step2_dir,
+            step3_dir,
+            args.vessel_model_path,
+            args.batch_size,
+            args.num_workers,
+            use_amp,
+            device,
+        )
+    else:
+        run_inference_in_process(
+            step1_dir,
+            step2_dir,
+            step3_dir,
+            args.breast_model_path,
+            args.vessel_model_path,
+            args.batch_size,
+            args.num_workers,
+            use_amp,
+        )
     t_inf = time.time()
     print(f"Inference done in {t_inf - t_pre:.1f}s")
 

--- a/segmentation/batch_segmentation.py
+++ b/segmentation/batch_segmentation.py
@@ -83,6 +83,57 @@ def find_nii_files(images_dir: str) -> list[tuple[str, str]]:
     return nii_files
 
 
+def find_case_files(
+    images_dir: str,
+    adapter: DatasetAdapter | None = None,
+    case_limit: int | None = None,
+) -> list[tuple[str, str]]:
+    """Enumerate (case_id, file_path) pairs to preprocess.
+
+    When ``adapter`` is given (Step 4), discovery routes through
+    ``adapter.discover_cases()`` / ``adapter.load_timepoints(case_id)`` instead
+    of assuming the MAMA-MIA ``<images_dir>/<case_id>/*.nii.gz`` layout --
+    e.g. UChicago's manifest-driven, sub-source-partitioned images would
+    otherwise be silently missed or misread by ``find_nii_files``. ``images_dir``
+    is unused in that case (the adapter owns its own root).
+
+    ``case_limit`` (applied here, at case granularity, before file expansion)
+    exists because the CLI's ``--patient-limit`` slices the flat file list --
+    imprecise for a case with more than one phase file. When ``adapter`` is
+    ``None``, this function is exactly :func:`find_nii_files` and ``case_limit``
+    is ignored; the CLI keeps applying ``--patient-limit`` post-hoc for that
+    path, unchanged from before Step 4.
+    """
+    if adapter is None:
+        return find_nii_files(images_dir)
+    case_ids = adapter.discover_cases()
+    if case_limit is not None:
+        case_ids = case_ids[:case_limit]
+    pairs: list[tuple[str, str]] = []
+    for case_id in case_ids:
+        for phase_path in adapter.load_timepoints(case_id):
+            pairs.append((case_id, str(phase_path)))
+    return pairs
+
+
+def _base_name_for(case_id: str, file_path: str, adapter: DatasetAdapter | None) -> str:
+    """Derive the unique intermediate-file base name for one (case, phase) file.
+
+    MAMA-MIA filenames already embed the case id (``DUKE_001_0000.nii.gz``), so
+    the bare stem is used -- byte-for-byte the pre-Step-4 behavior when
+    ``adapter`` is ``None``. UChicago's phase files are named identically
+    across *every* case (``phase_0000.nii.gz`` for every exam); without a
+    case-id prefix, different patients' same-numbered phase would collide on
+    the same path in the flat step1/step2/step3 intermediate directories,
+    silently overwriting each other's preprocessed output. Prefixing with
+    ``case_id`` (only when an adapter is given) avoids that collision --
+    :func:`build_output_path` already expects and strips exactly this prefix
+    when recovering the timepoint for the final output filename.
+    """
+    raw = Path(file_path).name.replace(".nii.gz", "")
+    return f"{case_id}_{raw}" if adapter is not None else raw
+
+
 def preprocess_image(
     input_path: str, output_path: str, adapter: DatasetAdapter | None = None
 ) -> bool:
@@ -192,7 +243,7 @@ def preprocess_parallel(
 
     def _work(item: tuple[str, str]) -> tuple[str, str, bool]:
         case_id, file_path = item
-        base_name = Path(file_path).name.replace(".nii.gz", "")
+        base_name = _base_name_for(case_id, file_path, adapter)
         step1_file = step1_dir / f"{base_name}.npy"
         ok = preprocess_image(file_path, step1_file, adapter=adapter)
         return case_id, base_name, ok
@@ -306,7 +357,47 @@ def main() -> None:
     p.add_argument("--no-amp", action="store_true", help="Disable mixed precision")
     p.add_argument("--resume", action="store_true")
     p.add_argument("--cleanup", action="store_true")
+    p.add_argument(
+        "--dataset-name",
+        default=None,
+        help=(
+            "If set (mamamia|uchicago), build a DatasetAdapter via "
+            "cohorts.factory and route discovery/preprocessing/output-path "
+            "through it instead of the hardcoded MAMA-MIA logic (Step 4). "
+            "--images-dir is ignored in this mode; the adapter owns its root."
+        ),
+    )
+    p.add_argument(
+        "--dataset-root",
+        default=None,
+        help="Root path for --dataset-name (e.g. the UChicago manifest directory).",
+    )
+    p.add_argument(
+        "--dataset-cohort",
+        default=None,
+        help="mamamia only: duke|ispy1|ispy2|nact.",
+    )
     args = p.parse_args()
+
+    adapter: DatasetAdapter | None = None
+    if args.dataset_name:
+        from cohorts.factory import build_adapter_from_config
+        from config import ConfigNode
+
+        if not args.dataset_root:
+            p.error("--dataset-root is required when --dataset-name is set.")
+        dataset_config = ConfigNode._wrap(
+            {
+                "dataset": {
+                    "name": args.dataset_name,
+                    "cohort": args.dataset_cohort,
+                    "root": args.dataset_root,
+                    "split_policy": "auto",
+                }
+            }
+        )
+        adapter = build_adapter_from_config(dataset_config)
+        print(f"Using dataset adapter: {type(adapter).__name__}")
 
     out_dir = Path(args.output_dir)
     temp_dir = Path(args.temp_dir)
@@ -318,16 +409,31 @@ def main() -> None:
     for d in (out_dir, step1_dir, step2_dir, step3_dir):
         d.mkdir(parents=True, exist_ok=True)
 
-    print(f"Finding .nii.gz files in {args.images_dir}...")
-    nii_files = sorted(find_nii_files(args.images_dir), key=lambda x: (x[0], str(x[1])))
-    print(f"Found {len(nii_files)} .nii.gz files")
+    if adapter is not None:
+        print(f"Discovering cases via {type(adapter).__name__}...")
+        # Case-level limit applied before file expansion (see find_case_files):
+        # a file-list-level limit would be imprecise once a case has more than
+        # one phase file.
+        nii_files = sorted(
+            find_case_files(
+                args.images_dir, adapter=adapter, case_limit=args.patient_limit
+            ),
+            key=lambda x: (x[0], str(x[1])),
+        )
+        print(f"Found {len(nii_files)} file(s) across the selected cases")
+    else:
+        print(f"Finding .nii.gz files in {args.images_dir}...")
+        nii_files = sorted(
+            find_nii_files(args.images_dir), key=lambda x: (x[0], str(x[1]))
+        )
+        print(f"Found {len(nii_files)} .nii.gz files")
 
     if args.file_start is not None:
         end = args.file_end if args.file_end is not None else args.file_start
         end = min(end, len(nii_files) - 1)
         nii_files = nii_files[args.file_start : end + 1]
         print(f"Range {args.file_start}-{end}: {len(nii_files)} files")
-    if args.patient_limit:
+    if args.patient_limit and adapter is None:
         nii_files = nii_files[: args.patient_limit]
 
     if args.resume:
@@ -336,7 +442,7 @@ def main() -> None:
             (cid, fp)
             for cid, fp in nii_files
             if not build_output_path(
-                out_dir, cid, Path(fp).name.replace(".nii.gz", "")
+                out_dir, cid, _base_name_for(cid, fp, adapter), adapter=adapter
             ).exists()
         ]
         print(f"Resume: {len(nii_files)} remaining (skipped {before - len(nii_files)})")
@@ -350,7 +456,7 @@ def main() -> None:
         f"Preprocessing {len(nii_files)} file(s) with {args.preprocess_workers} workers..."
     )
     base_name_to_case, failed = preprocess_parallel(
-        nii_files, step1_dir, args.preprocess_workers
+        nii_files, step1_dir, args.preprocess_workers, adapter=adapter
     )
     t_pre = time.time()
     print(
@@ -381,7 +487,7 @@ def main() -> None:
     for base_name, case_id in base_name_to_case.items():
         step3_file = step3_dir / f"{base_name}.npz"
         if step3_file.exists():
-            dst = build_output_path(out_dir, case_id, base_name)
+            dst = build_output_path(out_dir, case_id, base_name, adapter=adapter)
             shutil.move(str(step3_file), str(dst))
             successful.append(str(dst))
             print(f"  ✓ {case_id}: {dst}")

--- a/segmentation/batch_segmentation.py
+++ b/segmentation/batch_segmentation.py
@@ -31,6 +31,8 @@ import SimpleITK as sitk
 import torch
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from cohorts.base import DatasetAdapter
 
 _HERE = Path(__file__).resolve().parent
@@ -84,10 +86,27 @@ def find_nii_files(images_dir: str) -> list[tuple[str, str]]:
     return nii_files
 
 
+def _parse_case_ids(value: str | None) -> list[str] | None:
+    """Resolve ``--case-ids`` (a comma-separated list, or a file of one per line)."""
+    if value is None:
+        return None
+    path = Path(value)
+    if path.is_file():
+        lines = path.read_text().splitlines()
+        ids = [s.strip() for s in lines]
+    else:
+        ids = [s.strip() for s in value.split(",")]
+    ids = [s for s in ids if s and not s.startswith("#")]
+    if not ids:
+        raise ValueError(f"--case-ids resolved to an empty selection: {value!r}")
+    return ids
+
+
 def find_case_files(
     images_dir: str,
     adapter: DatasetAdapter | None = None,
     case_limit: int | None = None,
+    select_cases: Sequence[str] | None = None,
 ) -> list[tuple[str, str]]:
     """Enumerate (case_id, file_path) pairs to preprocess.
 
@@ -104,11 +123,30 @@ def find_case_files(
     ``None``, this function is exactly :func:`find_nii_files` and ``case_limit``
     is ignored; the CLI keeps applying ``--patient-limit`` post-hoc for that
     path, unchanged from before Step 4.
+
+    ``select_cases`` picks an explicit set of case ids instead of a prefix of
+    discovery order. ``case_limit`` alone can only ever reach the *first* N
+    discovered cases, which on a manifest grouped by sub-source (UChicago:
+    simbiosys, then uch_nac, then her2_naclike) means whole sub-sources are
+    unreachable -- the reason the first smoke tests only ever covered
+    her2_naclike. Selection is fail-closed: an id that discovery does not know
+    raises rather than being silently dropped, so a typo'd exam id can't quietly
+    shrink the run. Takes precedence over ``case_limit``.
     """
     if adapter is None:
         return find_nii_files(images_dir)
     case_ids = adapter.discover_cases()
-    if case_limit is not None:
+    if select_cases is not None:
+        known = set(case_ids)
+        unknown = [c for c in select_cases if c not in known]
+        if unknown:
+            raise ValueError(
+                f"{len(unknown)} requested case id(s) are not in "
+                f"{type(adapter).__name__}.discover_cases(): {unknown}"
+            )
+        wanted = set(select_cases)
+        case_ids = [c for c in case_ids if c in wanted]
+    elif case_limit is not None:
         case_ids = case_ids[:case_limit]
     pairs: list[tuple[str, str]] = []
     for case_id in case_ids:
@@ -406,6 +444,18 @@ def main() -> None:
         default=str(_SUBMODULE / "trained_models" / "dv_model.pth"),
     )
     p.add_argument("--patient-limit", type=int, default=None)
+    p.add_argument(
+        "--case-ids",
+        default=None,
+        help=(
+            "Adapter mode only: run exactly these case ids instead of the first "
+            "--patient-limit discovered ones. Either a comma-separated list or a "
+            "path to a file with one case id per line (blank lines and #comments "
+            "ignored). Fail-closed: an id discovery does not know raises. Needed "
+            "to reach cases outside the head of discovery order -- e.g. UChicago's "
+            "uch_nac/her2_naclike sub-sources, which --patient-limit cannot reach."
+        ),
+    )
     p.add_argument("--file-start", type=int, default=None)
     p.add_argument("--file-end", type=int, default=None)
     p.add_argument("--batch-size", type=int, default=16)
@@ -503,12 +553,18 @@ def main() -> None:
 
     if adapter is not None:
         print(f"Discovering cases via {type(adapter).__name__}...")
+        select_cases = _parse_case_ids(args.case_ids)
+        if select_cases is not None:
+            print(f"Explicit case selection: {len(select_cases)} case(s)")
         # Case-level limit applied before file expansion (see find_case_files):
         # a file-list-level limit would be imprecise once a case has more than
         # one phase file.
         nii_files = sorted(
             find_case_files(
-                args.images_dir, adapter=adapter, case_limit=args.patient_limit
+                args.images_dir,
+                adapter=adapter,
+                case_limit=args.patient_limit,
+                select_cases=select_cases,
             ),
             key=lambda x: (x[0], str(x[1])),
         )

--- a/segmentation/external_breast_masks.py
+++ b/segmentation/external_breast_masks.py
@@ -1,0 +1,255 @@
+"""Inject external (ground-truth) whole-breast masks into the vessel-seg pipeline.
+
+The segmentation pipeline (``batch_segmentation.py``) normally computes breast
+masks itself (STEP-2, a U-Net) and feeds them as an extra input channel to the
+vessel stage (STEP-3). This module lets STEP-3 instead consume the
+externally-provided BreastDivider "whole-breast" masks shipped with the
+UChicago manifest, so we can test whether real breast masks change the vessel
+segmentation outcome.
+
+Source data (see the manifest data dictionary):
+  - manifest CSV ``..._with_whole_breast_masks.csv`` -- one row per exam_id,
+    with ``whole_breast_mask_archive_path`` / ``whole_breast_mask_archive_member``
+    naming the mask's NIfTI member inside a shared TAR.
+  - ``whole_breast_masks.tar`` -- one NIfTI per exam at
+    ``whole_breast_masks/<dataset>/<exam_id>.nii.gz``, labels
+    ``0=background / 1=left / 2=right``. Use ``mask > 0`` for a whole-breast
+    union.
+
+Key facts (verified against real data, not just the dictionary):
+  - The mask is stored in the SAME raw array space / affine as the exam's
+    ``phase_0000.nii.gz`` (``exact_source_grid_match`` for the smoke-test
+    patients). So applying the SAME geometric transform the adapter applies to
+    images (``UChicagoDataset.preprocess``) lands the mask in STEP-1 space with
+    no resize. We apply ONLY that geometric transform -- NOT
+    ``normalize_image``/``zscore_image``, which are intensity ops meaningless
+    for a 0/1 label map.
+  - There is ONE mask per exam, generated from phase 0 only. This build did NOT
+    include motion correction, so reusing the phase-0 mask for every dynamic
+    phase of an exam is a documented approximation (it assumes the breast does
+    not move across phases), not an oversight. Callers that fan the mask out to
+    all phases must surface this limitation.
+"""
+
+from __future__ import annotations
+
+import csv
+import tarfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import SimpleITK as sitk
+
+if TYPE_CHECKING:
+    from cohorts.base import DatasetAdapter
+
+DEFAULT_MANIFEST_CSV = (
+    "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
+    "dce2d_internal_ultrafast_manifest_with_whole_breast_masks.csv"
+)
+
+
+def load_manifest(manifest_csv: str | Path) -> dict[str, dict[str, str]]:
+    """Load the mask-augmented manifest, indexed by ``exam_id`` (181 small rows)."""
+    manifest_csv = Path(manifest_csv)
+    with manifest_csv.open(newline="") as f:
+        rows = {row["exam_id"]: row for row in csv.DictReader(f)}
+    return rows
+
+
+def _resolve_mask_member(
+    exam_id: str, manifest: dict[str, dict[str, str]]
+) -> tuple[str, str]:
+    """Return ``(archive_path, archive_member)`` for an exam, or raise clearly."""
+    if exam_id not in manifest:
+        raise KeyError(f"exam_id not in mask manifest: {exam_id}")
+    row = manifest[exam_id]
+    archive_path = row.get("whole_breast_mask_archive_path", "").strip()
+    archive_member = row.get("whole_breast_mask_archive_member", "").strip()
+    if not archive_path or not archive_member:
+        raise ValueError(
+            f"exam_id {exam_id} has no whole_breast_mask archive path/member in manifest"
+        )
+    return archive_path, archive_member
+
+
+def validate_masks_available(
+    case_ids: list[str], manifest: dict[str, dict[str, str]]
+) -> None:
+    """Fail-closed check: raise if ANY case lacks a resolvable mask member.
+
+    Never silently skip a patient -- surface every missing case at once so the
+    caller can bail before spending GPU time (matches this project's
+    fail-closed data-join review standard).
+    """
+    missing = []
+    for case_id in case_ids:
+        try:
+            _resolve_mask_member(case_id, manifest)
+        except (KeyError, ValueError) as exc:
+            missing.append(f"{case_id}: {exc}")
+    if missing:
+        raise ValueError(
+            "External breast masks missing for {} of {} case(s):\n  {}".format(
+                len(missing), len(case_ids), "\n  ".join(missing)
+            )
+        )
+
+
+def build_whole_breast_mask(
+    exam_id: str,
+    manifest: dict[str, dict[str, str]],
+    extract_dir: Path,
+    adapter: DatasetAdapter,
+    target_shape: tuple[int, int, int] | None = None,
+) -> np.ndarray:
+    """Extract + binarize + reorient one exam's whole-breast mask into STEP-1 space.
+
+    Returns a ``float16`` array in the same geometry/shape as the exam's STEP-1
+    preprocessed image. Applies the adapter's GEOMETRIC transform only (no
+    intensity normalization). If ``target_shape`` is given and does not match
+    after the transform, falls back to a ``torchio.Resize`` (the same convention
+    ``predict_breast_batched`` uses) and warns -- not expected for the
+    exact-grid-match smoke-test patients, but keeps the one documented
+    repaired-geometry manifest case safe.
+    """
+    archive_path, archive_member = _resolve_mask_member(exam_id, manifest)
+
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path) as tf:
+        tf.extract(archive_member, path=extract_dir)
+    mask_path = extract_dir / archive_member
+
+    mask_raw = sitk.GetArrayFromImage(sitk.ReadImage(str(mask_path)))
+    binary = (mask_raw > 0).astype(np.float32)
+    reoriented = adapter.preprocess(binary)
+
+    if target_shape is not None and reoriented.shape != tuple(target_shape):
+        import torchio as tio
+
+        print(
+            f"  [warn] {exam_id}: mask shape {reoriented.shape} != target "
+            f"{tuple(target_shape)}; resizing (torchio.Resize)."
+        )
+        resized = tio.Resize(tuple(target_shape))(reoriented[np.newaxis])
+        reoriented = np.squeeze(resized)
+
+    return reoriented.astype(np.float16)
+
+
+def build_external_step2_dir(
+    base_name_to_case: dict[str, str],
+    step1_dir: Path,
+    manifest_csv: str | Path,
+    out_dir: Path,
+    adapter: DatasetAdapter,
+    persist_copy_dir: Path | None = None,
+) -> dict[str, dict]:
+    """Populate ``out_dir`` (a step2-shaped dir) from external whole-breast masks.
+
+    ``base_name_to_case`` maps each STEP-1 basename (``{case_id}_{phase_stem}``)
+    to its exam ``case_id`` -- exactly what ``preprocess_parallel`` returns. One
+    mask is built per exam (from phase 0) and written to EVERY phase's STEP-1
+    basename for that exam (the no-motion-correction reuse-across-phases
+    approximation; see module docstring).
+
+    Fail-closed: validates all case_ids up front. Writes ``{basename}.npy``
+    (float16, native STEP-1 shape) matching STEP-3's ``additional_input_dir``
+    contract. If ``persist_copy_dir`` is given, also writes a copy there
+    (outside any --cleanup temp dir) so a later comparison can read the exact
+    masks that were used.
+    """
+    step1_dir = Path(step1_dir)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if persist_copy_dir is not None:
+        persist_copy_dir = Path(persist_copy_dir)
+        persist_copy_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_manifest(manifest_csv)
+    case_ids = sorted(set(base_name_to_case.values()))
+    validate_masks_available(case_ids, manifest)
+
+    # Group STEP-1 basenames by exam so each exam's mask is built exactly once.
+    phases_by_case: dict[str, list[str]] = {}
+    for base_name, case_id in base_name_to_case.items():
+        phases_by_case.setdefault(case_id, []).append(base_name)
+
+    extract_dir = out_dir / "_extracted_masks"
+    report: dict[str, dict] = {}
+    for case_id in case_ids:
+        target_shape = None
+        # native STEP-1 shape for this exam (any of its phases; all identical)
+        for base_name in phases_by_case[case_id]:
+            step1_file = step1_dir / f"{base_name}.npy"
+            if step1_file.exists():
+                target_shape = np.load(step1_file, mmap_mode="r").shape
+                break
+
+        mask = build_whole_breast_mask(
+            case_id, manifest, extract_dir, adapter, target_shape=target_shape
+        )
+
+        n_written = 0
+        for base_name in phases_by_case[case_id]:
+            np.save(out_dir / f"{base_name}.npy", mask)
+            if persist_copy_dir is not None:
+                np.save(persist_copy_dir / f"{base_name}.npy", mask)
+            n_written += 1
+
+        _, archive_member = _resolve_mask_member(case_id, manifest)
+        report[case_id] = {
+            "n_phases": n_written,
+            "mask_shape": tuple(int(s) for s in mask.shape),
+            "mask_voxel_count": int((mask > 0).sum()),
+            "source_member": archive_member,
+        }
+        print(
+            f"  [ok] {case_id}: mask {report[case_id]['mask_shape']} "
+            f"({report[case_id]['mask_voxel_count']} breast voxels) "
+            f"-> {n_written} phase(s)"
+        )
+
+    return report
+
+
+def _cli() -> None:
+    """Standalone conversion, for debugging against an existing STEP-1 dir."""
+    import argparse
+    import sys
+
+    here = Path(__file__).resolve().parent
+    repo_root = here.parent
+    for p in (str(repo_root), str(here)):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    from cohorts.uchicago import UChicagoDataset
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--step1-dir", required=True, type=Path)
+    ap.add_argument("--out-dir", required=True, type=Path)
+    ap.add_argument("--manifest-csv", default=DEFAULT_MANIFEST_CSV)
+    ap.add_argument(
+        "--dataset-root",
+        default="/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest",
+    )
+    args = ap.parse_args()
+
+    # Reconstruct base_name -> case_id from the STEP-1 dir. UChicago basenames
+    # are {case_id}_phase_XXXX; strip the trailing _phase_XXXX to get case_id.
+    base_name_to_case = {}
+    for npy in sorted(args.step1_dir.glob("*.npy")):
+        base = npy.stem
+        case_id = base.rsplit("_phase_", 1)[0]
+        base_name_to_case[base] = case_id
+
+    adapter = UChicagoDataset(root=args.dataset_root)
+    report = build_external_step2_dir(
+        base_name_to_case, args.step1_dir, args.manifest_csv, args.out_dir, adapter
+    )
+    print(f"\n[done] {len(report)} exam(s) -> {args.out_dir}")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/segmentation/slurm/submit_uchicago_orientation_check.slurm
+++ b/segmentation/slurm/submit_uchicago_orientation_check.slurm
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uc-orient
+#SBATCH --partition=gpuq
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=00:40:00
+#SBATCH --output=logs/uc-orient-%j.out
+#SBATCH --error=logs/uc-orient-%j.err
+
+set -eo pipefail
+
+# Scores the three candidate UChicagoDataset.preprocess transforms (passthrough,
+# mirrored, order_only) against the BreastDivider ground-truth breast masks, by
+# running the pinned breast model on one phase-0 case per sub-source under each.
+#
+# Why this and not the smoke test: the smoke test only proves inference RUNS.
+# `mirrored` and `order_only` produce identically-shaped arrays, so both run --
+# they differ only in whether the anatomy is left-right reflected. Only scoring
+# against ground truth separates them. See the script docstring.
+#
+# Submit from the repo root:
+#   PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_orientation_check.slurm
+
+cd "${PROJECT_ROOT}"
+source ~/.bashrc || true
+micromamba activate vanguard || true
+
+WORK_DIR="/tmp/uc_orient_${SLURM_JOB_ID:-local}"
+mkdir -p "${WORK_DIR}" results
+trap 'rm -rf "${WORK_DIR}" || true' EXIT
+
+BREAST_MODEL="${BREAST_MODEL:-${PROJECT_ROOT}/vanguard-blood-vessel-segmentation/trained_models/breast_model.pth}"
+OUT_CSV="${OUT_CSV:-${PROJECT_ROOT}/results/uchicago_orientation_check.csv}"
+
+echo "=== UChicago orientation check ==="
+echo "Node: $(hostname)  Date: $(date)"
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || true
+
+python -u "${PROJECT_ROOT}/scripts/validate_uchicago_orientation.py" \
+  --breast-model-path "${BREAST_MODEL}" \
+  --work-dir          "${WORK_DIR}" \
+  --out-csv           "${OUT_CSV}"
+
+echo "=== finished: $(date) ==="
+echo "Results: ${OUT_CSV}"

--- a/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
+++ b/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
@@ -51,11 +51,25 @@ VESSEL_MODEL="${VESSEL_MODEL:-${PROJECT_ROOT}/vanguard-blood-vessel-segmentation
 PATIENT_LIMIT="${PATIENT_LIMIT:-5}"
 BATCH_SIZE="${BATCH_SIZE:-16}"
 
+# CASE_IDS (optional): a file of case ids (one per line) or a comma-separated
+# list, selecting exactly which exams to run. Mutually exclusive with
+# PATIENT_LIMIT, which can only ever reach the FIRST N cases in discovery order
+# -- that is why the original smoke runs were all her2_naclike. Example:
+#   CASE_IDS=segmentation/slurm/uchicago_qc_cases_simbiosys_uch_nac.txt
+CASE_IDS="${CASE_IDS:-}"
+if [[ -n "${CASE_IDS}" ]]; then
+  SELECT_ARGS=(--case-ids "${CASE_IDS}")
+  SELECT_DESC="case ids from ${CASE_IDS}"
+else
+  SELECT_ARGS=(--patient-limit "${PATIENT_LIMIT}")
+  SELECT_DESC="first ${PATIENT_LIMIT} discovered patients"
+fi
+
 TMPDIR="/tmp/uc_seg_smoke_${SLURM_JOB_ID:-local}"
 mkdir -p "${TMPDIR}"
 trap 'rm -rf "${TMPDIR}" || true' EXIT
 
-echo "=== UChicago Segmentation Smoke Test (${PATIENT_LIMIT} patients) ==="
+echo "=== UChicago Segmentation Smoke Test (${SELECT_DESC}) ==="
 echo "Node: $(hostname)  GPU: ${CUDA_VISIBLE_DEVICES:-?}  Date: $(date)"
 echo "Manifest root: ${UCHICAGO_ROOT}"
 echo "Output: ${OUTPUT_DIR}"
@@ -68,7 +82,7 @@ python -u "${PROJECT_ROOT}/segmentation/batch_segmentation.py" \
   --temp-dir           "${TMPDIR}" \
   --breast-model-path  "${BREAST_MODEL}" \
   --vessel-model-path  "${VESSEL_MODEL}" \
-  --patient-limit      "${PATIENT_LIMIT}" \
+  "${SELECT_ARGS[@]}" \
   --batch-size         "${BATCH_SIZE}" \
   --num-workers        3 \
   --preprocess-workers 4 \

--- a/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
+++ b/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
@@ -21,13 +21,11 @@ set -eo pipefail
 # memory at once (Dataset3DSimple/Dataset3DDivided) -- 5 patients x 24 phases
 # = 120 full volumes resident at once.
 #
-# ORIENTATION (was a known risk; now checked): UChicagoDataset.preprocess() used
-# to be a pass-through, assuming the manifest's images already arrived correctly
-# oriented for this model. That was wrong -- it fed mis-oriented volumes in and
-# crashed inference on a tiling-coverage assertion. preprocess() now flips x/z
-# (RAS -> LAI) before the base reorientation; see cohorts/README.md. One residual
-# unknown: a pure left-right mirror can't be ruled out from near-symmetric breast
-# anatomy, so treat left/right-specific conclusions from this run as provisional.
+# ORIENTATION: HFDP already canonicalized the anatomical axis directions.
+# SimpleITK returns each phase as (z, y, x), so UChicagoDataset.preprocess()
+# converts array order only to the model's (y, x, z). A pass-through put the thin
+# slice axis in the wrong model dimension; header-derived flips overcorrected the
+# data. See cohorts/README.md for the validated source-to-model contract.
 #
 # Submit from the repo root:
 #   PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_segmentation_smoke.slurm

--- a/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
+++ b/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uc-seg-smoke
+#SBATCH --partition=gpuq
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/uc-seg-smoke-%j.out
+#SBATCH --error=logs/uc-seg-smoke-%j.err
+set -eo pipefail
+
+# Step 4d smoke test: batch vessel segmentation on 5 real UChicago patients,
+# via the newly-wired --dataset-name uchicago adapter path (see Step 4d commit
+# message). Writes to a SEPARATE scratch output dir; cannot disturb any
+# existing MAMA-MIA segmentation output.
+#
+# KNOWN, ACCEPTED RISK (explicitly not verified before this run): UChicagoDataset
+# .preprocess() is a pass-through -- it assumes the manifest's images are
+# already correctly oriented for this model. That assumption has not been
+# checked against real UChicago volumes. If it's wrong, this will not error --
+# it will silently produce garbage segmentations. Treat any output from this
+# run as exploratory until that assumption is verified.
+#
+# Submit from the repo root:
+#   PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
+
+source ~/.bashrc || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+export xml_catalog_files_libxml2=""
+
+PROJECT_ROOT="${PROJECT_ROOT:?PROJECT_ROOT must be set, e.g. PROJECT_ROOT=\$(pwd) sbatch ... from the repo root}"
+mkdir -p logs
+
+export OMP_NUM_THREADS=2
+export MKL_NUM_THREADS=2
+export PYTHONUNBUFFERED=1
+
+UCHICAGO_ROOT="${UCHICAGO_ROOT:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest}"
+OUTPUT_DIR="${OUTPUT_DIR:-/ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke}"
+BREAST_MODEL="${BREAST_MODEL:-${PROJECT_ROOT}/vanguard-blood-vessel-segmentation/trained_models/breast_model.pth}"
+VESSEL_MODEL="${VESSEL_MODEL:-${PROJECT_ROOT}/vanguard-blood-vessel-segmentation/trained_models/dv_model.pth}"
+PATIENT_LIMIT="${PATIENT_LIMIT:-5}"
+BATCH_SIZE="${BATCH_SIZE:-16}"
+
+TMPDIR="/tmp/uc_seg_smoke_${SLURM_JOB_ID:-local}"
+mkdir -p "${TMPDIR}"
+trap 'rm -rf "${TMPDIR}" || true' EXIT
+
+echo "=== UChicago Segmentation Smoke Test (${PATIENT_LIMIT} patients) ==="
+echo "Node: $(hostname)  GPU: ${CUDA_VISIBLE_DEVICES:-?}  Date: $(date)"
+echo "Manifest root: ${UCHICAGO_ROOT}"
+echo "Output: ${OUTPUT_DIR}"
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || true
+
+python -u "${PROJECT_ROOT}/segmentation/batch_segmentation.py" \
+  --dataset-name       uchicago \
+  --dataset-root       "${UCHICAGO_ROOT}" \
+  --output-dir         "${OUTPUT_DIR}" \
+  --temp-dir           "${TMPDIR}" \
+  --breast-model-path  "${BREAST_MODEL}" \
+  --vessel-model-path  "${VESSEL_MODEL}" \
+  --patient-limit      "${PATIENT_LIMIT}" \
+  --batch-size         "${BATCH_SIZE}" \
+  --num-workers        3 \
+  --preprocess-workers 4 \
+  --cleanup
+
+echo "=== Smoke test finished: $(date) ==="
+echo "Outputs under: ${OUTPUT_DIR}"

--- a/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
+++ b/segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
@@ -3,7 +3,7 @@
 #SBATCH --partition=gpuq
 #SBATCH --gres=gpu:1
 #SBATCH --cpus-per-task=4
-#SBATCH --mem=32G
+#SBATCH --mem=128G
 #SBATCH --time=01:00:00
 #SBATCH --output=logs/uc-seg-smoke-%j.out
 #SBATCH --error=logs/uc-seg-smoke-%j.err
@@ -14,12 +14,20 @@ set -eo pipefail
 # message). Writes to a SEPARATE scratch output dir; cannot disturb any
 # existing MAMA-MIA segmentation output.
 #
-# KNOWN, ACCEPTED RISK (explicitly not verified before this run): UChicagoDataset
-# .preprocess() is a pass-through -- it assumes the manifest's images are
-# already correctly oriented for this model. That assumption has not been
-# checked against real UChicago volumes. If it's wrong, this will not error --
-# it will silently produce garbage segmentations. Treat any output from this
-# run as exploratory until that assumption is verified.
+# --mem=128G (vs. 32G in the analogous MAMA-MIA smoke script) is not a guess:
+# a first run at 32G was OOM-killed during inference. UChicago has ~24 phases
+# per patient at larger volume dimensions vs. MAMA-MIA's ~4-6, and
+# run_inference_in_process loads every volume for the current stage into
+# memory at once (Dataset3DSimple/Dataset3DDivided) -- 5 patients x 24 phases
+# = 120 full volumes resident at once.
+#
+# ORIENTATION (was a known risk; now checked): UChicagoDataset.preprocess() used
+# to be a pass-through, assuming the manifest's images already arrived correctly
+# oriented for this model. That was wrong -- it fed mis-oriented volumes in and
+# crashed inference on a tiling-coverage assertion. preprocess() now flips x/z
+# (RAS -> LAI) before the base reorientation; see cohorts/README.md. One residual
+# unknown: a pure left-right mirror can't be ruled out from near-symmetric breast
+# anatomy, so treat left/right-specific conclusions from this run as provisional.
 #
 # Submit from the repo root:
 #   PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_segmentation_smoke.slurm

--- a/segmentation/slurm/submit_uchicago_segmentation_smoke_external_breast.slurm
+++ b/segmentation/slurm/submit_uchicago_segmentation_smoke_external_breast.slurm
@@ -55,11 +55,22 @@ PERSIST_DIR="${PERSIST_DIR:-/ess/scratch/scratch1/t-9sbose/uchicago_breast_masks
 PATIENT_LIMIT="${PATIENT_LIMIT:-5}"
 BATCH_SIZE="${BATCH_SIZE:-16}"
 
+# CASE_IDS (optional): see submit_uchicago_segmentation_smoke.slurm -- selects
+# exams explicitly instead of taking the first PATIENT_LIMIT in discovery order.
+CASE_IDS="${CASE_IDS:-}"
+if [[ -n "${CASE_IDS}" ]]; then
+  SELECT_ARGS=(--case-ids "${CASE_IDS}")
+  SELECT_DESC="case ids from ${CASE_IDS}"
+else
+  SELECT_ARGS=(--patient-limit "${PATIENT_LIMIT}")
+  SELECT_DESC="first ${PATIENT_LIMIT} discovered patients"
+fi
+
 TMPDIR="/tmp/uc_seg_smoke_ext_${SLURM_JOB_ID:-local}"
 mkdir -p "${TMPDIR}" "${PERSIST_DIR}"
 trap 'rm -rf "${TMPDIR}" || true' EXIT
 
-echo "=== UChicago Segmentation Smoke Test -- EXTERNAL breast masks (${PATIENT_LIMIT} patients) ==="
+echo "=== UChicago Segmentation Smoke Test -- EXTERNAL breast masks (${SELECT_DESC}) ==="
 echo "Node: $(hostname)  GPU: ${CUDA_VISIBLE_DEVICES:-?}  Date: $(date)"
 echo "Manifest root: ${UCHICAGO_ROOT}"
 echo "Output: ${OUTPUT_DIR}"
@@ -73,7 +84,7 @@ python -u "${PROJECT_ROOT}/segmentation/batch_segmentation.py" \
   --temp-dir           "${TMPDIR}" \
   --breast-model-path  "${BREAST_MODEL}" \
   --vessel-model-path  "${VESSEL_MODEL}" \
-  --patient-limit      "${PATIENT_LIMIT}" \
+  "${SELECT_ARGS[@]}" \
   --batch-size         "${BATCH_SIZE}" \
   --num-workers        3 \
   --preprocess-workers 4 \

--- a/segmentation/slurm/submit_uchicago_segmentation_smoke_external_breast.slurm
+++ b/segmentation/slurm/submit_uchicago_segmentation_smoke_external_breast.slurm
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uc-seg-smoke-ext
+#SBATCH --partition=gpuq
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=128G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/uc-seg-smoke-ext-%j.out
+#SBATCH --error=logs/uc-seg-smoke-ext-%j.err
+set -eo pipefail
+
+# External-breast-mask counterpart to submit_uchicago_segmentation_smoke.slurm.
+# Same 5 UChicago patients, same vessel model, but STEP-2 breast-model
+# inference is REPLACED with the ground-truth BreastDivider whole-breast masks
+# shipped in the manifest TAR (--use-external-breast-masks). This isolates
+# whether real breast masks change the vessel segmentation outcome vs. the
+# model-predicted-breast-mask baseline.
+#
+# BASELINE TO COMPARE AGAINST:
+#   /ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke_v2
+#
+# CAVEAT (per mentor + data dictionary): there is ONE whole-breast mask per
+# exam, generated from phase 0 only, and this preprocessing build did NOT
+# include motion correction. The same phase-0 mask is therefore reused across
+# all ~24 dynamic phases of an exam -- a documented approximation (assumes the
+# breast does not move across phases), not a bug.
+#
+# Distinct OUTPUT_DIR and TMPDIR (with an _ext_ prefix) so this can never
+# collide with or race against the baseline run -- a concurrency bug this
+# session already hit once (see LAB_NOTEBOOK.md, 2026-07-13). RUN THIS SOLO:
+# confirm `squeue -u $USER` shows no other uc-seg-smoke job first.
+#
+# Submit from the repo root:
+#   PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_segmentation_smoke_external_breast.slurm
+
+source ~/.bashrc || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+export xml_catalog_files_libxml2=""
+
+PROJECT_ROOT="${PROJECT_ROOT:?PROJECT_ROOT must be set, e.g. PROJECT_ROOT=\$(pwd) sbatch ... from the repo root}"
+mkdir -p logs
+
+export OMP_NUM_THREADS=2
+export MKL_NUM_THREADS=2
+export PYTHONUNBUFFERED=1
+
+UCHICAGO_ROOT="${UCHICAGO_ROOT:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest}"
+OUTPUT_DIR="${OUTPUT_DIR:-/ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke_external_breast}"
+VESSEL_MODEL="${VESSEL_MODEL:-${PROJECT_ROOT}/vanguard-blood-vessel-segmentation/trained_models/dv_model.pth}"
+BREAST_MODEL="${BREAST_MODEL:-${PROJECT_ROOT}/vanguard-blood-vessel-segmentation/trained_models/breast_model.pth}"
+# Persist the converted external masks outside the (cleaned) temp dir so the
+# comparison script can read exactly what STEP-3 consumed.
+PERSIST_DIR="${PERSIST_DIR:-/ess/scratch/scratch1/t-9sbose/uchicago_breast_masks_external}"
+PATIENT_LIMIT="${PATIENT_LIMIT:-5}"
+BATCH_SIZE="${BATCH_SIZE:-16}"
+
+TMPDIR="/tmp/uc_seg_smoke_ext_${SLURM_JOB_ID:-local}"
+mkdir -p "${TMPDIR}" "${PERSIST_DIR}"
+trap 'rm -rf "${TMPDIR}" || true' EXIT
+
+echo "=== UChicago Segmentation Smoke Test -- EXTERNAL breast masks (${PATIENT_LIMIT} patients) ==="
+echo "Node: $(hostname)  GPU: ${CUDA_VISIBLE_DEVICES:-?}  Date: $(date)"
+echo "Manifest root: ${UCHICAGO_ROOT}"
+echo "Output: ${OUTPUT_DIR}"
+echo "Persisted external masks: ${PERSIST_DIR}"
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || true
+
+python -u "${PROJECT_ROOT}/segmentation/batch_segmentation.py" \
+  --dataset-name       uchicago \
+  --dataset-root       "${UCHICAGO_ROOT}" \
+  --output-dir         "${OUTPUT_DIR}" \
+  --temp-dir           "${TMPDIR}" \
+  --breast-model-path  "${BREAST_MODEL}" \
+  --vessel-model-path  "${VESSEL_MODEL}" \
+  --patient-limit      "${PATIENT_LIMIT}" \
+  --batch-size         "${BATCH_SIZE}" \
+  --num-workers        3 \
+  --preprocess-workers 4 \
+  --use-external-breast-masks \
+  --external-breast-mask-persist-dir "${PERSIST_DIR}" \
+  --cleanup
+
+echo "=== Smoke test (external breast masks) finished: $(date) ==="
+echo "Outputs under: ${OUTPUT_DIR}"
+echo "Compare against baseline: /ess/scratch/scratch1/t-9sbose/uchicago_vessel_segmentations_smoke_v2"

--- a/segmentation/slurm/uchicago_qc_cases_simbiosys_uch_nac.txt
+++ b/segmentation/slurm/uchicago_qc_cases_simbiosys_uch_nac.txt
@@ -1,0 +1,24 @@
+# UChicago QC cases: the first 3 exams of each of the two sub-sources that the
+# original 5-patient smoke test never reached.
+#
+# --patient-limit N can only take the FIRST N cases in discovery order, and the
+# manifest is grouped by sub-source (simbiosys, then uch_nac, then her2_naclike
+# -- and discovery order puts her2_naclike's exams first). That is the only
+# reason every earlier smoke run was 100% her2_naclike: not a sampling choice,
+# an artifact of the limit flag. Pass this file to batch_segmentation.py's
+# --case-ids to select explicitly instead.
+#
+# Selection rule (deterministic, no cherry-picking): the first 3 exams of each
+# sub-source in manifest/discovery order -- the same "first N in discovery
+# order" rule that chose the her2_naclike 5. All 6 have ground-truth
+# BreastDivider whole-breast masks in the manifest TAR, so the external-mask
+# run's fail-closed validation passes for all of them.
+#
+# simbiosys (86 exams in the manifest)
+simbiosys_1_3_1182546865420849063085610933350647997753785791330
+simbiosys_1_3_762581036591479695896658294531625749619654724689
+simbiosys_1_3_1105771244081795911622875098820358030057064206519
+# uch_nac (60 exams in the manifest)
+uch_nac_1_3_1019907248185347538207292859618046285193584113217
+uch_nac_1_3_308777118052852895330150307412056530807398339215
+uch_nac_1_3_1250630811977034081483705511958488817669131375036

--- a/segmentation/slurm/uchicago_rerun_cases_all_subsources.txt
+++ b/segmentation/slurm/uchicago_rerun_cases_all_subsources.txt
@@ -1,0 +1,15 @@
+# UChicago rerun cases: 2 exams per sub-source (all three covered).
+# Deterministic: first 2 exam_ids of each 'dataset' group, manifest order.
+# Used for the 2026-07-14 re-run of the vessel smoke test on the CORRECTED
+# preprocess() (Anna's a8f8bcb, array-order only). The earlier 5-patient runs
+# were all her2_naclike AND ran under the mirrored transform -- both fixed here.
+#
+# her2_naclike
+her2_naclike_1_3_460916236258738760757611796646821159407878075922
+her2_naclike_1_3_832679562131043796836036911926759503134022916607
+# simbiosys
+simbiosys_1_3_1182546865420849063085610933350647997753785791330
+simbiosys_1_3_762581036591479695896658294531625749619654724689
+# uch_nac
+uch_nac_1_3_1019907248185347538207292859618046285193584113217
+uch_nac_1_3_308777118052852895330150307412056530807398339215

--- a/segmentation/tests/test_adapter_seam.py
+++ b/segmentation/tests/test_adapter_seam.py
@@ -1,14 +1,21 @@
 """CPU test: the Step 4 dataset-adapter seam in the segmentation stage.
 
-Two seams were added to ``batch_segmentation`` behind a ``None``-fallback
-(Step 4 of the multi-dataset migration, see cohorts/README.md):
+Seams added to ``batch_segmentation`` behind a ``None``-fallback (Step 4 of the
+multi-dataset migration, see cohorts/README.md):
 
 1. ``preprocess_image`` takes its geometry reorientation from
    ``adapter.preprocess`` instead of the hardcoded MAMA-MIA axis transform.
 2. ``build_output_path`` takes the top-level ``source`` directory from
    ``adapter.case_dataset_name`` instead of the ``case_id.split("_")[0]`` prefix.
+3. ``find_case_files`` routes case/file discovery through
+   ``adapter.discover_cases()``/``load_timepoints()`` instead of assuming the
+   MAMA-MIA ``<images_dir>/<case_id>/*.nii.gz`` layout.
+4. ``_base_name_for`` prefixes the intermediate-file base name with ``case_id``
+   when an adapter is given, so cases whose phase files share identical names
+   across patients (UChicago's ``phase_0000.nii.gz`` for every exam) don't
+   collide in the flat step1/step2/step3 intermediate directories.
 
-This checks both invariants Step 4 must hold, on tiny synthetic data, CPU only
+This checks the invariants Step 4 must hold, on tiny synthetic data, CPU only
 (safe for the login node):
 
 * Adapter OFF vs. a MAMA-MIA adapter is byte-identical (the adapter encodes
@@ -42,12 +49,16 @@ for _p in (str(_SEG_DIR), str(_PROJECT_ROOT)):
         sys.path.insert(0, _p)
 
 from batch_segmentation import (  # noqa: E402
+    _base_name_for,
     build_output_path,
+    find_case_files,
+    find_nii_files,
     preprocess_image,
 )
 
 from cohorts.base import DatasetAdapter  # noqa: E402
 from cohorts.mamamia import MamaMiaDataset  # noqa: E402
+from cohorts.uchicago import UChicagoDataset  # noqa: E402
 
 
 class _PassThroughAdapter(DatasetAdapter):
@@ -70,6 +81,25 @@ def _write_nii(path: Path, arr: np.ndarray) -> None:
     """Write ``arr`` (z, y, x order) as a .nii.gz at ``path``."""
     path.parent.mkdir(parents=True, exist_ok=True)
     sitk.WriteImage(sitk.GetImageFromArray(arr), str(path))
+
+
+def _write_uchicago_manifest(tmp: Path, exam_ids: list[str]) -> Path:
+    """Write a manifest where every exam's phase file is named identically.
+
+    Mirrors the real manifest's naming convention (``phase_0000.nii.gz`` for
+    every exam) -- exactly the collision risk ``_base_name_for`` exists to
+    prevent.
+    """
+    root = tmp / "uc"
+    rows = ["exam_id,dataset,patient_key,fold,pcr,phase_files"]
+    for i, exam_id in enumerate(exam_ids):
+        phase_path = root / "images" / "simbiosys" / exam_id / "phase_0000.nii.gz"
+        phase_path.parent.mkdir(parents=True, exist_ok=True)
+        phase_path.touch()
+        rows.append(f'{exam_id},simbiosys,p{i},0,1.0,"[""{phase_path.as_posix()}""]"')
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "dce2d_internal_ultrafast_manifest.csv").write_text("\n".join(rows) + "\n")
+    return root
 
 
 def main() -> int:  # noqa: C901
@@ -138,6 +168,68 @@ def main() -> int:  # noqa: C901
             f"pass-through={pt_source!r} -> seam live: {path_seam_live}"
         )
         ok = ok and path_seam_live
+
+        # 5. find_case_files: adapter OFF matches find_nii_files exactly.
+        mama_images = tmp / "mama_images"
+        (mama_images / "DUKE_001").mkdir(parents=True)
+        (mama_images / "DUKE_001" / "DUKE_001_0000.nii.gz").touch()
+        none_pairs = sorted((c, str(p)) for c, p in find_case_files(str(mama_images)))
+        direct_pairs = sorted((c, str(p)) for c, p in find_nii_files(str(mama_images)))
+        discovery_noop_identical = none_pairs == direct_pairs
+        print(
+            "[discovery] find_case_files(adapter=None) == find_nii_files: "
+            f"{discovery_noop_identical}"
+        )
+        ok = ok and discovery_noop_identical
+
+        # 6. find_case_files with an adapter discovers manifest-driven cases,
+        #    not a directory glob (UChicago-shaped: two cases, no <case_id>/
+        #    subdirectory of `images_dir` matching find_nii_files' assumption).
+        expected_uc_exam_ids = {"e1", "e2"}
+        uc_root = _write_uchicago_manifest(tmp, sorted(expected_uc_exam_ids))
+        uc_adapter = UChicagoDataset(root=uc_root)
+        uc_pairs = find_case_files(str(uc_root), adapter=uc_adapter)
+        uc_case_ids = {c for c, _ in uc_pairs}
+        manifest_discovery_ok = uc_case_ids == expected_uc_exam_ids and len(
+            uc_pairs
+        ) == len(expected_uc_exam_ids)
+        print(
+            f"[discovery] adapter-driven discovery finds manifest cases: "
+            f"{manifest_discovery_ok} (found {uc_case_ids})"
+        )
+        ok = ok and manifest_discovery_ok
+
+        # 7. find_case_files honors case_limit at case granularity.
+        uc_limited = find_case_files(str(uc_root), adapter=uc_adapter, case_limit=1)
+        case_limit_ok = len({c for c, _ in uc_limited}) == 1
+        print(f"[discovery] case_limit=1 yields exactly one case: {case_limit_ok}")
+        ok = ok and case_limit_ok
+
+        # 8. _base_name_for: no collision across cases with identically-named
+        #    phase files (the real UChicago manifest names every exam's first
+        #    phase "phase_0000.nii.gz" -- without the case_id prefix, e1 and
+        #    e2 would silently overwrite each other's intermediate .npy file).
+        uc_base_names = {
+            _base_name_for(case_id, file_path, uc_adapter)
+            for case_id, file_path in uc_pairs
+        }
+        no_collision = len(uc_base_names) == len(uc_pairs)
+        print(
+            f"[discovery] adapter-driven base names are collision-free: "
+            f"{no_collision} ({sorted(uc_base_names)})"
+        )
+        ok = ok and no_collision
+
+        # 9. _base_name_for is unchanged (bare stem, no prefix) when adapter=None.
+        mama_base_name = _base_name_for(
+            "DUKE_001", str(mama_images / "DUKE_001" / "DUKE_001_0000.nii.gz"), None
+        )
+        base_name_noop_identical = mama_base_name == "DUKE_001_0000"
+        print(
+            "[discovery] _base_name_for(adapter=None) unchanged: "
+            f"{base_name_noop_identical} ({mama_base_name!r})"
+        )
+        ok = ok and base_name_noop_identical
 
     if ok:
         print("\nPASS: segmentation adapter seam is a no-op for MAMA-MIA and live.")

--- a/segmentation/tests/test_adapter_seam.py
+++ b/segmentation/tests/test_adapter_seam.py
@@ -1,0 +1,150 @@
+"""CPU test: the Step 4 dataset-adapter seam in the segmentation stage.
+
+Two seams were added to ``batch_segmentation`` behind a ``None``-fallback
+(Step 4 of the multi-dataset migration, see cohorts/README.md):
+
+1. ``preprocess_image`` takes its geometry reorientation from
+   ``adapter.preprocess`` instead of the hardcoded MAMA-MIA axis transform.
+2. ``build_output_path`` takes the top-level ``source`` directory from
+   ``adapter.case_dataset_name`` instead of the ``case_id.split("_")[0]`` prefix.
+
+This checks both invariants Step 4 must hold, on tiny synthetic data, CPU only
+(safe for the login node):
+
+* Adapter OFF vs. a MAMA-MIA adapter is byte-identical (the adapter encodes
+  exactly today's behavior, so it must change nothing).
+* The seam is actually live: an adapter with a pass-through ``preprocess`` and a
+  different ``case_dataset_name`` (UChicago-shaped) routes through, producing a
+  different preprocessed array and a different output directory.
+
+This lives in ``segmentation/tests/`` (not the CI-collected top-level ``tests/``)
+because importing ``batch_segmentation`` pulls in torch and the vessel-seg
+submodule, which the CI image does not carry. The adapter methods themselves are
+covered CI-safely in ``tests/test_cohort_adapters.py``.
+
+Run:  python segmentation/tests/test_adapter_seam.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import SimpleITK as sitk
+
+HERE = Path(__file__).resolve().parent
+_SEG_DIR = HERE.parent
+_PROJECT_ROOT = _SEG_DIR.parent
+for _p in (str(_SEG_DIR), str(_PROJECT_ROOT)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from batch_segmentation import (  # noqa: E402
+    build_output_path,
+    preprocess_image,
+)
+
+from cohorts.base import DatasetAdapter  # noqa: E402
+from cohorts.mamamia import MamaMiaDataset  # noqa: E402
+
+
+class _PassThroughAdapter(DatasetAdapter):
+    """A UChicago-shaped adapter: no geometry transform, sub-source identity.
+
+    Mirrors the two ways UChicago differs from MAMA-MIA at this stage without
+    needing a real manifest on disk: ``preprocess`` is a pass-through (data is
+    already oriented) and ``case_dataset_name`` returns a fixed sub-source rather
+    than a case-id prefix.
+    """
+
+    def preprocess(self, volume: np.ndarray) -> np.ndarray:
+        return volume
+
+    def case_dataset_name(self, case_id: str) -> str:
+        return "uchicago_subsource"
+
+
+def _write_nii(path: Path, arr: np.ndarray) -> None:
+    """Write ``arr`` (z, y, x order) as a .nii.gz at ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sitk.WriteImage(sitk.GetImageFromArray(arr), str(path))
+
+
+def main() -> int:  # noqa: C901
+    """Run the segmentation adapter-seam checks."""
+    rng = np.random.default_rng(0)
+    ok = True
+
+    with tempfile.TemporaryDirectory() as tmp_name:
+        tmp = Path(tmp_name)
+        # Asymmetric shape so the axis transform is observable (a symmetric
+        # cube could hide a wrong/absent transform).
+        arr = rng.random((6, 8, 10)).astype(np.float32)
+        nii = tmp / "DUKE_001" / "DUKE_001_0000.nii.gz"
+        _write_nii(nii, arr)
+
+        mamamia = MamaMiaDataset(cohort="duke", root=tmp)
+        passthrough = _PassThroughAdapter(root=tmp)
+
+        # 1. preprocess_image: adapter OFF vs. MAMA-MIA adapter is byte-identical.
+        off_npy = tmp / "off.npy"
+        mm_npy = tmp / "mm.npy"
+        pt_npy = tmp / "pt.npy"
+        preprocess_image(str(nii), str(off_npy))
+        preprocess_image(str(nii), str(mm_npy), adapter=mamamia)
+        preprocess_image(str(nii), str(pt_npy), adapter=passthrough)
+
+        off = np.load(off_npy)
+        mm = np.load(mm_npy)
+        pt = np.load(pt_npy)
+
+        # equal_nan: normalize_image can emit NaN on degenerate tiny inputs; both
+        # paths run the identical transform + normalize, so NaNs land in identical
+        # positions. We assert element-wise equality treating those as equal.
+        noop_identical = np.array_equal(off, mm, equal_nan=True)
+        print(f"[preprocess] MAMA-MIA adapter == adapter-off: {noop_identical}")
+        ok = ok and noop_identical
+
+        # 2. The seam is live: pass-through orientation differs from the MAMA-MIA
+        #    transform (different shape once axes are no longer swapped).
+        seam_live = not np.array_equal(off, pt) and off.shape != pt.shape
+        print(
+            f"[preprocess] pass-through adapter differs from MAMA-MIA transform: "
+            f"{seam_live} (off.shape={off.shape}, passthrough.shape={pt.shape})"
+        )
+        ok = ok and seam_live
+
+        # 3. build_output_path: adapter OFF vs. MAMA-MIA adapter is byte-identical.
+        out_root = tmp / "out"
+        off_path = build_output_path(out_root, "DUKE_001", "DUKE_001_0000")
+        mm_path = build_output_path(
+            out_root, "DUKE_001", "DUKE_001_0000", adapter=mamamia
+        )
+        path_noop_identical = off_path == mm_path
+        print(f"[output_path] MAMA-MIA adapter == adapter-off: {path_noop_identical}")
+        ok = ok and path_noop_identical
+
+        # 4. The seam is live: the sub-source adapter changes the top-level dir.
+        pt_path = build_output_path(
+            out_root, "DUKE_001", "DUKE_001_0000", adapter=passthrough
+        )
+        off_source = off_path.relative_to(out_root).parts[0]
+        pt_source = pt_path.relative_to(out_root).parts[0]
+        path_seam_live = off_source == "DUKE" and pt_source == "uchicago_subsource"
+        print(
+            f"[output_path] source dir: adapter-off={off_source!r}, "
+            f"pass-through={pt_source!r} -> seam live: {path_seam_live}"
+        )
+        ok = ok and path_seam_live
+
+    if ok:
+        print("\nPASS: segmentation adapter seam is a no-op for MAMA-MIA and live.")
+        return 0
+    print("\nFAIL: adapter seam did not behave as expected.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tabular/train.py
+++ b/tabular/train.py
@@ -54,9 +54,14 @@ def run_evaluation_pipeline(
     df: pd.DataFrame,
     config: dict[str, Any],
     outdir: Path,
+    report_by: str | None = None,
     group_col_from_adapter: bool = False,
 ) -> None:
     """Run evaluator-based cross-validation over configured model/features.
+
+    ``report_by`` (a dataset adapter's ``report_by`` column, e.g. UChicago's
+    ``dataset`` sub-source) drives the per-subgroup QC breakdown (Step 4); when
+    ``None`` -- every non-adapter run -- behavior is unchanged.
 
     ``group_col_from_adapter`` must be ``True`` only when the caller actually
     populated ``model_params.group_col`` from an adapter identity key (via
@@ -65,7 +70,10 @@ def run_evaluation_pipeline(
     ``config`` alone.
     """
     context = prepare_evaluation_context(
-        df, config, group_col_from_adapter=group_col_from_adapter
+        df,
+        config,
+        report_by=report_by,
+        group_col_from_adapter=group_col_from_adapter,
     )
     fold_results_list, nested_rows = run_cross_validation_from_context(context)
 
@@ -99,7 +107,9 @@ def run_evaluation_pipeline(
     kfold_results = context["evaluator"].aggregate_kfold_results(fold_results_list)
 
     logging.info("Saving evaluator outputs to: %s", outdir)
-    context["evaluator"].save_results(kfold_results, outdir)
+    context["evaluator"].save_results(
+        kfold_results, outdir, report_by=context.get("report_by")
+    )
 
     print("\n" + "=" * 48)
     print(f"Plots saved in: {outdir / context['evaluator'].model_name / 'plots'}")
@@ -109,9 +119,14 @@ def run_evaluation_pipeline(
 def prepare_evaluation_context(
     df: pd.DataFrame,
     config: dict[str, Any],
+    report_by: str | None = None,
     group_col_from_adapter: bool = False,
 ) -> dict[str, Any]:
     """Prepare evaluator inputs and deterministic fold splits for a config.
+
+    ``report_by`` names an optional per-case subgroup column (a dataset adapter's
+    ``report_by``, Step 4) attached to each fold's predictions for the QC
+    breakdown; ``None`` (every non-adapter run) leaves predictions unchanged.
 
     ``group_col_from_adapter`` must be ``True`` only when the caller populated
     ``model_params.group_col`` from an adapter identity key (``_apply_group_keys``
@@ -204,6 +219,7 @@ def prepare_evaluation_context(
         "feature_select_enabled": feature_select_enabled,
         "nested_tune_enabled": nested_tune_enabled,
         "stratum_col": stratum_col,
+        "report_by": report_by,
         "X": X,
         "y": y,
         "case_ids": case_ids,
@@ -231,6 +247,7 @@ def run_single_fold_from_context(
     nested_tune_enabled = context["nested_tune_enabled"]
     feature_select_enabled = context["feature_select_enabled"]
     stratum_col = context["stratum_col"]
+    report_by = context.get("report_by")
 
     logging.info("Processing fold %d", split.fold_idx)
     train_idx = split.train_indices
@@ -289,6 +306,15 @@ def run_single_fold_from_context(
     )
     if stratum_col and stratum_col in cohort_df.columns:
         pred_df["stratum"] = cohort_df.iloc[val_idx][stratum_col].astype(str).to_numpy()
+    # QC subgroup column from the dataset adapter's report_by (Step 4): attach it
+    # so save_results can break metrics down by sub-source. None for non-adapter
+    # runs, so predictions are unchanged.
+    if (
+        report_by
+        and report_by in cohort_df.columns
+        and report_by not in pred_df.columns
+    ):
+        pred_df[report_by] = cohort_df.iloc[val_idx][report_by].astype(str).to_numpy()
 
     return (
         FoldResults(fold_idx=split.fold_idx, predictions=pred_df),
@@ -474,6 +500,7 @@ def run_pipeline_from_config(
     if adapter is not None:
         logging.info("Using dataset adapter: %s", type(adapter).__name__)
 
+    report_by = adapter.report_by if adapter is not None else None
     group_col_from_adapter = False
     try:
         merged_data = prepare_data(config, outdir, adapter=adapter)
@@ -489,7 +516,11 @@ def run_pipeline_from_config(
             if group_col_from_adapter:
                 merged_data = _apply_group_keys(merged_data, config, adapter)
         run_evaluation_pipeline(
-            merged_data, config, outdir, group_col_from_adapter=group_col_from_adapter
+            merged_data,
+            config,
+            outdir,
+            report_by=report_by,
+            group_col_from_adapter=group_col_from_adapter,
         )
     except Exception as exc:  # noqa: BLE001
         logging.error("Pipeline failed: %s", exc, exc_info=True)

--- a/tabular/train.py
+++ b/tabular/train.py
@@ -372,8 +372,10 @@ def _apply_provided_folds(
     both train and validation), this validates rather than trusts, and raises on
     anything unsafe:
 
-    - ``split_col`` must not collide with ``case_id`` or the configured label
-      column (it would overwrite real data);
+    - ``split_col`` must not already be a column in ``feats_df`` (it would
+      silently drop and overwrite whatever that column held -- ``case_id`` and
+      the label column included, but not limited to them: any real feature or
+      metadata column of the same name is just as unsafe to clobber);
     - the provided folds must map each ``case_id`` at most once, and the merge is
       ``validate="one_to_one"`` so a duplicate on either side is an error, not a
       row-exploding leak;
@@ -389,11 +391,12 @@ def _apply_provided_folds(
         return feats_df
 
     split_col = str(config.model_params.split_col)
-    label_col = str(config.data_paths.label_column)
-    if split_col in {"case_id", label_col}:
+    if split_col in feats_df.columns:
         raise ValueError(
-            f"model_params.split_col={split_col!r} collides with a reserved column "
-            f"('case_id' or the label column {label_col!r}); choose another name."
+            f"model_params.split_col={split_col!r} collides with an existing "
+            "column in the feature table; attaching provided folds under that "
+            "name would silently drop and overwrite it. Choose a different "
+            "model_params.split_col."
         )
 
     dup_folds = folds["case_id"][folds["case_id"].duplicated()].unique().tolist()
@@ -404,8 +407,6 @@ def _apply_provided_folds(
         )
 
     folds = folds.rename(columns={"fold": split_col})
-    if split_col in feats_df.columns:
-        feats_df = feats_df.drop(columns=[split_col])
     # validate="one_to_one": a duplicate case_id on either side raises MergeError
     # rather than fanning a case across folds.
     feats_df = feats_df.merge(folds, on="case_id", how="left", validate="one_to_one")

--- a/tests/test_cohort_adapters.py
+++ b/tests/test_cohort_adapters.py
@@ -117,20 +117,16 @@ def test_resample_is_noop_when_no_target_spacing() -> None:
     assert np.array_equal(adapter.resample(volume, (1.0, 1.0, 1.0)), volume)
 
 
-def test_uchicago_preprocess_flips_x_and_z_then_applies_base_transform() -> None:
-    """UChicago is RAS where MAMA-MIA is LAI, so x/z are flipped before the base transform.
-
-    SimpleITK returns (z, y, x)-ordered arrays, so undoing that sign difference
-    means flipping array axes 0 and 2 and then deferring to the base MAMA-MIA
-    reorientation. An identity pass-through (the original assumption) put the
-    thin slice axis where the model expects an in-plane axis.
-    """
+def test_uchicago_preprocess_changes_array_order_without_flipping() -> None:
+    """Map SimpleITK ``(z, y, x)`` to model ``(y, x, z)`` exactly."""
     adapter = UChicagoDataset(root=Path("/data/uchicago"))
     volume = np.arange(2 * 3 * 4).reshape(2, 3, 4)
-    flipped = volume[::-1, :, ::-1]
-    expected = np.swapaxes(np.swapaxes(flipped, 0, 2), 0, 1)[::-1]
-    assert np.array_equal(adapter.preprocess(volume), expected)
-    assert not np.array_equal(adapter.preprocess(volume), volume)
+    result = adapter.preprocess(volume)
+
+    assert result.shape == (3, 4, 2)
+    assert result[0, 0, 0] == volume[0, 0, 0]
+    assert result[2, 3, 1] == volume[1, 2, 3]
+    assert result[1, 2, 0] == volume[0, 1, 2]
 
 
 def test_base_load_folds_is_none() -> None:

--- a/tests/test_cohort_adapters.py
+++ b/tests/test_cohort_adapters.py
@@ -8,7 +8,7 @@ Deliberately not tested here: the exact set of methods each subclass
 overrides. That's an implementation-shape detail that will keep shifting as
 the design evolves; pinning it in a test would make routine changes fail for no
 functional reason. What's tested instead is the *behavior* those overrides are
-responsible for (identity parsing, preprocessing pass-through, provided folds,
+responsible for (identity parsing, preprocessing reorientation, provided folds,
 split-policy defaults, etc.).
 
 A few tests that need a small manifest use a synthetic CSV fixture; none touch
@@ -117,18 +117,20 @@ def test_resample_is_noop_when_no_target_spacing() -> None:
     assert np.array_equal(adapter.resample(volume, (1.0, 1.0, 1.0)), volume)
 
 
-def test_uchicago_preprocess_is_passthrough() -> None:
-    """UChicago data ships preprocessed, so preprocess returns it unchanged.
+def test_uchicago_preprocess_flips_x_and_z_then_applies_base_transform() -> None:
+    """UChicago is RAS where MAMA-MIA is LAI, so x/z are flipped before the base transform.
 
-    It must NOT apply the base MAMA-MIA orientation transform, which would be
-    wrong for the already-oriented ultrafast volumes.
+    SimpleITK returns (z, y, x)-ordered arrays, so undoing that sign difference
+    means flipping array axes 0 and 2 and then deferring to the base MAMA-MIA
+    reorientation. An identity pass-through (the original assumption) put the
+    thin slice axis where the model expects an in-plane axis.
     """
     adapter = UChicagoDataset(root=Path("/data/uchicago"))
     volume = np.arange(2 * 3 * 4).reshape(2, 3, 4)
-    result = adapter.preprocess(volume)
-    assert np.array_equal(result, volume)
-    base_transform = np.swapaxes(np.swapaxes(volume, 0, 2), 0, 1)[::-1]
-    assert not np.array_equal(result, base_transform)
+    flipped = volume[::-1, :, ::-1]
+    expected = np.swapaxes(np.swapaxes(flipped, 0, 2), 0, 1)[::-1]
+    assert np.array_equal(adapter.preprocess(volume), expected)
+    assert not np.array_equal(adapter.preprocess(volume), volume)
 
 
 def test_base_load_folds_is_none() -> None:

--- a/tests/test_graph_extraction_adapter.py
+++ b/tests/test_graph_extraction_adapter.py
@@ -1,0 +1,96 @@
+"""Tests for the Step 4 (graph-extraction) adapter seam.
+
+Graph extraction discovers a *different* artifact than the raw-DCE-phase
+contract ``DatasetAdapter.load_timepoints()`` already covers: per-timepoint
+vessel-segmentation ``.npz`` files produced by the (upstream) segmentation
+stage. ``DatasetAdapter.load_segmented_timepoints()`` is the new seam for that,
+and ``graph_extraction.pipeline.run_study_pipeline`` takes an optional
+``adapter`` that must be a no-op when absent (matching the Step 2/3 fallback
+pattern).
+
+Deliberately scoped to the discovery seam only, not a full pipeline run: the
+rest of ``run_study_pipeline`` is heavy numerical compute (skeletonization,
+TC4D) with no existing test scaffold to build a byte-identical fixture against
+yet -- that full-pipeline parity gate is a follow-up, mirroring how each prior
+step added its own validation gate incrementally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cohorts import DatasetAdapter, MamaMiaDataset
+
+
+def _write_segmentation_npz(
+    path: Path, shape: tuple[int, int, int] = (2, 2, 2)
+) -> None:
+    """Write a minimal valid vessel-segmentation .npz file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(path, vessel=np.zeros(shape, dtype=np.float32))
+
+
+def _make_segmentation_dir(root: Path, case_id: str, timepoints: list[int]) -> Path:
+    """Create <root>/<case_id>/images/<case_id>_<tp>_vessel_segmentation.npz files."""
+    images_dir = root / case_id / "images"
+    for tp in timepoints:
+        _write_segmentation_npz(
+            images_dir / f"{case_id}_{tp:04d}_vessel_segmentation.npz"
+        )
+    return root
+
+
+def test_base_load_segmented_timepoints_matches_discover_study_timepoints(
+    tmp_path: Path,
+) -> None:
+    """The base adapter delegates to the exact function graph_extraction already uses."""
+    from graph_extraction.core4d import discover_study_timepoints
+
+    case_id = "DUKE_001"
+    _make_segmentation_dir(tmp_path, case_id, [0, 1, 2])
+    adapter = DatasetAdapter(root=tmp_path)
+
+    via_adapter = adapter.load_segmented_timepoints(input_dir=tmp_path, case_id=case_id)
+    via_function = discover_study_timepoints(input_dir=tmp_path, case_id=case_id)
+
+    assert via_adapter == via_function
+    assert via_adapter[1] == [0, 1, 2]
+
+
+def test_mamamia_load_segmented_timepoints_needs_no_override(tmp_path: Path) -> None:
+    """MamaMiaDataset uses the inherited base behavior unchanged (no override)."""
+    case_id = "ISPY2_045"
+    _make_segmentation_dir(tmp_path, case_id, [0, 3])
+    adapter = MamaMiaDataset(cohort="ispy2", root=tmp_path)
+
+    files, timepoints = adapter.load_segmented_timepoints(
+        input_dir=tmp_path, case_id=case_id
+    )
+
+    assert timepoints == [0, 3]
+    assert all(f.name.startswith(case_id) for f in files)
+
+
+def test_load_segmented_timepoints_raises_when_none_found(tmp_path: Path) -> None:
+    """Missing segmentation files raise the same error as the underlying function."""
+    adapter = DatasetAdapter(root=tmp_path)
+    (tmp_path / "DUKE_999").mkdir()
+
+    with pytest.raises(ValueError, match="No candidate segmentation files"):
+        adapter.load_segmented_timepoints(input_dir=tmp_path, case_id="DUKE_999")
+
+
+def test_base_viz_flip_spec_default_matches_current_mamamia_constant() -> None:
+    """The adapter default must match graph_extraction's hardcoded MAMA-MIA constant.
+
+    A regression guard: if PROCESSING_VIZ_FLIP_SPEC ever changes, this fails
+    loudly instead of silently producing different MIP visualizations for
+    adapter=None vs. adapter=MamaMiaDataset(...) runs.
+    """
+    from graph_extraction.constants import PROCESSING_VIZ_FLIP_SPEC
+
+    assert DatasetAdapter.viz_flip_spec == PROCESSING_VIZ_FLIP_SPEC
+    assert MamaMiaDataset.viz_flip_spec == PROCESSING_VIZ_FLIP_SPEC

--- a/tests/test_provided_folds.py
+++ b/tests/test_provided_folds.py
@@ -203,6 +203,45 @@ def test_apply_provided_folds_rejects_split_col_collision(tmp_path: Path) -> Non
         _apply_provided_folds(feats_df, config, adapter)
 
 
+def test_apply_provided_folds_rejects_split_col_collision_with_ordinary_feature(
+    tmp_path: Path,
+) -> None:
+    """Regression test: split_col colliding with a non-reserved feature must also raise.
+
+    The original collision check only guarded case_id and the label column, so
+    split_col matching any other real feature/metadata column was silently
+    dropped and overwritten instead of raising -- exactly the kind of silent
+    corruption the rest of this function's fail-closed validation exists to
+    prevent.
+    """
+    adapter = UChicagoDataset(root=_write_manifest(tmp_path))
+    config = ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "dataset": {
+                    "name": "uchicago",
+                    "cohort": None,
+                    "root": "/x",
+                    "split_policy": "auto",
+                },
+                # Collides with an ordinary feature column, not case_id/pcr.
+                "model_params": {"split_col": "tumor_size"},
+            },
+        )
+    )
+    feats_df = pd.DataFrame(
+        {
+            "case_id": ["e1", "e2", "e3"],
+            "pcr": [1, 0, 1],
+            "tumor_size": [12.5, 8.0, 20.1],
+        }
+    )
+
+    with pytest.raises(ValueError, match="collides"):
+        _apply_provided_folds(feats_df, config, adapter)
+
+
 def test_apply_provided_folds_rejects_duplicate_case_in_features(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_qc_report_by.py
+++ b/tests/test_qc_report_by.py
@@ -1,0 +1,96 @@
+"""Tests for the Step 4 QC-reporting adapter seam (report_by sub-source breakdown).
+
+A dataset adapter's ``report_by`` names the column QC/eval metrics should be
+broken down by (``None`` for MAMA-MIA; ``"dataset"`` -- the manifest sub-source
+-- for UChicago). ``run_pipeline_from_config`` threads it into
+``run_evaluation_pipeline``: each fold's predictions get the column attached, and
+``Evaluator.save_results`` selects it (via ``_stratum_column``) for the
+per-subgroup metric breakdown. When ``report_by`` is ``None`` -- every non-adapter
+run -- selection and predictions are byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from config import DEFAULT_CONFIG, ConfigNode, _deep_merge
+from evaluation.evaluator import _stratum_column
+from tabular.train import prepare_evaluation_context, run_single_fold_from_context
+
+
+def test_stratum_column_none_report_by_is_unchanged_alias_behavior() -> None:
+    """report_by=None selects the first alias, exactly as before."""
+    preds = pd.DataFrame({"subtype": ["A", "B"], "y_true": [1, 0]})
+    assert _stratum_column(preds) == "subtype"
+    assert _stratum_column(preds, report_by=None) == "subtype"
+
+    assert _stratum_column(pd.DataFrame({"y_true": [1]})) is None
+
+
+def test_stratum_column_prefers_report_by_when_present() -> None:
+    """report_by wins over the default aliases when it is a real column."""
+    preds = pd.DataFrame({"subtype": ["A", "B"], "dataset": ["simbiosys", "uch_nac"]})
+    assert _stratum_column(preds, report_by="dataset") == "dataset"
+
+
+def test_stratum_column_ignores_report_by_absent_from_predictions() -> None:
+    """A report_by column that isn't present falls back to the aliases."""
+    preds = pd.DataFrame({"subtype": ["A", "B"]})
+    assert _stratum_column(preds, report_by="dataset") == "subtype"
+    assert _stratum_column(pd.DataFrame({"y_true": [1]}), report_by="dataset") is None
+
+
+def _fold_config() -> ConfigNode:
+    """Predefined 2-fold config, clinical off, so only the toy feature is used."""
+    return ConfigNode._wrap(
+        _deep_merge(
+            DEFAULT_CONFIG,
+            {
+                "model_params": {"split_mode": "predefined", "split_col": "fold"},
+                "feature_toggles": {"use_clinical": False},
+            },
+        )
+    )
+
+
+def _toy_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "case_id": ["c1", "c2", "c3", "c4"],
+            "pcr": [1, 0, 1, 0],
+            "dataset": ["simbiosys", "uch_nac", "simbiosys", "uch_nac"],
+            "feature_a": [0.1, 0.9, 0.2, 0.8],
+            "fold": [0, 0, 1, 1],
+        }
+    )
+
+
+def test_report_by_stored_in_context_and_kept_out_of_features() -> None:
+    """report_by flows into the context; the sub-source column is not a feature."""
+    context = prepare_evaluation_context(
+        _toy_frame(), _fold_config(), report_by="dataset"
+    )
+    assert context["report_by"] == "dataset"
+    assert "dataset" not in context["X"].columns  # sub-source is not a predictor
+
+
+def test_report_by_column_attached_to_fold_predictions() -> None:
+    """A fold's predictions carry the report_by column, so save_results can split."""
+    context = prepare_evaluation_context(
+        _toy_frame(), _fold_config(), report_by="dataset"
+    )
+    fold_results, _nested, _override = run_single_fold_from_context(
+        context, context["splits"][0]
+    )
+    preds = fold_results.predictions
+    assert "dataset" in preds.columns
+    assert set(preds["dataset"]).issubset({"simbiosys", "uch_nac"})
+
+
+def test_no_report_by_leaves_predictions_without_subsource_column() -> None:
+    """Without report_by (non-adapter run), no sub-source column is attached."""
+    context = prepare_evaluation_context(_toy_frame(), _fold_config())
+    fold_results, _nested, _override = run_single_fold_from_context(
+        context, context["splits"][0]
+    )
+    assert "dataset" not in fold_results.predictions.columns


### PR DESCRIPTION
## What this is

It sits on top of the unmerged Step 4 modularization branches (adapter wiring for graph → segmentation → QC), so the commit list includes those. The UChicago-specific work is the top 4 commits.

## How I actually run it

```bash
PROJECT_ROOT="$(pwd)" sbatch segmentation/slurm/submit_uchicago_segmentation_smoke.slurm
```

That calls `segmentation/batch_segmentation.py --dataset-name uchicago`, which:

1. **Discovers cases** from the manifest CSV (`dce2d_internal_ultrafast_manifest.csv`, 181 exams) via `UChicagoDataset.discover_cases()` — not a directory glob.
2. **Preprocesses** each phase with `UChicagoDataset.preprocess()` (see the orientation note below).
3. **STEP-2: breast mask** — the breast U-Net (`breast_model.pth`).
4. **STEP-3: vessel mask** — the vessel U-Net (`dv_model.pth`), tiled over the volume.
5. Writes per-phase `.npz` vessel probability masks.

Models come from the pinned `vanguard-blood-vessel-segmentation/` submodule. Runs are 5-patient smoke tests on a GPU node, not the full 181.

## Three things I'd most like a second opinion on

**1. Orientation (`cohorts/uchicago.py:preprocess`).** This was originally an identity pass-through, assuming the HFDP-preprocessed phase files (`policy_name = hfdp_t1_v1`) already arrived in the layout the vessel model expects. **They don't** — passing them straight through put the thin slice axis where the model expects a large in-plane axis, and inference died on a tiling-coverage assertion. It now flips array axes 0 and 2 (UChicago is stored `RAS`; MAMA-MIA's ISPY2/DUKE are `LAI`) and then applies the base MAMA-MIA reorientation.

I derived that from the NIfTI direction cosines but did **not** trust them alone — MAMA-MIA's own ISPY1 reports `PSL` (a true axis permutation) yet gets the same fixed transform as ISPY2/DUKE and evidently works, so the headers are clearly not reliable ground truth in this data. I confirmed the flip visually (MIP + z-depth progression against a MAMA-MIA reference, matching anatomical landmarks).

**Still unverified: a pure left-right mirror.** Breast anatomy is near-symmetric, so a MIP can't rule it out. **Could you confirm what orientation HFDP actually writes?** That would settle it.

**2. Breast masks.** The model's STEP-2 breast masks looked badly off, so I plugged in the real BreastDivider whole-breast masks you provided (`--use-external-breast-masks`) and compared. The real masks change the vessel output materially: the model breast mask was a small mis-localized blob, while the real mask fills the bilateral breast silhouette, and with it the vessel model finds a much fuller, coherent branching tree (all vessel voxel counts up; matched-phase vessel Dice 0.02–0.36 between the two runs).

Caveat I want to flag rather than hide: there's **no motion correction**, and there's **one mask per exam (phase 0)**, so that mask is reused across all phases.

**3. Sub-source coverage bias.** Every smoke run before this one silently covered `her2_naclike` only — `--patient-limit N` takes the first N in discovery order, and the manifest is grouped by sub-source, so `simbiosys` and `uch_nac` were unreachable. Added `--case-ids` (fail-closed: an unknown id raises rather than being dropped) plus a case list covering the previously-unreached sub-sources.

## QC

`data_viz/uchicago_skeleton_interactive.py` makes one self-contained 3D HTML per case — the UChicago counterpart to the Duke QC htmls. UChicago has no radiologist annotations, so the annotation layers are replaced by the vessel skeleton, overlaying the real-breast-mask run against the model-breast-mask baseline in one scene. Skeletonization reuses the pipeline's own `skeletonize3d` on an EDT priority (the same routine `tc4d.py` uses), so the centerlines match what the graph stage would produce.

## Known gaps (deliberately not addressed here)

- **No resampling.** `target_spacing_mm` is `None` for every dataset today and `resample()` raises if set, so there is no native-vs-resampled split anywhere in the pipeline yet. If UChicago needs one, it's unbuilt.
- **The graph stage can't consume this output yet.** Its discovery seam (`graph_extraction/core4d.py`) rejects the pipeline's own UChicago output naming, so segmentation → graph isn't connected for UChicago.
- **One submodule fix isn't in this PR** because it lives in a separate repo: `vanguard-blood-vessel-segmentation/dataset_3d.py`'s `compute_starts` didn't guarantee tiling coverage for arbitrary volume sizes (it trusted the caller's `divisions` count). It needs its own PR there. Not load-bearing once the orientation was fixed — the subvolume count went back to the intended 23040 — so it's a safety net.