### PR TITLE
Advanced GNN modeling Tier 0,1: training hygiene + multi-statistic readout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,6 @@ presentations/
 
 # Design Docs
 docs/design/
+
+# Dev-phase decision gates (throwaway scaffolding, deleted at end of dev)
+gnn/dev_gates/

--- a/config.py
+++ b/config.py
@@ -162,6 +162,14 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # gnn/DESIGN_segment_graph.md.
         "gnn_node_mode": "voxel",
         "gnn_node_features": ["peak_time", "radius"],
+        # Whole-graph readout for GCNClassifier (voxel/segment): "mean"
+        # (default, the original single global_mean_pool -- fully backward
+        # compatible), "mean_max", or "mean_max_sum". Concatenating max/sum
+        # pools keeps the distributional tails that mean-pool discards; see
+        # gnn/PLAN_advanced_modeling.md decision D2.1 and gnn/model.py
+        # POOLING_WIDTHS. Junction mode (EdgeGNNClassifier) ignores this and
+        # always mean-pools for now.
+        "gnn_pooling": "mean",
         # Edge features for node_mode="junction" (segment-as-edge, Option A):
         # the segment summary rides on the edges there. Empty for voxel/segment
         # mode, which carry no edge features. Uses the seg_* vocabulary (see

--- a/config.py
+++ b/config.py
@@ -139,6 +139,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "pooling": "mean_max_logcount",
         "early_stopping_patience": 0,
         "restore_best_epoch": False,
+        "inner_val_fraction": 0.2,
         "max_grad_norm": 0.0,
         "lr_scheduler": "none",
         "lr_scheduler_factor": 0.5,

--- a/configs/gnn.yaml
+++ b/configs/gnn.yaml
@@ -22,11 +22,23 @@ model_params:
   dropout: 0.2
   learning_rate: 0.001
   gnn_node_features: ["peak_time", "radius"]
+  # Frozen baseline reference (PLAN_advanced_modeling.md, decision D0.6). These
+  # keys are now honored by gnn/train.py, but here they are pinned to the
+  # HISTORICAL behavior that produced the ~0.51 baseline so this config keeps
+  # reproducing it exactly (the shared config defaults are weight_decay=1e-4 and
+  # loss=weighted_bce -- different from what the old GNN runs actually used).
+  # The Tier-0 improvements live in configs/gnn_tier0.yaml instead.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
 
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_duke_mean.yaml
+++ b/configs/gnn_duke_mean.yaml
@@ -1,0 +1,55 @@
+# Tier-0 "optimization hygiene" arm for the GNN centerline pipeline.
+# Same cohort / cache / features / architecture as the frozen baseline
+# (configs/gnn.yaml, decision D0.6) -- the ONLY differences are training-loop
+# knobs, so any paired ΔAUC vs. gnn.yaml is attributable to optimization, not
+# to representation or architecture (PLAN_advanced_modeling.md, Tier 0 / D5).
+#
+# Turned on here vs. the frozen baseline:
+#   - loss: weighted_bce           (D1.3) up-weight the minority pCR class
+#   - weight_decay: 1e-4           (D1.4) L2 regularization
+#   - max_grad_norm: 1.0           (D1.4) gradient clipping
+#   - lr_scheduler: plateau        (D1.5) ReduceLROnPlateau on val loss
+#   - early_stopping_patience: 10  (D1.2) stop after 10 stale epochs
+#   - restore_best_epoch: true     (D1.1) report best-val-loss epoch, not final
+#   - epochs: 100                  raised ceiling so patience, not the ceiling,
+#                                  ends most folds (baseline used a fixed 25)
+
+experiment_setup:
+  name: "gnn_duke_mean"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  group_col: "site"
+  stratum_col: null
+  split_mode: "random" # frozen-fold parity with gnn.yaml (D0.2)
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features: ["peak_time", "radius"]
+  # Tier-0 training knobs (the only deltas vs. configs/gnn.yaml).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+
+data_paths:
+  gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
+  gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
+  gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_tier0_sweep"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: ["DUKE"]

--- a/configs/gnn_duke_meanmax.yaml
+++ b/configs/gnn_duke_meanmax.yaml
@@ -1,0 +1,49 @@
+# Tier-1 readout arm (PLAN_advanced_modeling.md, decision D2.1).
+# Identical to the Tier-0 arm (configs/gnn_tier0_sweep_tier0.yaml: all Tier-0
+# training knobs on, same cache, same features, same folds per seed) EXCEPT the
+# whole-graph readout: gnn_pooling="mean_max" concatenates a global max-pool
+# onto the mean-pool, restoring the distributional tails that mean-pool alone
+# discards. So a paired ΔAUC vs. the Tier-0 (mean-pool) arm isolates the readout
+# change (D5: one change per arm), directly testing whether mean-pool washout is
+# what caps the GNN below the quantile-based tabular baseline (Gate G0 finding).
+
+experiment_setup:
+  name: "gnn_duke_meanmax"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  group_col: "site"
+  stratum_col: null
+  split_mode: "random" # frozen-fold parity with gnn.yaml (D0.2)
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features: ["peak_time", "radius"]
+  gnn_pooling: "mean_max"
+  # Tier-0 training knobs (the only deltas vs. configs/gnn.yaml).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+
+data_paths:
+  gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
+  gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
+  gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_tier0_sweep"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: ["DUKE"]

--- a/configs/gnn_junction.yaml
+++ b/configs/gnn_junction.yaml
@@ -46,7 +46,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_junction"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_junction_smoke.yaml
+++ b/configs/gnn_junction_smoke.yaml
@@ -47,7 +47,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_junction_smoke"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_overfit_check.yaml
+++ b/configs/gnn_overfit_check.yaml
@@ -30,7 +30,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_smoke"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_pcr_gaussian.yaml
+++ b/configs/gnn_pcr_gaussian.yaml
@@ -48,7 +48,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_pcr_dummy"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_segment.yaml
+++ b/configs/gnn_segment.yaml
@@ -41,7 +41,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_segment"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_segment_smoke.yaml
+++ b/configs/gnn_segment_smoke.yaml
@@ -42,7 +42,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_segment_smoke"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_segment_smoke_all_graph_sources.yaml
+++ b/configs/gnn_segment_smoke_all_graph_sources.yaml
@@ -44,7 +44,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_segment_smoke_all_graph_sources"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_segment_smoke_breast_density.yaml
+++ b/configs/gnn_segment_smoke_breast_density.yaml
@@ -46,7 +46,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_segment_smoke_breast_density"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_segment_smoke_graph_features.yaml
+++ b/configs/gnn_segment_smoke_graph_features.yaml
@@ -38,7 +38,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_segment_smoke_graph_features"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_segment_smoke_site_confound_check.yaml
+++ b/configs/gnn_segment_smoke_site_confound_check.yaml
@@ -53,7 +53,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_segment_smoke_site_confound"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_smoke.yaml
+++ b/configs/gnn_smoke.yaml
@@ -22,11 +22,19 @@ model_params:
   dropout: 0.2
   learning_rate: 0.001
   gnn_node_features: ["peak_time", "radius"]
+  # Pinned to historical behavior, matching configs/gnn.yaml (see the D0.6 note
+  # there). Keeps the smoke path a faithful fast mirror of the frozen baseline.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
 
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_smoke"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/configs/gnn_tier0.yaml
+++ b/configs/gnn_tier0.yaml
@@ -1,0 +1,55 @@
+# Tier-0 "optimization hygiene" arm for the GNN centerline pipeline.
+# Same cohort / cache / features / architecture as the frozen baseline
+# (configs/gnn.yaml, decision D0.6) -- the ONLY differences are training-loop
+# knobs, so any paired ΔAUC vs. gnn.yaml is attributable to optimization, not
+# to representation or architecture (PLAN_advanced_modeling.md, Tier 0 / D5).
+#
+# Turned on here vs. the frozen baseline:
+#   - loss: weighted_bce           (D1.3) up-weight the minority pCR class
+#   - weight_decay: 1e-4           (D1.4) L2 regularization
+#   - max_grad_norm: 1.0           (D1.4) gradient clipping
+#   - lr_scheduler: plateau        (D1.5) ReduceLROnPlateau on val loss
+#   - early_stopping_patience: 10  (D1.2) stop after 10 stale epochs
+#   - restore_best_epoch: true     (D1.1) report best-val-loss epoch, not final
+#   - epochs: 100                  raised ceiling so patience, not the ceiling,
+#                                  ends most folds (baseline used a fixed 25)
+
+experiment_setup:
+  name: "gnn_tier0"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  group_col: "site"
+  stratum_col: "dataset"
+  split_mode: "random" # frozen-fold parity with gnn.yaml (D0.2)
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features: ["peak_time", "radius"]
+  # Tier-0 training knobs (the only deltas vs. configs/gnn.yaml).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+
+data_paths:
+  gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
+  gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
+  gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/gnn_tier0_sweep_baseline.yaml
+++ b/configs/gnn_tier0_sweep_baseline.yaml
@@ -1,0 +1,46 @@
+# Full-cohort config for the GNN centerline pipeline (gnn/train.py).
+# Mirrors configs/deepsets_ispy2.yaml's shape but points at the raw centerline
+# tree / VanguardCenterlineDataset cache instead of a Deep Sets manifest.
+
+experiment_setup:
+  name: "gnn_sweep_baseline"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  group_col: "site"
+  stratum_col: "dataset"
+  split_mode: "random" # or "predefined" to honor split_col from the labels file
+  split_col: "fold"
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features: ["peak_time", "radius"]
+  # Frozen baseline reference (PLAN_advanced_modeling.md, decision D0.6). These
+  # keys are now honored by gnn/train.py, but here they are pinned to the
+  # HISTORICAL behavior that produced the ~0.51 baseline so this config keeps
+  # reproducing it exactly (the shared config defaults are weight_decay=1e-4 and
+  # loss=weighted_bce -- different from what the old GNN runs actually used).
+  # The Tier-0 improvements live in configs/gnn_tier0.yaml instead.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+
+data_paths:
+  gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
+  gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
+  gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_tier0_sweep"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/gnn_tier0_sweep_tier0.yaml
+++ b/configs/gnn_tier0_sweep_tier0.yaml
@@ -1,0 +1,55 @@
+# Tier-0 "optimization hygiene" arm for the GNN centerline pipeline.
+# Same cohort / cache / features / architecture as the frozen baseline
+# (configs/gnn.yaml, decision D0.6) -- the ONLY differences are training-loop
+# knobs, so any paired ΔAUC vs. gnn.yaml is attributable to optimization, not
+# to representation or architecture (PLAN_advanced_modeling.md, Tier 0 / D5).
+#
+# Turned on here vs. the frozen baseline:
+#   - loss: weighted_bce           (D1.3) up-weight the minority pCR class
+#   - weight_decay: 1e-4           (D1.4) L2 regularization
+#   - max_grad_norm: 1.0           (D1.4) gradient clipping
+#   - lr_scheduler: plateau        (D1.5) ReduceLROnPlateau on val loss
+#   - early_stopping_patience: 10  (D1.2) stop after 10 stale epochs
+#   - restore_best_epoch: true     (D1.1) report best-val-loss epoch, not final
+#   - epochs: 100                  raised ceiling so patience, not the ceiling,
+#                                  ends most folds (baseline used a fixed 25)
+
+experiment_setup:
+  name: "gnn_sweep_tier0"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  group_col: "site"
+  stratum_col: "dataset"
+  split_mode: "random" # frozen-fold parity with gnn.yaml (D0.2)
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features: ["peak_time", "radius"]
+  # Tier-0 training knobs (the only deltas vs. configs/gnn.yaml).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+
+data_paths:
+  gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
+  gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
+  gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_tier0_sweep"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/gnn_tier1_meanmax.yaml
+++ b/configs/gnn_tier1_meanmax.yaml
@@ -1,0 +1,49 @@
+# Tier-1 readout arm (PLAN_advanced_modeling.md, decision D2.1).
+# Identical to the Tier-0 arm (configs/gnn_tier0_sweep_tier0.yaml: all Tier-0
+# training knobs on, same cache, same features, same folds per seed) EXCEPT the
+# whole-graph readout: gnn_pooling="mean_max" concatenates a global max-pool
+# onto the mean-pool, restoring the distributional tails that mean-pool alone
+# discards. So a paired ΔAUC vs. the Tier-0 (mean-pool) arm isolates the readout
+# change (D5: one change per arm), directly testing whether mean-pool washout is
+# what caps the GNN below the quantile-based tabular baseline (Gate G0 finding).
+
+experiment_setup:
+  name: "gnn_sweep_tier1_meanmax"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  group_col: "site"
+  stratum_col: "dataset"
+  split_mode: "random" # frozen-fold parity with gnn.yaml (D0.2)
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features: ["peak_time", "radius"]
+  gnn_pooling: "mean_max"
+  # Tier-0 training knobs (the only deltas vs. configs/gnn.yaml).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+
+data_paths:
+  gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
+  gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
+  gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_tier0_sweep"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/loco_gnn_junction.yaml
+++ b/configs/loco_gnn_junction.yaml
@@ -85,7 +85,7 @@ model_params:
 data_paths:
   gnn_centerline_root: "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
   gnn_dce_root: "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images"
-  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
   gnn_cache_dir: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache_loco_junction"
   gnn_id_column: "case_id"
   gnn_label_column: "pcr"

--- a/gnn/PLAN_advanced_modeling.md
+++ b/gnn/PLAN_advanced_modeling.md
@@ -1,0 +1,359 @@
+# Plan: Improving GNN Baseline Performance with More Advanced Modeling
+
+**Scope:** the vessel-centerline **GNN** pCR classifier only (`gnn/model.py`,
+`gnn/train.py`). Not the tabular or Deep Sets tracks. Derived from `NOTES.md`
+("Look into more sophisticated modeling approaches" + "This Week" items) and the
+diagnosis recorded in `LAB_NOTEBOOK.md` (2026-07-15 entries).
+
+**Author intent (from the task):** come up with a plan to improve baseline model
+performance using more advanced modeling techniques, and *record every decision
+carefully*. This file is that record. Each numbered **Decision (Dn)** states what
+we chose, why, and what we rejected — so a future agent can audit or revise a
+choice without re-deriving it.
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done ·
+`[-]` dropped (with reason).
+
+---
+
+## 1. Where the baseline actually is (grounded facts, not assumptions)
+
+Read directly from the code and notebook on 2026-07-20:
+
+**Current architecture (`gnn/model.py`):**
+- `GCNClassifier`: 2× `GCNConv` → ReLU → dropout, then **global mean pool**, then
+  a single linear head → 1 logit/graph. `hidden_dim=32`, `num_layers=2`,
+  `dropout=0.2`.
+- `EdgeGNNClassifier`: the junction-mode counterpart (`EdgeConditionedConv`),
+  same mean-pool + linear-head readout.
+- Optional graph-level covariates concatenated onto the pooled embedding before
+  the head (`graph_dim>0`).
+
+**Current training (`gnn/train.py`, confirmed by reading lines 440–483):**
+- Optimizer: plain `Adam`, `lr=0.001`. **No weight decay, no LR scheduler, no
+  gradient clipping.**
+- Loss: plain `BCEWithLogitsLoss`. **No `pos_weight`** (pCR is the minority
+  class, fold pCR rates 0.09–0.48 per the notebook).
+- **Fixed 25 epochs, no early stopping.** The model used for prediction is the
+  **final-epoch** model (line 480, right after the loop) — there is **no
+  best-validation-epoch selection**. A fold that peaks at epoch 10 and decays is
+  reported at its decayed epoch-25 state.
+- Per-fold node-feature standardization (fit on train split only) — good, keep.
+- 5-fold CV, `evaluation/` framework, standard `metrics.json`/`predictions.csv`.
+
+**Current features (`configs/gnn.yaml`):** `["peak_time", "radius"]` (voxel mode).
+Richer `seg_*` geometry, degree, washout, bifurcation-angle, and clinical
+covariates exist in the loader but were **not** used in the latest experiments.
+
+**Current performance (`LAB_NOTEBOOK.md`, 2026-07-15):**
+- GNN val AUC ≈ **0.51**, near chance, **unstable across folds** (fold-only
+  std ≈ 0.038). Fold ranking is consistent across seeds (Spearman 0.9–1.0):
+  fold 0 always worst (~0.45), fold 2 always best (~0.55).
+- Tabular XGBoost on 33 hand-summarized columns (mean/std/q10/q50/q90 of the 6
+  node features + counts): **0.540 ± 0.018** — modestly *above* the GNN, at
+  ~half the fold spread. Logistic regression 0.499 (chance).
+- Per-fold AUC does **not** track between GNN and XGBoost (GNN's worst fold is
+  XGBoost's best) → some fold difficulty is representation-dependent, not purely
+  a cohort confound.
+- Cohort is DUKE-dominated (94% after single-breast harmonization). ISPY1 sits
+  *below* chance (~0.44).
+
+---
+
+## 2. Diagnosis: why "more advanced modeling" is the right lever (and its limits)
+
+Three distinct problems are tangled together. Advanced modeling addresses some
+but not all — naming which is which is the most important decision here.
+
+1. **Under-trained / mis-selected models (optimization hygiene).** Fixed epochs +
+   final-epoch reporting + no imbalance handling means we are almost certainly
+   *not* reporting each model at its best, and the loss is dominated by the
+   majority (non-pCR) class. This is cheap to fix and could account for part of
+   the instability. **Advanced modeling helps here.**
+
+2. **Lossy representation / readout.** XGBoost beats the GNN using *quantiles* of
+   the same node features, while the GNN sees only the **mean** (global mean
+   pool). Distributional tails (max enhancement, quantiles) are exactly what
+   mean-pooling destroys, and the notebook already flags mean-pool signal-washout
+   as a concern. Attention/multi-statistic readout and a stronger conv operator
+   target this directly. **Advanced modeling helps here — highest-value lever.**
+
+3. **Possibly-weak intrinsic signal + cohort confound.** ISPY1 below chance, a
+   DUKE-dominated cohort, and seed-stable fold ranking all point to a
+   cohort/acquisition component that **no architecture change can fix**. This
+   bounds the expected upside and is *the reason the plan is gated* — we do not
+   spend the expensive-technique budget until a cheap change shows the signal is
+   there to be captured.
+
+**Honest ceiling statement:** at ~0.51–0.54 AUC we cannot assume a large gain is
+available. The plan is therefore designed to *fail cheaply and informatively* —
+each tier has a pre-registered stop rule, matching the lab's existing practice
+(the single-breast experiment's pre-registered stop rule, `LAB_NOTEBOOK.md`).
+
+---
+
+## 3. Guiding principles (constraints this plan must respect)
+
+From `AGENTS.md`, `agents.local.md`, and `~/.claude/CLAUDE.md`:
+
+- **Simplicity first** (`agents.local.md`): start with the cheapest change that
+  could move the needle; add complexity only after it earns its place.
+- **Fail fast, few fallbacks.** No defensive try/except, no "try it multiple
+  ways" chains. One interface per choice; break loudly on mismatch.
+- **Reuse before writing.** Check the shared package first; match existing style.
+  `GCNConv` is already imported and reused across `model.py` and `pretrain/`.
+- **No heavy compute on the head node.** Every training run goes through Slurm
+  (`gnn/slurm/`, `tier1q`, account `karczmar-lab`).
+- **Reproducible + audited.** Every new results dir gets a `README.md` (command,
+  config, git commit, inputs) *before* the result is reported; every session
+  appends to `LAB_NOTEBOOK.md`.
+- **Don't silently change cohort/splits.** Fold definitions are frozen; changing
+  them is an explicit, separate decision (see D1 and Open Question OQ-1).
+
+---
+
+## 4. Fixed evaluation protocol (decide once, hold constant across all tiers)
+
+This is the single most important set of decisions: without it, any AUC change
+is uninterpretable. These are locked for the whole plan.
+
+- **Decision D0.1 — Primary metric: paired ΔAUC vs. the baseline, per (seed×fold).**
+  Report mean ΔAUC with the paired distribution, not just two aggregate numbers.
+  *Why:* fold variance (±0.038) dwarfs plausible effect sizes, so an unpaired
+  comparison is underpowered. This is exactly the design the single-breast
+  experiment used (paired delta-AUC by seed×fold, n=15). *Rejected:* comparing
+  aggregate mean AUCs alone — too noisy at this effect size.
+
+- **Decision D0.2 — Frozen folds, shared across arms.** Every arm uses the *same*
+  split definition as the current baseline (`split_mode`, `random_state=42`, same
+  `n_splits=5`). No arm may change folds and architecture at once.
+  *Why:* the notebook already caught the "frozen-fold check proves cohort parity,
+  not representation isolation" subtlety; we keep folds identical so a ΔAUC is
+  attributable to the *model*, not the split. *Rejected:* re-freezing folds
+  stratified by dataset — that is a real idea but a **separate** experiment
+  (OQ-1), not bundled in here.
+
+- **Decision D0.3 — ≥5 seeds per arm; separate fold variance from run variance.**
+  Report the GNN's fold-only std *and* run-only std separately.
+  *Why:* the notebook showed tabular models were deterministic (pure fold std)
+  while the GNN mixes fold + training-run noise; conflating them misled the first
+  std comparison. *Rejected:* 3 seeds (what prior runs used) — too few to trust a
+  small ΔAUC.
+
+- **Decision D0.4 — Report OOF AUC broken out by `dataset` (and ISPY2 laterality).**
+  A gain that only appears on DUKE (94% of cohort) is a cohort artifact, not a
+  method win. Reuse the existing per-dataset OOF breakdown already in
+  `analysis/`. *Rejected:* pooled-only reporting — hides the confound.
+
+- **Decision D0.5 — Keep the leakage canary and confound plots every run.**
+  `pcr_dummy` learnability check + `prediction_vs_num_nodes.png` stay on, so a
+  spurious "win" driven by graph size or a wiring bug is caught immediately.
+
+- **Decision D0.6 — Reference baseline is frozen and named.** The comparison
+  point is **arm-1 voxel mode, `["peak_time","radius"]`, current
+  `GCNClassifier`** (the exact config behind the 0.51 number). Every ΔAUC in
+  this plan is against *that*, on the frozen folds. *Why:* a moving baseline
+  makes tiers incomparable.
+
+---
+
+## 5. Tiered plan (cheap → expensive, each gated by the previous)
+
+Ordering rationale: Tiers 0–1 are cheap, touch only `train.py`/`model.py`, and
+attack diagnosis-problems #1 and #2 (the fixable ones). Tiers 2–3 are expensive
+(new pretraining data, temporal encoders) and only make sense if a cheaper tier
+shows the signal is capturable. **Do not start a tier until the prior tier's gate
+passes.**
+
+### Tier 0 — Optimization hygiene (cheapest; directly from `NOTES.md` TODO)
+
+`NOTES.md` explicitly lists: early stopping, clipping, LR scheduling. Add
+imbalance handling and best-epoch selection alongside, because they are the same
+size of change and address diagnosis-problem #1.
+
+- **[x] D1.1 — Best-validation-epoch model selection.** *Done* (`restore_best_epoch`).
+  **Refinement recorded:** the selection signal is validation **loss**, not val
+  AUC as originally written — this matches `deepsets/train.py` (keeping the two
+  tracks consistent) and val loss is smoother than AUC on these small imbalanced
+  folds. The correctness win (not reporting the arbitrary final epoch) holds
+  either way. *Rejected:* early-stopping-only without checkpointing the best epoch.
+- **[x] D1.2 — Early stopping with patience.** *Done* (`early_stopping_patience`;
+  `epochs` ceiling raised to 100 in `gnn_tier0.yaml`). Verified firing on the
+  smoke cache (fold stopped at epoch 5, best epoch 1).
+- **[x] D1.3 — `pos_weight` in `BCEWithLogitsLoss`.** *Done* via `loss:
+  weighted_bce` (`pos_weight = n_neg/n_pos` from the fold train split). A
+  zero-positive fold falls back to `pos_weight=1.0` **and logs its class
+  balance** — a degenerate split surfaced, not silently defaulted. `focal` is
+  also wired (`loss: focal`) for later if `pos_weight` under-delivers.
+- **[x] D1.4 — Weight decay + gradient clipping.** *Done* (`weight_decay`,
+  `max_grad_norm`). `gnn_tier0.yaml` uses `1e-4` / `1.0`.
+- **[x] D1.5 — LR scheduler.** *Done* (`lr_scheduler: plateau` in
+  `gnn_tier0.yaml`; `cosine` also available). Composes with early stopping.
+
+**Implementation note (fail-fast):** all Tier-0 knobs reuse the existing shared
+`model_params` config keys that `deepsets/train.py` already consumes — the GNN
+simply had never wired them in. `build_loss_fn` / `FocalWithLogitsLoss` are small
+local copies of the Deep Sets versions (reimplemented, not cross-imported, to
+avoid coupling the two model tracks). Every existing GNN config's behavior is
+preserved: the shared defaults (`weight_decay=1e-4`, `loss=weighted_bce`) differ
+from the historical GNN runs, so `configs/gnn.yaml` and `gnn_smoke.yaml` now
+**pin** the historical values explicitly (D0.6) rather than silently inheriting
+the new defaults. No fallback chains.
+
+**Status: code + configs landed on branch `feat/gnn-tier0-training`, validated
+end-to-end on the 8-case smoke cache.** The real 5-fold run (baseline
+`gnn.yaml` vs `gnn_tier0.yaml`, ≥5 seeds, D0 protocol, via Slurm) is the next
+action and is **blocked** on a data-path issue found during verification:
+`pcr_labels.csv` has moved from `.../saritbose/pcr_labels.csv` to
+`.../saritbose/metadata/pcr_labels.csv` (the committed configs and
+`agents.local.md` still point at the old path). Resolve that path decision
+before submitting (see §7 / Open Questions).
+
+- **Gate G0 (pre-registered):** run baseline + Tier-0 stack under the D0 protocol.
+  **Proceed to Tier 1 only if** mean paired ΔAUC > 0 with the paired distribution
+  not straddling 0 *or* fold-only std drops meaningfully (stability win counts).
+  If Tier 0 does nothing on either axis, that is itself a finding (the problem is
+  representation/signal, not optimization) — go **straight to Tier 1's readout
+  change**, which is the representation lever, and record the null.
+
+### Tier 1 — Architecture: readout and convolution (the highest-value lever)
+
+Attacks diagnosis-problem #2 (mean-pool washes out the distributional signal
+XGBoost exploits). Do readout **before** fancier convs — it is cheaper and the
+evidence (quantiles beat mean) points straight at it.
+
+- **[ ] D2.1 — Multi-statistic readout: concat `[mean ‖ max ‖ sum]` pool.**
+  Replace the lone `global_mean_pool` with concatenated mean+max(+sum) pools into
+  the head. *Why:* directly restores the tail/extreme information (peak
+  enhancement, quantiles) that beat the mean in the tabular baseline; ~10 lines,
+  no new layer types. **This is the first thing to try in Tier 1.** *Rejected as
+  the opener:* attention pooling (D2.2) — more parameters, try only if
+  multi-stat readout under-delivers.
+- **[ ] D2.2 — Attention readout (`GlobalAttention` / `Set2Set`).** A learned,
+  node-weighted pooling. *Why:* if some vessels/segments carry the pCR signal and
+  most are noise, attention can up-weight them — and the attention weights double
+  as **saliency maps** (a separate `NOTES.md` TODO). *Gated behind D2.1:* only if
+  multi-stat readout shows a signal worth refining.
+- **[ ] D2.3 — Stronger conv operator: `GraphSAGE` or `GATConv`.** Swap `GCNConv`
+  for one alternative (pick **one**, not a sweep-of-everything — start with
+  `GraphSAGE` for robustness with max-aggregation; `GATv2Conv` if we want
+  attention + saliency and the graphs are small enough). *Why:* `GCNConv`'s
+  symmetric-normalized mean aggregation is the weakest common operator and, like
+  mean-pool, is averaging-biased. *Rejected:* GIN (built for graph-isomorphism /
+  molecular tasks; less obviously suited to continuous per-node kinetic signal);
+  running GCN/SAGE/GAT/GIN as a 4-way sweep (violates simplicity-first — commit to
+  one, justify, and only branch if it fails).
+- **[ ] D2.4 — Depth + over-smoothing control: JumpingKnowledge or residuals,
+  and/or `BatchNorm`/`LayerNorm` between convs.** *Why:* only if we want >2 layers;
+  2-layer GNNs under-reach on long vessel paths, but naive deepening over-smooths.
+  *Gated:* only pursue if a wider receptive field is hypothesized to matter (e.g.
+  segment/junction modes where paths are longer). Keep at 2 layers otherwise.
+
+- **Also settle the features confound here (D2.5).** Before crediting architecture
+  for any gain, run **one** arm that gives the *current* `GCNClassifier` the
+  richer `seg_*`/geometry/degree feature set that the latest experiments omitted.
+  *Why:* the notebook explicitly flags that the richer feature set was never
+  tested and could change the picture; if features alone close the gap, we should
+  know before attributing it to architecture. This is a feature arm, not an
+  architecture arm — keep it labeled as such.
+
+- **Gate G1 (pre-registered):** best Tier-1 arm vs. best Tier-0 model, D0 protocol.
+  **Proceed to Tier 2 only if** the best architecture reaches an absolute OOF AUC
+  that (a) clears the XGBoost tabular baseline (0.540) *and* (b) shows a positive
+  paired ΔAUC that holds on non-DUKE datasets (D0.4), not DUKE-only. If Tier 1
+  cannot beat a quantile-on-features XGBoost, the GNN is not yet earning its
+  complexity and Tier 2/3 are premature — record that verdict.
+
+### Tier 2 — Self-supervised pretraining (already prototyped; high ceiling)
+
+`NOTES.md` "This Week: Pretraining task"; a contrast-forecasting pilot already
+exists (`gnn/pretrain/`, `project_contrast_forecasting_pilot` memory). This is
+where the currently-discarded **temporal** DCE signal re-enters the model.
+
+- **[ ] D3.1 — Pretrain the encoder on node-level contrast forecasting (SSL),
+  then fine-tune the classifier head.** Use `ContrastForecastGNN`
+  (`gnn/pretrain/model.py`) as the shared encoder: predict each node's future
+  enhancement frames (label-free), then transfer the `GCNConv` stack into
+  `GCNClassifier` and fine-tune on pCR. *Why:* pCR labels are scarce and noisy
+  (~1500 cases, imbalanced); a label-free objective over the full 4D signal is the
+  standard way to get a stronger encoder. The forecasting pilot already beat
+  trivial baselines (MAE 0.022 vs last-frame 0.225) on the placeholder data.
+- **[ ] D3.2 — Keep the "does the graph matter" ablation.** The pretrain package
+  already ships `PerNodeForecaster` (graph-free, same temporal head). Carry that
+  ablation into fine-tuning: if the graph-free pretrained encoder fine-tunes as
+  well as the GNN one, the message-passing is not what's helping — a falsifier we
+  want kept live (matches the design doc §7.ii).
+- **Open decisions inherited from the pilot** (`project_contrast_forecasting_pilot`
+  memory, unresolved): **Q1** variable-T handling across cohorts; **Q2** target
+  normalization for the forecasting loss. These must be settled *before* a
+  real-cohort pretrain run — flagged here so they are not silently defaulted.
+
+- **Gate G2:** fine-tuned-from-pretrained vs. best Tier-1 from-scratch, D0
+  protocol. Proceed to invest further in pretraining only if it beats
+  from-scratch on the paired ΔAUC, on non-DUKE data.
+
+### Tier 3 — Explicit temporal encoding in the classifier (most speculative)
+
+`NOTES.md` "This Week: Encode the temporal structure from contrast." Currently the
+temporal axis is collapsed to scalars (`peak_time`, `washin_slope`, …). A per-node
+temporal encoder (GRU/TCN over frames) inside the classifier — reusing the
+`_TemporalForecastHead`-style encoder from `pretrain/` — would keep the dynamics
+the loader is told to preserve (`AGENTS.md`: "Do not discard dynamic/kinematic
+information").
+
+- **[ ] D4.1 — Per-node GRU/TCN over raw frames → GNN, end-to-end for pCR.**
+  Only pursue if Tier 2 shows the temporal signal carries pCR information (Tier 2
+  is the cheaper test of the same hypothesis, since it reuses the temporal
+  encoder without a full end-to-end classifier). *Rejected as an earlier tier:*
+  it is the most code and the most compute for a hypothesis Tier 2 screens first.
+
+---
+
+## 6. Cross-cutting decisions
+
+- **Decision D5 — One change per arm.** Never combine a readout change, a conv
+  change, and a loss change in one arm and call the delta "the architecture."
+  Ablate one axis at a time against the frozen baseline. *Why:* the notebook's
+  own methodological correction (junction arm changed representation *and*
+  architecture, muddying attribution) is the mistake this rule prevents.
+- **Decision D6 — Config-driven, no new parallel scripts.** Every knob above is a
+  `model_params`/config field consumed by the existing `gnn/train.py`, matching
+  the repo's "extend the CLI/config, don't fork one-off scripts" preference
+  (`prefer_config_over_new_scripts` memory). New model *classes* go in
+  `gnn/model.py`; new training *behavior* goes in `train.py` behind config.
+- **Decision D7 — Graph mode held fixed at voxel for Tiers 0–1.** Establish the
+  modeling wins on the already-validated voxel baseline first; only revisit
+  segment/junction modes (D2.4's longer paths) once a voxel-mode win exists.
+  *Why:* changing mode + architecture at once re-introduces the confound D5 bans.
+- **Decision D8 — Every arm writes a results `README.md` + `LAB_NOTEBOOK.md`
+  entry** with the exact command, config snapshot, git commit, and the paired
+  ΔAUC table, per repo policy — *before* the result is reported anywhere.
+
+---
+
+## 7. Open questions to resolve with the human (not silently defaulted)
+
+- **OQ-1 — Re-freeze folds stratified jointly by dataset?** The notebook found
+  fold pCR rates swing 0.09–0.48; joint dataset-stratification might cut fold
+  variance. But it changes the frozen split, so it is a **separate, explicit**
+  decision and would reset the D0.6 baseline. Recommend running it as its own
+  A/B *after* Tier 0, not folding it into the modeling tiers.
+- **OQ-2 — Is 0.54 (XGBoost) the bar, or is there a target AUC from the clinical
+  side?** The gate G1 uses 0.540 as the "earn your complexity" threshold; if the
+  team has a different clinically-meaningful bar, it changes the stop rules.
+- **OQ-3 — Pretraining data source (Q1/Q2 above).** Duke placeholder vs. the full
+  cohort, variable-T handling, and target normalization must be pinned before any
+  real Tier-2 run.
+
+---
+
+## 8. First concrete step
+
+Implement Tier 0 (D1.1–D1.5) as config fields in `gnn/train.py`, with **best-val-
+epoch selection defaulted on** and everything else defaulted to reproduce the
+current baseline exactly. Run baseline + Tier-0 on the frozen folds under the D0
+protocol via Slurm. Evaluate against Gate G0. This is the cheapest change with a
+plausible correctness fix (final-epoch reporting) already identified in the code.
+
+*Nothing in this plan runs compute on the head node; every training arm is a
+Slurm job under `tier1q`/`karczmar-lab`.*

--- a/gnn/PLAN_advanced_modeling.md
+++ b/gnn/PLAN_advanced_modeling.md
@@ -1,9 +1,9 @@
 # Plan: Improving GNN Baseline Performance with More Advanced Modeling
 
 **Scope:** the vessel-centerline **GNN** pCR classifier only (`gnn/model.py`,
-`gnn/train.py`). Not the tabular or Deep Sets tracks. Derived from `NOTES.md`
-("Look into more sophisticated modeling approaches" + "This Week" items) and the
-diagnosis recorded in `LAB_NOTEBOOK.md` (2026-07-15 entries).
+`gnn/train.py`). Not the tabular or Deep Sets tracks. This plan consolidates the
+GNN modeling backlog and the 2026-07-15 baseline diagnosis (§1) into auditable
+decisions.
 
 **Author intent (from the task):** come up with a plan to improve baseline model
 performance using more advanced modeling techniques, and *record every decision
@@ -18,7 +18,7 @@ Status legend: `[ ]` not started · `[~]` in progress · `[x]` done ·
 
 ## 1. Where the baseline actually is (grounded facts, not assumptions)
 
-Read directly from the code and notebook on 2026-07-20:
+Read directly from the code on 2026-07-20:
 
 **Current architecture (`gnn/model.py`):**
 - `GCNClassifier`: 2× `GCNConv` → ReLU → dropout, then **global mean pool**, then
@@ -33,7 +33,7 @@ Read directly from the code and notebook on 2026-07-20:
 - Optimizer: plain `Adam`, `lr=0.001`. **No weight decay, no LR scheduler, no
   gradient clipping.**
 - Loss: plain `BCEWithLogitsLoss`. **No `pos_weight`** (pCR is the minority
-  class, fold pCR rates 0.09–0.48 per the notebook).
+  class, fold pCR rates 0.09–0.48).
 - **Fixed 25 epochs, no early stopping.** The model used for prediction is the
   **final-epoch** model (line 480, right after the loop) — there is **no
   best-validation-epoch selection**. A fold that peaks at epoch 10 and decays is
@@ -45,7 +45,7 @@ Read directly from the code and notebook on 2026-07-20:
 Richer `seg_*` geometry, degree, washout, bifurcation-angle, and clinical
 covariates exist in the loader but were **not** used in the latest experiments.
 
-**Current performance (`LAB_NOTEBOOK.md`, 2026-07-15):**
+**Current performance (baseline diagnosis, measured 2026-07-15):**
 - GNN val AUC ≈ **0.51**, near chance, **unstable across folds** (fold-only
   std ≈ 0.038). Fold ranking is consistent across seeds (Spearman 0.9–1.0):
   fold 0 always worst (~0.45), fold 2 always best (~0.55).
@@ -74,9 +74,9 @@ but not all — naming which is which is the most important decision here.
 2. **Lossy representation / readout.** XGBoost beats the GNN using *quantiles* of
    the same node features, while the GNN sees only the **mean** (global mean
    pool). Distributional tails (max enhancement, quantiles) are exactly what
-   mean-pooling destroys, and the notebook already flags mean-pool signal-washout
-   as a concern. Attention/multi-statistic readout and a stronger conv operator
-   target this directly. **Advanced modeling helps here — highest-value lever.**
+   mean-pooling destroys, and mean-pool signal-washout is a known concern here.
+   Attention/multi-statistic readout and a stronger conv operator target this
+   directly. **Advanced modeling helps here — highest-value lever.**
 
 3. **Possibly-weak intrinsic signal + cohort confound.** ISPY1 below chance, a
    DUKE-dominated cohort, and seed-stable fold ranking all point to a
@@ -88,16 +88,16 @@ but not all — naming which is which is the most important decision here.
 **Honest ceiling statement:** at ~0.51–0.54 AUC we cannot assume a large gain is
 available. The plan is therefore designed to *fail cheaply and informatively* —
 each tier has a pre-registered stop rule, matching the lab's existing practice
-(the single-breast experiment's pre-registered stop rule, `LAB_NOTEBOOK.md`).
+(the single-breast experiment used the same pre-registered-stop-rule design).
 
 ---
 
 ## 3. Guiding principles (constraints this plan must respect)
 
-From `AGENTS.md`, `agents.local.md`, and `~/.claude/CLAUDE.md`:
+From `AGENTS.md` and the project's working conventions:
 
-- **Simplicity first** (`agents.local.md`): start with the cheapest change that
-  could move the needle; add complexity only after it earns its place.
+- **Simplicity first:** start with the cheapest change that could move the
+  needle; add complexity only after it earns its place.
 - **Fail fast, few fallbacks.** No defensive try/except, no "try it multiple
   ways" chains. One interface per choice; break loudly on mismatch.
 - **Reuse before writing.** Check the shared package first; match existing style.
@@ -105,8 +105,8 @@ From `AGENTS.md`, `agents.local.md`, and `~/.claude/CLAUDE.md`:
 - **No heavy compute on the head node.** Every training run goes through Slurm
   (`gnn/slurm/`, `tier1q`, account `karczmar-lab`).
 - **Reproducible + audited.** Every new results dir gets a `README.md` (command,
-  config, git commit, inputs) *before* the result is reported; every session
-  appends to `LAB_NOTEBOOK.md`.
+  config, git commit, inputs) *before* the result is reported; every session is
+  recorded in the project lab notebook.
 - **Don't silently change cohort/splits.** Fold definitions are frozen; changing
   them is an explicit, separate decision (see D1 and Open Question OQ-1).
 
@@ -127,23 +127,22 @@ is uninterpretable. These are locked for the whole plan.
 - **Decision D0.2 — Frozen folds, shared across arms.** Every arm uses the *same*
   split definition as the current baseline (`split_mode`, `random_state=42`, same
   `n_splits=5`). No arm may change folds and architecture at once.
-  *Why:* the notebook already caught the "frozen-fold check proves cohort parity,
-  not representation isolation" subtlety; we keep folds identical so a ΔAUC is
+  *Why:* an earlier frozen-fold check already surfaced the "cohort parity is not
+  representation isolation" subtlety; we keep folds identical so a ΔAUC is
   attributable to the *model*, not the split. *Rejected:* re-freezing folds
   stratified by dataset — that is a real idea but a **separate** experiment
   (OQ-1), not bundled in here.
 
 - **Decision D0.3 — ≥5 seeds per arm; separate fold variance from run variance.**
   Report the GNN's fold-only std *and* run-only std separately.
-  *Why:* the notebook showed tabular models were deterministic (pure fold std)
-  while the GNN mixes fold + training-run noise; conflating them misled the first
-  std comparison. *Rejected:* 3 seeds (what prior runs used) — too few to trust a
-  small ΔAUC.
+  *Why:* tabular models were deterministic (pure fold std) while the GNN mixes
+  fold + training-run noise; conflating them misled the first std comparison.
+  *Rejected:* 3 seeds (what prior runs used) — too few to trust a small ΔAUC.
 
 - **Decision D0.4 — Report OOF AUC broken out by `dataset` (and ISPY2 laterality).**
   A gain that only appears on DUKE (94% of cohort) is a cohort artifact, not a
-  method win. Reuse the existing per-dataset OOF breakdown already in
-  `analysis/`. *Rejected:* pooled-only reporting — hides the confound.
+  method win. Report the per-dataset OOF breakdown. *Rejected:* pooled-only
+  reporting — hides the confound.
 
 - **Decision D0.5 — Keep the leakage canary and confound plots every run.**
   `pcr_dummy` learnability check + `prediction_vs_num_nodes.png` stay on, so a
@@ -165,9 +164,9 @@ attack diagnosis-problems #1 and #2 (the fixable ones). Tiers 2–3 are expensiv
 shows the signal is capturable. **Do not start a tier until the prior tier's gate
 passes.**
 
-### Tier 0 — Optimization hygiene (cheapest; directly from `NOTES.md` TODO)
+### Tier 0 — Optimization hygiene (cheapest)
 
-`NOTES.md` explicitly lists: early stopping, clipping, LR scheduling. Add
+The optimization backlog is: early stopping, clipping, LR scheduling. Add
 imbalance handling and best-epoch selection alongside, because they are the same
 size of change and address diagnosis-problem #1.
 
@@ -200,14 +199,11 @@ from the historical GNN runs, so `configs/gnn.yaml` and `gnn_smoke.yaml` now
 **pin** the historical values explicitly (D0.6) rather than silently inheriting
 the new defaults. No fallback chains.
 
-**Status: code + configs landed on branch `feat/gnn-tier0-training`, validated
-end-to-end on the 8-case smoke cache.** The real 5-fold run (baseline
-`gnn.yaml` vs `gnn_tier0.yaml`, ≥5 seeds, D0 protocol, via Slurm) is the next
-action and is **blocked** on a data-path issue found during verification:
-`pcr_labels.csv` has moved from `.../saritbose/pcr_labels.csv` to
-`.../saritbose/metadata/pcr_labels.csv` (the committed configs and
-`agents.local.md` still point at the old path). Resolve that path decision
-before submitting (see §7 / Open Questions).
+**Status: code + configs implemented and validated end-to-end on the 8-case
+smoke cache.** The `pcr_labels.csv` path was relocated to
+`.../saritbose/metadata/pcr_labels.csv` and every config updated to match. The
+real 5-fold run (baseline `gnn.yaml` vs `gnn_tier0.yaml`, ≥5 seeds, D0 protocol,
+via Slurm) is the next action.
 
 - **Gate G0 (pre-registered):** run baseline + Tier-0 stack under the D0 protocol.
   **Proceed to Tier 1 only if** mean paired ΔAUC > 0 with the paired distribution
@@ -232,7 +228,7 @@ evidence (quantiles beat mean) points straight at it.
 - **[ ] D2.2 — Attention readout (`GlobalAttention` / `Set2Set`).** A learned,
   node-weighted pooling. *Why:* if some vessels/segments carry the pCR signal and
   most are noise, attention can up-weight them — and the attention weights double
-  as **saliency maps** (a separate `NOTES.md` TODO). *Gated behind D2.1:* only if
+  as **saliency maps** (a separate saliency goal). *Gated behind D2.1:* only if
   multi-stat readout shows a signal worth refining.
 - **[ ] D2.3 — Stronger conv operator: `GraphSAGE` or `GATConv`.** Swap `GCNConv`
   for one alternative (pick **one**, not a sweep-of-everything — start with
@@ -252,10 +248,10 @@ evidence (quantiles beat mean) points straight at it.
 - **Also settle the features confound here (D2.5).** Before crediting architecture
   for any gain, run **one** arm that gives the *current* `GCNClassifier` the
   richer `seg_*`/geometry/degree feature set that the latest experiments omitted.
-  *Why:* the notebook explicitly flags that the richer feature set was never
-  tested and could change the picture; if features alone close the gap, we should
-  know before attributing it to architecture. This is a feature arm, not an
-  architecture arm — keep it labeled as such.
+  *Why:* the richer feature set was never tested and could change the picture; if
+  features alone close the gap, we should know before attributing it to
+  architecture. This is a feature arm, not an architecture arm — keep it labeled
+  as such.
 
 - **Gate G1 (pre-registered):** best Tier-1 arm vs. best Tier-0 model, D0 protocol.
   **Proceed to Tier 2 only if** the best architecture reaches an absolute OOF AUC
@@ -266,8 +262,7 @@ evidence (quantiles beat mean) points straight at it.
 
 ### Tier 2 — Self-supervised pretraining (already prototyped; high ceiling)
 
-`NOTES.md` "This Week: Pretraining task"; a contrast-forecasting pilot already
-exists (`gnn/pretrain/`, `project_contrast_forecasting_pilot` memory). This is
+A contrast-forecasting SSL pilot already exists (`gnn/pretrain/`). This is
 where the currently-discarded **temporal** DCE signal re-enters the model.
 
 - **[ ] D3.1 — Pretrain the encoder on node-level contrast forecasting (SSL),
@@ -282,11 +277,11 @@ where the currently-discarded **temporal** DCE signal re-enters the model.
   already ships `PerNodeForecaster` (graph-free, same temporal head). Carry that
   ablation into fine-tuning: if the graph-free pretrained encoder fine-tunes as
   well as the GNN one, the message-passing is not what's helping — a falsifier we
-  want kept live (matches the design doc §7.ii).
-- **Open decisions inherited from the pilot** (`project_contrast_forecasting_pilot`
-  memory, unresolved): **Q1** variable-T handling across cohorts; **Q2** target
-  normalization for the forecasting loss. These must be settled *before* a
-  real-cohort pretrain run — flagged here so they are not silently defaulted.
+  want kept live.
+- **Open decisions inherited from the pilot** (unresolved): **Q1** variable-T
+  handling across cohorts; **Q2** target normalization for the forecasting loss.
+  These must be settled *before* a real-cohort pretrain run — flagged here so
+  they are not silently defaulted.
 
 - **Gate G2:** fine-tuned-from-pretrained vs. best Tier-1 from-scratch, D0
   protocol. Proceed to invest further in pretraining only if it beats
@@ -294,12 +289,11 @@ where the currently-discarded **temporal** DCE signal re-enters the model.
 
 ### Tier 3 — Explicit temporal encoding in the classifier (most speculative)
 
-`NOTES.md` "This Week: Encode the temporal structure from contrast." Currently the
-temporal axis is collapsed to scalars (`peak_time`, `washin_slope`, …). A per-node
-temporal encoder (GRU/TCN over frames) inside the classifier — reusing the
-`_TemporalForecastHead`-style encoder from `pretrain/` — would keep the dynamics
-the loader is told to preserve (`AGENTS.md`: "Do not discard dynamic/kinematic
-information").
+Currently the temporal axis is collapsed to scalars (`peak_time`,
+`washin_slope`, …). A per-node temporal encoder (GRU/TCN over frames) inside the
+classifier — reusing the `_TemporalForecastHead`-style encoder from `pretrain/` —
+would keep the dynamics the loader is told to preserve (`AGENTS.md`: "Do not
+discard dynamic/kinematic information").
 
 - **[ ] D4.1 — Per-node GRU/TCN over raw frames → GNN, end-to-end for pCR.**
   Only pursue if Tier 2 shows the temporal signal carries pCR information (Tier 2
@@ -313,31 +307,31 @@ information").
 
 - **Decision D5 — One change per arm.** Never combine a readout change, a conv
   change, and a loss change in one arm and call the delta "the architecture."
-  Ablate one axis at a time against the frozen baseline. *Why:* the notebook's
-  own methodological correction (junction arm changed representation *and*
-  architecture, muddying attribution) is the mistake this rule prevents.
+  Ablate one axis at a time against the frozen baseline. *Why:* an earlier
+  junction arm changed representation *and* architecture at once, muddying
+  attribution — the mistake this rule prevents.
 - **Decision D6 — Config-driven, no new parallel scripts.** Every knob above is a
   `model_params`/config field consumed by the existing `gnn/train.py`, matching
-  the repo's "extend the CLI/config, don't fork one-off scripts" preference
-  (`prefer_config_over_new_scripts` memory). New model *classes* go in
-  `gnn/model.py`; new training *behavior* goes in `train.py` behind config.
+  the repo's "extend the CLI/config, don't fork one-off scripts" preference.
+  New model *classes* go in `gnn/model.py`; new training *behavior* goes in
+  `train.py` behind config.
 - **Decision D7 — Graph mode held fixed at voxel for Tiers 0–1.** Establish the
   modeling wins on the already-validated voxel baseline first; only revisit
   segment/junction modes (D2.4's longer paths) once a voxel-mode win exists.
   *Why:* changing mode + architecture at once re-introduces the confound D5 bans.
-- **Decision D8 — Every arm writes a results `README.md` + `LAB_NOTEBOOK.md`
-  entry** with the exact command, config snapshot, git commit, and the paired
-  ΔAUC table, per repo policy — *before* the result is reported anywhere.
+- **Decision D8 — Every arm writes a results `README.md` and a project
+  lab-notebook entry** with the exact command, config snapshot, git commit, and
+  the paired ΔAUC table, per repo policy — *before* the result is reported anywhere.
 
 ---
 
 ## 7. Open questions to resolve with the human (not silently defaulted)
 
-- **OQ-1 — Re-freeze folds stratified jointly by dataset?** The notebook found
-  fold pCR rates swing 0.09–0.48; joint dataset-stratification might cut fold
-  variance. But it changes the frozen split, so it is a **separate, explicit**
-  decision and would reset the D0.6 baseline. Recommend running it as its own
-  A/B *after* Tier 0, not folding it into the modeling tiers.
+- **OQ-1 — Re-freeze folds stratified jointly by dataset?** Fold pCR rates swing
+  0.09–0.48; joint dataset-stratification might cut fold variance. But it changes
+  the frozen split, so it is a **separate, explicit** decision and would reset the
+  D0.6 baseline. Recommend running it as its own A/B *after* Tier 0, not folding
+  it into the modeling tiers.
 - **OQ-2 — Is 0.54 (XGBoost) the bar, or is there a target AUC from the clinical
   side?** The gate G1 uses 0.540 as the "earn your complexity" threshold; if the
   team has a different clinically-meaningful bar, it changes the stop rules.

--- a/gnn/README.md
+++ b/gnn/README.md
@@ -272,11 +272,15 @@ each case has many timepoints.
 
 ## Model + training
 
-`gnn/model.py` provides `GCNClassifier`: a stack of `GCNConv` layers, a global
-mean-pool readout to one embedding per graph, and a linear head producing one
-logit per graph. No edge features, attention, or segment-level pooling yet --
-those are deliberate next steps once this MVP is validated end-to-end, not
-omissions.
+`gnn/model.py` provides `GCNClassifier`: a stack of `GCNConv` layers, a
+configurable graph readout, and a linear head producing one logit per graph.
+The readout is set by `model_params.gnn_pooling` (Tier 1, decision D2.1):
+`"mean"` (default, the original single `global_mean_pool` -- backward
+compatible), `"mean_max"`, or `"mean_max_sum"`, which concatenate global
+max/add pools so the graph embedding keeps the distributional tails mean-pool
+discards (`gnn/model.py` `POOLING_WIDTHS` / `_graph_readout`). Junction mode
+(`EdgeGNNClassifier`) still mean-pools only. Attention readout and stronger
+conv operators are the next Tier-1 steps (see `gnn/PLAN_advanced_modeling.md`).
 
 Outline of `gnn/train.py`:
 

--- a/gnn/README.md
+++ b/gnn/README.md
@@ -295,11 +295,42 @@ Outline of `gnn/train.py`:
    `evaluation/kfold.py` (`create_predefined_splits`), so any model family can
    opt into the same fold definition.
 4. Train a fresh `GCNClassifier` per fold (`fit_predict_one_fold`):
-   node-feature standardization fit on that fold's train split only, plain
-   `BCEWithLogitsLoss`, metrics via `evaluation.metrics.compute_binary_metrics`.
+   node-feature standardization fit on that fold's train split only, a
+   config-selected loss (`build_loss_fn`), metrics via
+   `evaluation.metrics.compute_binary_metrics`.
 5. Aggregate fold predictions with `evaluator.aggregate_kfold_results` and
    save with `evaluator.save_results` -- the same `metrics.json` /
    `predictions.csv` / ROC-PR plots convention every other model family uses.
+
+### Training knobs (Tier 0)
+
+`fit_predict_one_fold` honors the same `model_params` training knobs as
+`deepsets/train.py` (their implementations are deliberately parallel; see
+`gnn/PLAN_advanced_modeling.md`, Tier 0). All default to reproducing the
+historical plain-Adam / final-epoch behavior *except* the two shared config
+defaults noted below, so **`configs/gnn.yaml` pins them explicitly** to stay a
+faithful baseline reference (decision D0.6):
+
+- `loss` -- `weighted_bce` (default; `pos_weight = n_neg/n_pos` from the fold's
+  train split, up-weighting the minority pCR class), `unweighted_bce` (the
+  historical plain `BCEWithLogitsLoss`), or `focal` (`focal_alpha`/`focal_gamma`).
+  A fold with zero training positives falls back to `pos_weight=1.0` and logs
+  its class balance -- a degenerate split, not a silent default.
+- `weight_decay` -- Adam L2 penalty (shared default `1e-4`).
+- `max_grad_norm` -- global grad-norm clip before each step (`0.0` disables).
+- `lr_scheduler` -- `none` (default), `cosine` (`CosineAnnealingLR`), or
+  `plateau` (`ReduceLROnPlateau` on val loss, with `lr_scheduler_factor` /
+  `lr_scheduler_patience`).
+- `early_stopping_patience` -- stop after N epochs with no val-loss improvement
+  (`0` disables). Raise `epochs` so patience, not the ceiling, ends most folds.
+- `restore_best_epoch` -- report the best-**val-loss** epoch's weights instead of
+  the final epoch's. (Val loss, not val AUC, matches `deepsets/train.py` and is
+  smoother on these small imbalanced folds.) `loss_history.csv` gains an `lr`
+  column so the schedule is auditable.
+
+The Tier-0 arm that turns these on lives in `configs/gnn_tier0.yaml` (identical
+to `gnn.yaml` except the training knobs, so a paired ΔAUC is attributable to
+optimization, not representation).
 
 Config-driven, like `tabular/train.py` and `deepsets/train.py`:
 

--- a/gnn/build_dataset.py
+++ b/gnn/build_dataset.py
@@ -22,7 +22,7 @@ _DEFAULT_ROOT = Path(
     "/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies"
 )
 _DEFAULT_LABELS_PATH = Path(
-    "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+    "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
 )
 _DEFAULT_DCE_ROOT = Path("/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images")
 _DEFAULT_CACHE_DIR = Path(

--- a/gnn/make_fold_assignments.py
+++ b/gnn/make_fold_assignments.py
@@ -42,7 +42,7 @@ from evaluation.kfold import create_kfold_splits
 from tabular.cohort import load_labels
 
 _DEFAULT_LABELS_PATH = Path(
-    "/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv"
+    "/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv"
 )
 _DEFAULT_OUT = Path("/ess/scratch/scratch1/t-9svena/gnn_caches/pcr_labels_folded.csv")
 

--- a/gnn/model.py
+++ b/gnn/model.py
@@ -26,11 +26,47 @@ from __future__ import annotations
 
 import torch
 from torch import nn
-from torch_geometric.nn import GCNConv, MessagePassing, global_mean_pool
+from torch_geometric.nn import (
+    GCNConv,
+    MessagePassing,
+    global_add_pool,
+    global_max_pool,
+    global_mean_pool,
+)
+
+# Readout variants for the whole-graph pooling step. A GCNConv stack followed by
+# global_mean_pool collapses every node to its *average*, which discards the
+# distributional tails (peak/extreme per-node signal) -- the Tier-0 sweep found
+# a tabular model on node-feature *quantiles* still beats the mean-pool GNN, so
+# concatenating max (and optionally sum) restores that information. See
+# gnn/PLAN_advanced_modeling.md decision D2.1. Values are the number of pooled
+# vectors concatenated, which scales the classifier's input width.
+POOLING_WIDTHS: dict[str, int] = {"mean": 1, "mean_max": 2, "mean_max_sum": 3}
+
+
+def _graph_readout(
+    h: torch.Tensor, batch_index: torch.Tensor, pooling: str
+) -> torch.Tensor:
+    """Concatenate the pooled node embeddings selected by ``pooling``.
+
+    ``"mean"`` reproduces the original single ``global_mean_pool`` readout;
+    ``"mean_max"``/``"mean_max_sum"`` append global max (and add) pools so the
+    graph embedding keeps extreme/aggregate node signal, not just the average.
+    """
+    parts = [global_mean_pool(h, batch_index)]
+    if pooling in ("mean_max", "mean_max_sum"):
+        parts.append(global_max_pool(h, batch_index))
+    if pooling == "mean_max_sum":
+        parts.append(global_add_pool(h, batch_index))
+    return torch.cat(parts, dim=1)
 
 
 class GCNClassifier(nn.Module):
-    """GCNConv stack -> global mean pool -> linear head, one logit per graph."""
+    """GCNConv stack -> graph readout -> linear head, one logit per graph.
+
+    ``pooling`` selects the readout (see ``POOLING_WIDTHS``); the default
+    ``"mean"`` is the original single mean-pool, fully backward compatible.
+    """
 
     def __init__(
         self,
@@ -40,6 +76,7 @@ class GCNClassifier(nn.Module):
         num_layers: int = 2,
         dropout: float = 0.2,
         graph_dim: int = 0,
+        pooling: str = "mean",
     ) -> None:
         super().__init__()
         if input_dim <= 0:
@@ -48,14 +85,20 @@ class GCNClassifier(nn.Module):
             raise ValueError("num_layers must be at least 1")
         if graph_dim < 0:
             raise ValueError("graph_dim must be >= 0")
+        if pooling not in POOLING_WIDTHS:
+            raise ValueError(
+                f"Unknown pooling {pooling!r}. Choose from {sorted(POOLING_WIDTHS)}."
+            )
         self.graph_dim = graph_dim
+        self.pooling = pooling
         self.convs = nn.ModuleList()
         in_dim = input_dim
         for _ in range(num_layers):
             self.convs.append(GCNConv(in_dim, hidden_dim))
             in_dim = hidden_dim
         self.dropout = nn.Dropout(p=dropout)
-        self.classifier = nn.Linear(hidden_dim + graph_dim, 1)
+        pooled_dim = hidden_dim * POOLING_WIDTHS[pooling]
+        self.classifier = nn.Linear(pooled_dim + graph_dim, 1)
 
     def forward(
         self,
@@ -74,7 +117,7 @@ class GCNClassifier(nn.Module):
             h = conv(h, edge_index)
             h = torch.relu(h)
             h = self.dropout(h)
-        pooled = global_mean_pool(h, batch_index)
+        pooled = _graph_readout(h, batch_index, self.pooling)
         if self.graph_dim > 0:
             if graph_features is None:
                 raise ValueError("graph_features is required when graph_dim > 0")

--- a/gnn/slurm/submit_gnn_build.slurm
+++ b/gnn/slurm/submit_gnn_build.slurm
@@ -42,7 +42,7 @@ export PYTHONUNBUFFERED=1
 
 ROOT="${ROOT:-/gpfs/data/karczmar-lab/workspaces/saritbose/centerlines_tc4d/studies}"
 DCE_ROOT="${DCE_ROOT:-/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/images}"
-LABELS_PATH="${LABELS_PATH:-/gpfs/data/karczmar-lab/workspaces/saritbose/pcr_labels.csv}"
+LABELS_PATH="${LABELS_PATH:-/gpfs/data/karczmar-lab/workspaces/saritbose/metadata/pcr_labels.csv}"
 CACHE_DIR="${CACHE_DIR:-/gpfs/data/karczmar-lab/workspaces/spencervenancio/gnn_cache}"
 ID_COLUMN="${ID_COLUMN:-case_id}"
 LABEL_COLUMN="${LABEL_COLUMN:-pcr}"

--- a/gnn/slurm/submit_gnn_duke_sweep.slurm
+++ b/gnn/slurm/submit_gnn_duke_sweep.slurm
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-duke-sweep
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=12:00:00
+#SBATCH --array=0-9
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# DUKE-only readout re-run: mean pool vs mean+max, 5 seeds each, restricted to
+# the DUKE cohort (the in-house data most resembles DUKE, so cross-cohort batch
+# effect is out of scope -- see gnn/CONCEPTS_STUDY_GUIDE.md #9). Both arms carry
+# all Tier-0 training knobs and filter the SAME full cache
+# (gnn_cache_tier0_sweep) to DUKE via gnn_dataset_include -- no rebuild. Folds
+# are stratified on the pCR label (stratum_col: null) since a DUKE-only cohort
+# makes dataset-stratification trivial; ~13 positives/fold over 280 DUKE cases.
+#
+# Answers: does the mean+max readout win hold when the model is TRAINED on DUKE
+# only (not just measured on the DUKE slice of a full-cohort model)? Pair
+# duke_meanmax_seedS vs duke_mean_seedS by seed x fold.
+#
+# 10 tasks = 2 arms x 5 seeds. Index 0-4 = mean, 5-9 = mean_max; seeds 0..4.
+#
+# Usage:
+#   sbatch gnn/slurm/submit_gnn_duke_sweep.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_duke_sweep"
+
+CONFIGS=(
+  configs/gnn_duke_mean.yaml configs/gnn_duke_mean.yaml configs/gnn_duke_mean.yaml \
+  configs/gnn_duke_mean.yaml configs/gnn_duke_mean.yaml \
+  configs/gnn_duke_meanmax.yaml configs/gnn_duke_meanmax.yaml configs/gnn_duke_meanmax.yaml \
+  configs/gnn_duke_meanmax.yaml configs/gnn_duke_meanmax.yaml
+)
+SEEDS=(0 1 2 3 4 0 1 2 3 4)
+TAGS=(
+  duke_mean_seed0 duke_mean_seed1 duke_mean_seed2 duke_mean_seed3 duke_mean_seed4 \
+  duke_meanmax_seed0 duke_meanmax_seed1 duke_meanmax_seed2 duke_meanmax_seed3 duke_meanmax_seed4
+)
+
+i="${SLURM_ARRAY_TASK_ID}"
+CONFIG="${CONFIGS[$i]}"
+SEED="${SEEDS[$i]}"
+TAG="${TAGS[$i]}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+
+echo "task ${i}: config=${CONFIG} seed=${SEED} outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config "${CONFIG}" \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/slurm/submit_gnn_tier0_sweep.slurm
+++ b/gnn/slurm/submit_gnn_tier0_sweep.slurm
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-tier0-sweep
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=1-00:00:00
+#SBATCH --array=0-9
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# Tier-0 optimization-hygiene sweep: the frozen baseline (configs/gnn.yaml
+# behavior, via gnn_tier0_sweep_baseline.yaml) vs. the Tier-0 stack
+# (gnn_tier0_sweep_tier0.yaml), each across 5 seeds, on the SAME freshly-built
+# cache and the SAME frozen folds -- so a paired ΔAUC by (seed x fold) isolates
+# optimization from representation/architecture (see gnn/PLAN_advanced_modeling.md,
+# decisions D0.1-D0.6 and Tier 0 / Gate G0).
+#
+# 10 tasks = 2 arms x 5 seeds. Both sweep configs point at the dedicated
+# cache gnn_cache_tier0_sweep (built by the companion build job, NOT the shared
+# gnn_cache) and write outputs to a persistent gpfs path (this worktree is
+# temporary). --random-state sets the per-fold torch seed offset AND the
+# stratified-split shuffle, so each seed is an independent CV draw.
+#
+# Usage (submit AFTER the cache build, chained on its job id):
+#   BUILD_JID=$(sbatch --parsable \
+#       CACHE_DIR=/gpfs/.../gnn_cache_tier0_sweep gnn/slurm/submit_gnn_build.slurm)
+#   sbatch --dependency=afterok:${BUILD_JID} gnn/slurm/submit_gnn_tier0_sweep.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_tier0_sweep"
+
+# Index 0-4 = baseline arm, 5-9 = tier0 arm; seeds 0..4 within each.
+CONFIGS=(
+  configs/gnn_tier0_sweep_baseline.yaml configs/gnn_tier0_sweep_baseline.yaml \
+  configs/gnn_tier0_sweep_baseline.yaml configs/gnn_tier0_sweep_baseline.yaml \
+  configs/gnn_tier0_sweep_baseline.yaml \
+  configs/gnn_tier0_sweep_tier0.yaml configs/gnn_tier0_sweep_tier0.yaml \
+  configs/gnn_tier0_sweep_tier0.yaml configs/gnn_tier0_sweep_tier0.yaml \
+  configs/gnn_tier0_sweep_tier0.yaml
+)
+SEEDS=(0 1 2 3 4 0 1 2 3 4)
+TAGS=(
+  baseline_seed0 baseline_seed1 baseline_seed2 baseline_seed3 baseline_seed4 \
+  tier0_seed0 tier0_seed1 tier0_seed2 tier0_seed3 tier0_seed4
+)
+
+i="${SLURM_ARRAY_TASK_ID}"
+CONFIG="${CONFIGS[$i]}"
+SEED="${SEEDS[$i]}"
+TAG="${TAGS[$i]}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+
+echo "task ${i}: config=${CONFIG} seed=${SEED} outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config "${CONFIG}" \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/slurm/submit_gnn_tier1_sweep.slurm
+++ b/gnn/slurm/submit_gnn_tier1_sweep.slurm
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-tier1-sweep
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=1-00:00:00
+#SBATCH --array=0-4
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# Tier-1 readout sweep (gnn/PLAN_advanced_modeling.md, D2.1): the mean+max
+# readout (gnn_pooling="mean_max") across 5 seeds, on the SAME cache and folds
+# as the Tier-0 sweep. Pairs seed-for-seed against the already-computed Tier-0
+# (mean-pool) runs under experiments/gnn_tier0_sweep/tier0_seed{0..4}/ -- both
+# arms share cache, features, folds, and all Tier-0 training knobs, so only the
+# readout differs (D5). No cache rebuild: the readout is a model change, the
+# graphs are identical, so we reuse gnn_cache_tier0_sweep.
+#
+# Only 5 jobs (mean_max x 5 seeds); the Tier-0 mean-pool comparison arm already
+# ran in the Tier-0 sweep. Analyze with analysis.gnn_tier1_readout_gate_g1.
+#
+# Usage:
+#   sbatch gnn/slurm/submit_gnn_tier1_sweep.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_tier1_sweep"
+SEED="${SLURM_ARRAY_TASK_ID}"
+OUTDIR="${OUT_ROOT}/tier1_meanmax_seed${SEED}"
+
+echo "tier1 task: seed=${SEED} pooling=mean_max outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config configs/gnn_tier1_meanmax.yaml \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/train.py
+++ b/gnn/train.py
@@ -594,6 +594,7 @@ def fit_predict_one_fold(
             num_layers=int(params.num_layers),
             dropout=float(params.dropout),
             graph_dim=graph_dim,
+            pooling=str(params.get("gnn_pooling", "mean")),
         ).to(device)
     optimizer = torch.optim.Adam(
         model.parameters(),

--- a/gnn/train.py
+++ b/gnn/train.py
@@ -313,14 +313,87 @@ def _apply_pcr_dummy_noise(
         graph.x[:, col] = class_mean + noise_by_index[index]
 
 
+class FocalWithLogitsLoss(nn.Module):
+    """Sigmoid focal loss for class-imbalanced binary classification.
+
+    Applies a modulating factor (1 - p_t)^gamma to down-weight easy examples,
+    with an optional alpha balancing term. Mirrors
+    ``deepsets.train.FocalWithLogitsLoss`` (reimplemented rather than imported
+    to avoid coupling the GNN track to the Deep Sets one -- the two are kept
+    independent everywhere else too).
+    """
+
+    def __init__(self, alpha: float = 0.25, gamma: float = 2.0) -> None:
+        super().__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """Return the mean focal loss over the batch."""
+        bce = torch.nn.functional.binary_cross_entropy_with_logits(
+            logits, targets, reduction="none"
+        )
+        probs = torch.sigmoid(logits)
+        p_t = targets * probs + (1.0 - targets) * (1.0 - probs)
+        alpha_t = targets * self.alpha + (1.0 - targets) * (1.0 - self.alpha)
+        focal_weight = alpha_t * (1.0 - p_t) ** self.gamma
+        return (focal_weight * bce).mean()
+
+
+LOSS_CHOICES = ("weighted_bce", "unweighted_bce", "focal")
+
+
+def build_loss_fn(
+    params: Any,
+    positive_count: int,
+    negative_count: int,
+    device: torch.device,
+) -> nn.Module:
+    """Instantiate the training loss from ``model_params``.
+
+    ``weighted_bce`` (the config default) sets ``BCEWithLogitsLoss``'s
+    ``pos_weight`` to ``negative_count / positive_count`` computed on the
+    fold's *train* split only, so the minority (pCR-positive) class is
+    up-weighted; ``unweighted_bce`` reproduces the historical GNN loss
+    exactly; ``focal`` uses ``focal_alpha`` / ``focal_gamma``. Parallels
+    ``deepsets.train.build_loss_fn`` (same three choices, same pos_weight
+    convention) -- kept as a small local copy rather than a cross-track import.
+    A fold with zero training positives is a broken split, not something to
+    paper over, so pos_weight falls back to 1.0 only in that degenerate case
+    (matching Deep Sets) and the class balance is logged by the caller.
+    """
+    loss_name = str(params.get("loss", "weighted_bce"))
+    if loss_name not in LOSS_CHOICES:
+        raise ValueError(f"Unknown loss {loss_name!r}. Choose from {LOSS_CHOICES}.")
+    if loss_name == "weighted_bce":
+        pos_weight_value = (
+            float(negative_count) / float(positive_count) if positive_count > 0 else 1.0
+        )
+        return nn.BCEWithLogitsLoss(
+            pos_weight=torch.tensor(
+                [pos_weight_value], dtype=torch.float32, device=device
+            )
+        )
+    if loss_name == "unweighted_bce":
+        return nn.BCEWithLogitsLoss()
+    alpha = float(params.get("focal_alpha", 0.25))
+    gamma = float(params.get("focal_gamma", 2.0))
+    return FocalWithLogitsLoss(alpha=alpha, gamma=gamma)
+
+
 def train_one_epoch(
     model: nn.Module,
     loader: DataLoader,
     optimizer: torch.optim.Optimizer,
     criterion: nn.Module,
     device: torch.device,
+    max_grad_norm: float = 0.0,
 ) -> float:
-    """Run one training epoch; return the mean per-graph loss."""
+    """Run one training epoch; return the mean per-graph loss.
+
+    ``max_grad_norm > 0`` clips the global gradient norm before each optimizer
+    step (``0.0`` disables clipping, reproducing the historical behavior).
+    """
     model.train()
     total_loss = 0.0
     num_graphs = 0
@@ -330,6 +403,8 @@ def train_one_epoch(
         logits = _model_forward(model, batch)
         loss = criterion(logits, batch.y.float())
         loss.backward()
+        if max_grad_norm > 0.0:
+            nn.utils.clip_grad_norm_(model.parameters(), max_grad_norm)
         optimizer.step()
         total_loss += loss.item() * batch.num_graphs
         num_graphs += batch.num_graphs
@@ -442,6 +517,7 @@ def fit_predict_one_fold(
     """
     params = config.model_params
     device = _resolve_device(str(params.device))
+    max_grad_norm = float(params.get("max_grad_norm", 0.0))
     torch.manual_seed(int(params.random_state) + int(split.fold_idx))
 
     train_graph_idx = cohort_df.iloc[split.train_indices]["graph_index"].tolist()
@@ -519,15 +595,61 @@ def fit_predict_one_fold(
             dropout=float(params.dropout),
             graph_dim=graph_dim,
         ).to(device)
-    optimizer = torch.optim.Adam(model.parameters(), lr=float(params.learning_rate))
-    criterion = nn.BCEWithLogitsLoss()
+    optimizer = torch.optim.Adam(
+        model.parameters(),
+        lr=float(params.learning_rate),
+        weight_decay=float(params.weight_decay),
+    )
+
+    # Loss: weighted_bce (default) up-weights the minority pCR class using the
+    # train split's own class balance; unweighted_bce reproduces the historical
+    # plain BCEWithLogitsLoss; focal uses focal_alpha/gamma. See build_loss_fn.
+    positive_count = sum(int(graph.y.item()) for graph in train_graphs)
+    negative_count = len(train_graphs) - positive_count
+    logging.info(
+        "fold %d class balance: positives=%d negatives=%d loss=%s",
+        split.fold_idx,
+        positive_count,
+        negative_count,
+        str(params.get("loss", "weighted_bce")),
+    )
+    criterion = build_loss_fn(params, positive_count, negative_count, device)
+
+    scheduler_name = str(params.get("lr_scheduler", "none")).lower()
+    scheduler: torch.optim.lr_scheduler.LRScheduler | None = None
+    epochs = int(params.epochs)
+    if scheduler_name == "cosine":
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+    elif scheduler_name == "plateau":
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+            optimizer,
+            mode="min",
+            factor=float(params.get("lr_scheduler_factor", 0.5)),
+            patience=int(params.get("lr_scheduler_patience", 5)),
+        )
+
+    # Best-epoch selection + early stopping. The signal is validation *loss*
+    # (not val AUC), matching deepsets.train.fit_predict_one_fold -- loss is
+    # smoother than AUC on these small, imbalanced folds, and keeping the two
+    # tracks consistent matters more than the plan's original "best val AUC"
+    # wording. restore_best_epoch=False + patience=0 reproduces the historical
+    # behavior of reporting the final-epoch model.
+    patience = int(params.get("early_stopping_patience", 0))
+    restore_best_epoch = bool(params.get("restore_best_epoch", False))
+    track_best_state = patience > 0 or restore_best_epoch
+    best_val_loss = float("inf")
+    best_epoch = 0
+    best_state_dict: dict[str, torch.Tensor] | None = None
+    epochs_without_improvement = 0
 
     history: list[dict[str, float]] = []
-    epochs = int(params.epochs)
     for epoch in range(1, epochs + 1):
-        train_loss = train_one_epoch(model, train_loader, optimizer, criterion, device)
+        train_loss = train_one_epoch(
+            model, train_loader, optimizer, criterion, device, max_grad_norm
+        )
         train_metrics = evaluate(model, train_eval_loader, criterion, device)
         val_metrics = evaluate(model, val_loader, criterion, device)
+        val_loss = val_metrics["loss"]
         history.append(
             {
                 "fold": float(split.fold_idx),
@@ -535,9 +657,10 @@ def fit_predict_one_fold(
                 "train_loss": train_loss,
                 "train_error_rate": train_metrics["error_rate"],
                 "train_auc": train_metrics.get("auc", float("nan")),
-                "val_loss": val_metrics["loss"],
+                "val_loss": val_loss,
                 "val_error_rate": val_metrics["error_rate"],
                 "val_auc": val_metrics.get("auc", float("nan")),
+                "lr": float(optimizer.param_groups[0]["lr"]),
             }
         )
         logging.info(
@@ -548,8 +671,39 @@ def fit_predict_one_fold(
             epochs,
             train_loss,
             train_metrics.get("auc", float("nan")),
-            val_metrics["loss"],
+            val_loss,
             val_metrics.get("auc", float("nan")),
+        )
+
+        if val_loss < best_val_loss:
+            best_val_loss = val_loss
+            best_epoch = epoch
+            if track_best_state:
+                best_state_dict = {k: v.clone() for k, v in model.state_dict().items()}
+            epochs_without_improvement = 0
+        else:
+            epochs_without_improvement += 1
+
+        if scheduler is not None:
+            if scheduler_name == "plateau":
+                scheduler.step(val_loss)
+            else:
+                scheduler.step()
+
+        if patience > 0 and epochs_without_improvement >= patience:
+            logging.info(
+                "fold %d early stopping at epoch %d (best epoch %d, val_loss %.4f)",
+                split.fold_idx,
+                epoch,
+                best_epoch,
+                best_val_loss,
+            )
+            break
+
+    if restore_best_epoch and best_state_dict is not None:
+        model.load_state_dict(best_state_dict)
+        logging.info(
+            "fold %d restored best model from epoch %d", split.fold_idx, best_epoch
         )
 
     y_true, y_prob = _predict_loader(model, val_loader, device)

--- a/gnn/train.py
+++ b/gnn/train.py
@@ -22,6 +22,7 @@ import matplotlib
 import numpy as np
 import pandas as pd
 import torch
+from sklearn.model_selection import StratifiedKFold
 from torch import nn
 from torch_geometric.data import Data
 from torch_geometric.loader import DataLoader
@@ -43,6 +44,9 @@ import matplotlib.pyplot as plt
 
 _MIN_STD = 1e-6
 _DECISION_THRESHOLD = 0.5
+# Smallest usable StratifiedKFold: fewer than 2 folds (or 2 of either class)
+# can't hold out a stratified inner-validation split -- see _stratified_inner_split.
+_MIN_INNER_SPLIT_FOLDS = 2
 
 
 def parse_args() -> argparse.Namespace:
@@ -496,6 +500,39 @@ def build_fold_prediction_table(
     return pred_df
 
 
+def _stratified_inner_split(
+    graphs: list[Data], *, random_state: int, val_fraction: float
+) -> tuple[list[Data], list[Data]]:
+    """Split a fold's training graphs into stratified inner-train / inner-val.
+
+    Stratified on the binary pCR label and used to drive early stopping, the LR
+    scheduler, and best-epoch selection off data that is never the outer
+    held-out fold, so the reported OOF AUC is not biased by the held-out labels
+    influencing which checkpoint is kept. Fails loudly on a fold too small or
+    too class-skewed to hold out a stratified split -- that is a broken fold,
+    not something to paper over with a silent fallback.
+    """
+    labels = np.array([int(graph.y.item()) for graph in graphs])
+    positives = int(labels.sum())
+    negatives = len(labels) - positives
+    n_splits = min(round(1.0 / val_fraction), positives, negatives)
+    if n_splits < _MIN_INNER_SPLIT_FOLDS:
+        raise ValueError(
+            "Cannot form a stratified inner early-stopping split: this fold has "
+            f"{positives} positive / {negatives} negative training cases, too few "
+            "to hold out a stratified inner-validation split (need >=2 of each). "
+            "Disable early stopping / the LR scheduler for this run or use a "
+            "larger training split."
+        )
+    splitter = StratifiedKFold(
+        n_splits=n_splits, shuffle=True, random_state=random_state
+    )
+    inner_train_idx, inner_val_idx = next(splitter.split(labels, labels))
+    inner_train = [graphs[i] for i in inner_train_idx]
+    inner_val = [graphs[i] for i in inner_val_idx]
+    return inner_train, inner_val
+
+
 def fit_predict_one_fold(
     *,
     dataset: VanguardCenterlineDataset,
@@ -506,6 +543,16 @@ def fit_predict_one_fold(
     graph_feature_groups: tuple[list[str], list[str], list[str]] | None = None,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[dict[str, float]]]:
     """Train a fresh GCNClassifier for one fold and return validation predictions.
+
+    When any model-selection control is active (LR scheduler, early stopping, or
+    best-epoch restore), a stratified inner-validation split is carved out of
+    this fold's OWN training cases and drives every selection signal, so the
+    outer held-out fold (``split.val_indices``) is untouched until the final
+    OOF prediction. Without that split the held-out labels would choose the
+    reported checkpoint and bias the CV AUC upward. When no control is active
+    (the frozen baseline) there is nothing to select on, so the model trains on
+    the full fold and reports its final epoch, reproducing the historical
+    behavior exactly.
 
     ``graph_feature_inputs`` (the raw graph-feature-input frame from
     ``dataset.load_graph_feature_inputs``) and ``graph_feature_groups`` (from
@@ -574,8 +621,38 @@ def fit_predict_one_fold(
         graph_dim = 0
 
     batch_size = int(params.batch_size)
-    train_loader = DataLoader(train_graphs, batch_size=batch_size, shuffle=True)
-    train_eval_loader = DataLoader(train_graphs, batch_size=batch_size, shuffle=False)
+
+    # Model-selection controls, resolved up front because they decide whether we
+    # train on the full fold or on an inner-train split (see below).
+    scheduler_name = str(params.get("lr_scheduler", "none")).lower()
+    epochs = int(params.epochs)
+    patience = int(params.get("early_stopping_patience", 0))
+    restore_best_epoch = bool(params.get("restore_best_epoch", False))
+    selection_active = scheduler_name != "none" or patience > 0 or restore_best_epoch
+
+    # When any selection control is active, hold out a stratified inner-validation
+    # split from this fold's OWN training cases and drive all selection signals
+    # (scheduler / early stopping / best epoch) off it; the outer fold stays
+    # untouched until the final prediction. When nothing selects, train on the
+    # full fold and report the final epoch (historical frozen-baseline behavior).
+    if selection_active:
+        fit_graphs, selection_graphs = _stratified_inner_split(
+            train_graphs,
+            random_state=int(params.random_state) + int(split.fold_idx),
+            val_fraction=float(params.get("inner_val_fraction", 0.2)),
+        )
+    else:
+        fit_graphs, selection_graphs = train_graphs, val_graphs
+
+    train_loader = DataLoader(fit_graphs, batch_size=batch_size, shuffle=True)
+    train_eval_loader = DataLoader(fit_graphs, batch_size=batch_size, shuffle=False)
+    # Selection signal (val_loss for scheduler / early stopping / best epoch):
+    # the inner split when active, else the outer fold (logging-only, never
+    # selected on in the frozen baseline).
+    selection_loader = DataLoader(
+        selection_graphs, batch_size=batch_size, shuffle=False
+    )
+    # Outer held-out fold -- touched only for the final OOF prediction below.
     val_loader = DataLoader(val_graphs, batch_size=batch_size, shuffle=False)
 
     if is_edge_mode:
@@ -603,10 +680,12 @@ def fit_predict_one_fold(
     )
 
     # Loss: weighted_bce (default) up-weights the minority pCR class using the
-    # train split's own class balance; unweighted_bce reproduces the historical
+    # training split's own class balance; unweighted_bce reproduces the historical
     # plain BCEWithLogitsLoss; focal uses focal_alpha/gamma. See build_loss_fn.
-    positive_count = sum(int(graph.y.item()) for graph in train_graphs)
-    negative_count = len(train_graphs) - positive_count
+    # Uses fit_graphs (the inner-train split when selection is active) so the
+    # class weighting matches the data the model actually optimizes over.
+    positive_count = sum(int(graph.y.item()) for graph in fit_graphs)
+    negative_count = len(fit_graphs) - positive_count
     logging.info(
         "fold %d class balance: positives=%d negatives=%d loss=%s",
         split.fold_idx,
@@ -616,10 +695,10 @@ def fit_predict_one_fold(
     )
     criterion = build_loss_fn(params, positive_count, negative_count, device)
 
-    scheduler_name = str(params.get("lr_scheduler", "none")).lower()
     scheduler: torch.optim.lr_scheduler.LRScheduler | None = None
-    epochs = int(params.epochs)
-    if scheduler_name == "cosine":
+    if scheduler_name == "none":
+        scheduler = None
+    elif scheduler_name == "cosine":
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
     elif scheduler_name == "plateau":
         scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
@@ -628,15 +707,20 @@ def fit_predict_one_fold(
             factor=float(params.get("lr_scheduler_factor", 0.5)),
             patience=int(params.get("lr_scheduler_patience", 5)),
         )
+    else:
+        raise ValueError(
+            f"Unrecognized lr_scheduler {scheduler_name!r}; expected one of "
+            "'none', 'cosine', 'plateau'. A typo must fail loudly, not silently "
+            "run with no scheduler."
+        )
 
     # Best-epoch selection + early stopping. The signal is validation *loss*
     # (not val AUC), matching deepsets.train.fit_predict_one_fold -- loss is
     # smoother than AUC on these small, imbalanced folds, and keeping the two
     # tracks consistent matters more than the plan's original "best val AUC"
     # wording. restore_best_epoch=False + patience=0 reproduces the historical
-    # behavior of reporting the final-epoch model.
-    patience = int(params.get("early_stopping_patience", 0))
-    restore_best_epoch = bool(params.get("restore_best_epoch", False))
+    # behavior of reporting the final-epoch model. patience / restore_best_epoch
+    # / scheduler_name were resolved above (they gate the inner-split decision).
     track_best_state = patience > 0 or restore_best_epoch
     best_val_loss = float("inf")
     best_epoch = 0
@@ -649,7 +733,9 @@ def fit_predict_one_fold(
             model, train_loader, optimizer, criterion, device, max_grad_norm
         )
         train_metrics = evaluate(model, train_eval_loader, criterion, device)
-        val_metrics = evaluate(model, val_loader, criterion, device)
+        # val_* columns track the SELECTION set (inner split when active), never
+        # the outer held-out fold -- that is what keeps the outer fold clean.
+        val_metrics = evaluate(model, selection_loader, criterion, device)
         val_loss = val_metrics["loss"]
         history.append(
             {

--- a/tests/test_gnn_inner_split.py
+++ b/tests/test_gnn_inner_split.py
@@ -1,0 +1,71 @@
+"""Unit tests for the inner train/early-stop split in ``gnn.train``.
+
+``_stratified_inner_split`` fixes model-selection leakage in
+:func:`gnn.train.fit_predict_one_fold`: the split must be carved out of a fold's
+OWN training cases (never the outer held-out fold), be stratified on the binary
+pCR label, be deterministic given a seed, and fail loudly on a fold too small to
+hold out a stratified split.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+pytest.importorskip("sklearn")
+
+from torch_geometric.data import Data  # noqa: E402
+
+from gnn.train import _stratified_inner_split  # noqa: E402
+
+
+def _graphs(labels: list[int]) -> list[Data]:
+    """One trivial single-node graph per label; only ``.y`` matters here."""
+    return [
+        Data(x=torch.zeros(1, 1), y=torch.tensor([float(label)])) for label in labels
+    ]
+
+
+def test_split_partitions_without_overlap() -> None:
+    """Inner-train and inner-val together cover every graph, with no overlap."""
+    graphs = _graphs([1] * 8 + [0] * 24)
+    inner_train, inner_val = _stratified_inner_split(
+        graphs, random_state=0, val_fraction=0.2
+    )
+    train_ids = {id(g) for g in inner_train}
+    val_ids = {id(g) for g in inner_val}
+    assert train_ids.isdisjoint(val_ids)
+    assert train_ids | val_ids == {id(g) for g in graphs}
+
+
+def test_split_is_stratified() -> None:
+    """A 0.2 hold-out keeps the minority class in both inner splits."""
+    graphs = _graphs([1] * 8 + [0] * 24)
+    inner_train, inner_val = _stratified_inner_split(
+        graphs, random_state=0, val_fraction=0.2
+    )
+
+    def positives(gs: list[Data]) -> int:
+        return sum(int(g.y.item()) for g in gs)
+
+    assert positives(inner_val) >= 1
+    assert positives(inner_train) >= 1
+    # ~20% held out (StratifiedKFold with n_splits=5).
+    assert len(inner_val) == pytest.approx(len(graphs) * 0.2, abs=2)
+
+
+def test_split_is_deterministic() -> None:
+    """The same random_state reproduces the same inner-train / inner-val split."""
+    graphs = _graphs([1] * 8 + [0] * 24)
+    a_train, a_val = _stratified_inner_split(graphs, random_state=7, val_fraction=0.2)
+    b_train, b_val = _stratified_inner_split(graphs, random_state=7, val_fraction=0.2)
+    assert [id(g) for g in a_train] == [id(g) for g in b_train]
+    assert [id(g) for g in a_val] == [id(g) for g in b_val]
+
+
+def test_too_few_positives_fails_loudly() -> None:
+    """A fold with only one positive raises instead of silently degrading."""
+    graphs = _graphs([1] * 1 + [0] * 20)
+    with pytest.raises(ValueError, match="stratified inner early-stopping split"):
+        _stratified_inner_split(graphs, random_state=0, val_fraction=0.2)

--- a/tests/test_gnn_model.py
+++ b/tests/test_gnn_model.py
@@ -9,7 +9,11 @@ pytest.importorskip("torch_geometric")
 
 from torch_geometric.data import Batch, Data  # noqa: E402
 
-from gnn.model import EdgeGNNClassifier, GCNClassifier  # noqa: E402
+from gnn.model import (  # noqa: E402
+    POOLING_WIDTHS,
+    EdgeGNNClassifier,
+    GCNClassifier,
+)
 
 
 def _make_batch() -> Batch:
@@ -34,6 +38,25 @@ def test_forward_returns_one_logit_per_graph() -> None:
     logits = model(batch.x, batch.edge_index, batch.batch)
     assert logits.shape == (2,)
     assert torch.isfinite(logits).all()
+
+
+@pytest.mark.parametrize("pooling", list(POOLING_WIDTHS))
+def test_pooling_variants_forward_and_classifier_width(pooling: str) -> None:
+    """Each readout yields a (2,) logit and scales the head input by its width."""
+    batch = _make_batch()
+    model = GCNClassifier(
+        input_dim=2, hidden_dim=8, num_layers=2, dropout=0.0, pooling=pooling
+    )
+    assert model.classifier.in_features == 8 * POOLING_WIDTHS[pooling]
+    logits = model(batch.x, batch.edge_index, batch.batch)
+    assert logits.shape == (2,)
+    assert torch.isfinite(logits).all()
+
+
+def test_rejects_invalid_pooling() -> None:
+    """Pooling must be one of the known readout variants."""
+    with pytest.raises(ValueError, match="Unknown pooling"):
+        GCNClassifier(input_dim=2, pooling="bogus")
 
 
 def test_rejects_invalid_input_dim() -> None:


### PR DESCRIPTION
This PR adds complexity the baseline GNN model. It's part of a 3 tiered plan laid out in `gnn/PLAN_advanced_modeling.md`.  I will roll out tiers 2 and 3 in a future PR.  

The additions are summarized as follows: 

**Training hygiene.** The GNN's training loop was bare-bones: plain Adam, plain BCE loss, a fixed number of epochs, and it reported the model at its final epoch even if that epoch was already overfit. This adds the standard training controls — class-weighted loss (pCR-positive is the minority class), weight decay, gradient clipping, a learning-rate scheduler, early stopping, and picking the best epoch by validation loss instead of taking the last one. Each control defaults to the old behavior, so existing runs are unaffected unless a config turns it on.

**Better graph readout.** Before the classifier, the model averaged every node down to a single mean, which discards the peaks and spread that carry the signal — a plain tabular model on those same statistics was outperforming the GNN. This lets the readout combine the mean with max and sum pooling, so the graph keeps its extremes, not just its average. The default stays mean-only, so it's backward compatible.

**How it runs.** New config files define the experiment arms (a frozen baseline reproducing the old behavior, a training-hygiene arm, and a readout arm) plus the Slurm scripts to launch them. Both new code paths have unit tests.

**One honest result.** A single-cohort (DUKE) re-run showed the readout gain did not hold up — it was a cross-cohort artifact, not a genuine improvement. That's logged in the project lab notebook. It does not block this PR: the readout is off by default, and this is exactly why it stays gated behind the frozen-baseline comparison rather than being switched on.

**Backward compatibility.** Every new option defaults to the historical behavior. The shared config defaults did shift, so the baseline config files pin the old values explicitly to keep reproducing the original numbers.