### PR TITLE
A the dataset adapter in graph extraction's discovery seam (Step 4a in Modularization)

### DIFF
--- a/cohorts/base.py
+++ b/cohorts/base.py
@@ -134,6 +134,36 @@ class DatasetAdapter:
             raise FileNotFoundError(f"No image dir for case {case_id}: {case_dir}")
         return sorted(case_dir.glob("*.nii.gz"))
 
+    def load_segmented_timepoints(
+        self, input_dir: Path, case_id: str
+    ) -> tuple[list[Path], list[int]]:
+        """Return a case's per-timepoint vessel-segmentation ``.npz`` files, ordered.
+
+        This is a *different* artifact from :meth:`load_timepoints`: it discovers
+        the graph-extraction stage's input (segmented vessel-probability volumes
+        produced by the segmentation stage), not raw DCE phases. Delegates to
+        ``graph_extraction.core4d.discover_study_timepoints`` for the base/MAMA-MIA
+        behavior (``<input_dir>/<case_id>/images/<case_id>_<4-digit>_vessel_segmentation.npz``),
+        so this is a no-op wrapper for MAMA-MIA and a documented seam for a future
+        dataset whose segmentation output is laid out differently.
+
+        Args:
+            input_dir: Root directory of vessel-segmentation output (a pipeline
+                artifact location, not this adapter's own ``root`` -- segmentation
+                output lives in its own directory, separate from raw data).
+            case_id: The case to discover timepoints for.
+
+        Returns:
+            ``(ordered file paths, ordered timepoint indices)``.
+        """
+        from graph_extraction.core4d import discover_study_timepoints
+
+        return discover_study_timepoints(input_dir=input_dir, case_id=case_id)
+
+    #: Axis to flip vessel/tumor/breast masks along for MIP visualization only
+    #: (does not affect computed centerline/graph features). MAMA-MIA default.
+    viz_flip_spec: ClassVar[str] = "z"
+
     def preprocess(self, volume: np.ndarray) -> np.ndarray:
         """Reorient a raw volume into the pipeline's processing layout.
 

--- a/graph_extraction/pipeline.py
+++ b/graph_extraction/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -23,6 +24,9 @@ from graph_extraction.masks import (
 from graph_extraction.tc4d import run_tc4d_from_priority
 from graph_extraction.vessel_mip import render_vessel_coverage_mip
 
+if TYPE_CHECKING:
+    from cohorts.base import DatasetAdapter
+
 
 def run_study_pipeline(
     *,
@@ -39,6 +43,7 @@ def run_study_pipeline(
     mip_dpi: int,
     radiologist_annotations_dir: Path,
     tumor_mask_dir: Path,
+    adapter: DatasetAdapter | None = None,
 ) -> dict[str, object]:
     """Run the full graph-extraction workflow for one study.
 
@@ -55,9 +60,20 @@ def run_study_pipeline(
     The returned dictionary is the study-level run summary written to
     `run_summary.json`. It records which stages ran, how long they took,
     whether quality checks passed, and where the main outputs were written.
+
+    ``adapter`` is optional (Step 4 of the multi-dataset migration, see
+    cohorts/README.md): when given, per-timepoint segmentation discovery routes
+    through ``adapter.load_segmented_timepoints()`` and the MIP-only flip spec
+    through ``adapter.viz_flip_spec``, instead of the hardcoded MAMA-MIA
+    function/constant. When ``None`` (every caller today), behavior is
+    byte-for-byte unchanged.
     """
     start = time.perf_counter()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    viz_flip_spec = (
+        adapter.viz_flip_spec if adapter is not None else PROCESSING_VIZ_FLIP_SPEC
+    )
 
     skeleton_path = output_dir / f"{case_id}_skeleton_4d_exam_mask.npy"
     support_path = output_dir / f"{case_id}_skeleton_4d_exam_support_mask.npy"
@@ -102,10 +118,16 @@ def run_study_pipeline(
         skeleton_status = "loaded_existing"
     else:
         t0 = time.perf_counter()
-        discovered_files, discovered_timepoints = discover_study_timepoints(
-            input_dir=input_dir,
-            case_id=case_id,
-        )
+        if adapter is not None:
+            discovered_files, discovered_timepoints = adapter.load_segmented_timepoints(
+                input_dir=input_dir,
+                case_id=case_id,
+            )
+        else:
+            discovered_files, discovered_timepoints = discover_study_timepoints(
+                input_dir=input_dir,
+                case_id=case_id,
+            )
         priority_4d = load_time_series_from_files(
             discovered_files,
         )
@@ -186,10 +208,16 @@ def run_study_pipeline(
                 }
             else:
                 try:
-                    k_files, k_timepoints = discover_study_timepoints(
-                        input_dir=input_dir,
-                        case_id=case_id,
-                    )
+                    if adapter is not None:
+                        k_files, k_timepoints = adapter.load_segmented_timepoints(
+                            input_dir=input_dir,
+                            case_id=case_id,
+                        )
+                    else:
+                        k_files, k_timepoints = discover_study_timepoints(
+                            input_dir=input_dir,
+                            case_id=case_id,
+                        )
                     kinetic_priority_4d = load_time_series_from_files(k_files)
                     kinetic_timepoints = list(k_timepoints)
                     if discovered_files is None:
@@ -267,11 +295,11 @@ def run_study_pipeline(
                 )
                 radiologist_mask_viz = _apply_flip_spec(
                     radiologist_mask_model,
-                    PROCESSING_VIZ_FLIP_SPEC,
+                    viz_flip_spec,
                 )
                 breast_mask_viz = _apply_flip_spec(
                     breast_mask_model,
-                    PROCESSING_VIZ_FLIP_SPEC,
+                    viz_flip_spec,
                 )
 
             tumor_mask_viz: np.ndarray | None = None
@@ -289,14 +317,14 @@ def run_study_pipeline(
             if tumor_mask_model is not None:
                 tumor_mask_viz = _apply_flip_spec(
                     tumor_mask_model,
-                    PROCESSING_VIZ_FLIP_SPEC,
+                    viz_flip_spec,
                 )
 
             method_label = "tc4d"
             row_masks: list[tuple[str, np.ndarray]] = [
                 (
                     method_label,
-                    _apply_flip_spec(skeleton_mask, PROCESSING_VIZ_FLIP_SPEC),
+                    _apply_flip_spec(skeleton_mask, viz_flip_spec),
                 )
             ]
             if radiologist_mask_viz is not None:
@@ -322,7 +350,7 @@ def run_study_pipeline(
                 **coverage_mip_diag,
                 "radiologist_context": radiologist_context_for_summary,
                 "tumor_context": tumor_context_for_summary,
-                "visualization_flip_spec": PROCESSING_VIZ_FLIP_SPEC,
+                "visualization_flip_spec": viz_flip_spec,
             }
             mip_status = "computed"
         except Exception as exc:

--- a/tests/test_graph_extraction_adapter.py
+++ b/tests/test_graph_extraction_adapter.py
@@ -1,0 +1,96 @@
+"""Tests for the Step 4 (graph-extraction) adapter seam.
+
+Graph extraction discovers a *different* artifact than the raw-DCE-phase
+contract ``DatasetAdapter.load_timepoints()`` already covers: per-timepoint
+vessel-segmentation ``.npz`` files produced by the (upstream) segmentation
+stage. ``DatasetAdapter.load_segmented_timepoints()`` is the new seam for that,
+and ``graph_extraction.pipeline.run_study_pipeline`` takes an optional
+``adapter`` that must be a no-op when absent (matching the Step 2/3 fallback
+pattern).
+
+Deliberately scoped to the discovery seam only, not a full pipeline run: the
+rest of ``run_study_pipeline`` is heavy numerical compute (skeletonization,
+TC4D) with no existing test scaffold to build a byte-identical fixture against
+yet -- that full-pipeline parity gate is a follow-up, mirroring how each prior
+step added its own validation gate incrementally.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cohorts import DatasetAdapter, MamaMiaDataset
+
+
+def _write_segmentation_npz(
+    path: Path, shape: tuple[int, int, int] = (2, 2, 2)
+) -> None:
+    """Write a minimal valid vessel-segmentation .npz file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(path, vessel=np.zeros(shape, dtype=np.float32))
+
+
+def _make_segmentation_dir(root: Path, case_id: str, timepoints: list[int]) -> Path:
+    """Create <root>/<case_id>/images/<case_id>_<tp>_vessel_segmentation.npz files."""
+    images_dir = root / case_id / "images"
+    for tp in timepoints:
+        _write_segmentation_npz(
+            images_dir / f"{case_id}_{tp:04d}_vessel_segmentation.npz"
+        )
+    return root
+
+
+def test_base_load_segmented_timepoints_matches_discover_study_timepoints(
+    tmp_path: Path,
+) -> None:
+    """The base adapter delegates to the exact function graph_extraction already uses."""
+    from graph_extraction.core4d import discover_study_timepoints
+
+    case_id = "DUKE_001"
+    _make_segmentation_dir(tmp_path, case_id, [0, 1, 2])
+    adapter = DatasetAdapter(root=tmp_path)
+
+    via_adapter = adapter.load_segmented_timepoints(input_dir=tmp_path, case_id=case_id)
+    via_function = discover_study_timepoints(input_dir=tmp_path, case_id=case_id)
+
+    assert via_adapter == via_function
+    assert via_adapter[1] == [0, 1, 2]
+
+
+def test_mamamia_load_segmented_timepoints_needs_no_override(tmp_path: Path) -> None:
+    """MamaMiaDataset uses the inherited base behavior unchanged (no override)."""
+    case_id = "ISPY2_045"
+    _make_segmentation_dir(tmp_path, case_id, [0, 3])
+    adapter = MamaMiaDataset(cohort="ispy2", root=tmp_path)
+
+    files, timepoints = adapter.load_segmented_timepoints(
+        input_dir=tmp_path, case_id=case_id
+    )
+
+    assert timepoints == [0, 3]
+    assert all(f.name.startswith(case_id) for f in files)
+
+
+def test_load_segmented_timepoints_raises_when_none_found(tmp_path: Path) -> None:
+    """Missing segmentation files raise the same error as the underlying function."""
+    adapter = DatasetAdapter(root=tmp_path)
+    (tmp_path / "DUKE_999").mkdir()
+
+    with pytest.raises(ValueError, match="No candidate segmentation files"):
+        adapter.load_segmented_timepoints(input_dir=tmp_path, case_id="DUKE_999")
+
+
+def test_base_viz_flip_spec_default_matches_current_mamamia_constant() -> None:
+    """The adapter default must match graph_extraction's hardcoded MAMA-MIA constant.
+
+    A regression guard: if PROCESSING_VIZ_FLIP_SPEC ever changes, this fails
+    loudly instead of silently producing different MIP visualizations for
+    adapter=None vs. adapter=MamaMiaDataset(...) runs.
+    """
+    from graph_extraction.constants import PROCESSING_VIZ_FLIP_SPEC
+
+    assert DatasetAdapter.viz_flip_spec == PROCESSING_VIZ_FLIP_SPEC
+    assert MamaMiaDataset.viz_flip_spec == PROCESSING_VIZ_FLIP_SPEC


### PR DESCRIPTION
## Summary
- Part of the multi-dataset modularization (Step 4/6 — see `cohorts/README.md`).
- Adds an optional `adapter: DatasetAdapter | None` parameter to `graph_extraction.pipeline.run_study_pipeline`.
- When an adapter is provided, per-timepoint segmentation discovery routes through `adapter.load_segmented_timepoints()` and MIP-only visualization flipping through `adapter.viz_flip_spec`, instead of the hardcoded MAMA-MIA function/constant.
- When `adapter=None` (every current caller), behavior is byte-for-byte unchanged — this is purely an additive seam, not a behavior change.
- Adds `DatasetAdapter.load_segmented_timepoints` to `cohorts/base.py` (delegates to the existing MAMA-MIA discovery function by default).

## Test plan
- [x] `pytest -q` — 134 passed / 2 skipped (2 pre-existing `torch_geometric` skips, unrelated)
- [x] `ruff check` / `ruff format` clean
- [x] Rebased onto current `main`; verified no behavior change on the `adapter=None` path
EOF
)"