### PR TITLE
Include a section about avoiding repeated mistakes/near misses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,7 @@ gmon.out
 HANDOFF_2026-06-29.md
 
 /LAB_NOTEBOOK.md
+
+docs/design/ 
+qc/ 
+presentations/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,3 +71,6 @@ If `agents.local.md` exists, read it after this file.
 - Reserve contrasting colors only to highlight a specific result or distinguish meaningful categories.
 - Avoid unnecessary visual elements ("chartjunk") such as excessive colors, gradients, 3D effects, and heavy styling.
 - Favor clean, simple figures that emphasize the data rather than the design.
+
+## Avoiding Repeated Mistakes
+After any material mistake, near-miss, wasted compute, confusing workflow, or user correction, identify the general rule that would have prevented it and propose a concise `AGENTS.md` change in the next substantive update. If an existing rule already covers the incident, explain why it was missed and propose clearer wording, placement, or triggers instead of a duplicate. Prefer reusable principles over incident-specific prohibitions; do not edit `AGENTS.md` without approval.


### PR DESCRIPTION
Following @annawoodard's recommendation in Slack, I've added a new section in `AGENTS.md` to avoid making repeated mistakes, or costly computational near-misses.