### PR TITLE
Agents/comment style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Derived outputs should go in clearly named output folders with enough provenance
 
 ## Project Conventions
 - Keep scripts and outputs named clearly enough that another student can understand what they are for.
+- Write comments and docstrings for a newcomer reading the code as it is now, in the present tense: state what the code does and why it is shaped this way. Do not narrate the change that produced it ("now we…", "no longer…", "instead of the old…", "removed X", "backward compatible with…") or reference prior approaches. That transitional rationale belongs in the commit message, lab notebook, and agent memory — in the code it bloats and goes stale. If a comment only makes sense to someone who saw the diff, it does not belong in the code.
 - Prefer saved CSVs, plots, QC panels, and short README/provenance notes for important outputs.
 - Document split/CV policy when training or evaluating models.
 - Do not change cohort definitions, labels, or train/test splits without making the change explicit.

--- a/configs/uchicago_gnn.yaml
+++ b/configs/uchicago_gnn.yaml
@@ -1,15 +1,14 @@
 # GNN training on the UChicago internal ultrafast DCE cohort (gnn/train.py).
 #
-# Uses the standard loader with no dataset adapter: Sarit's preprocessing output
-# is already in the layout the loader expects --
+# The Vanguard preprocessing output is in the layout the loader expects, so it
+# feeds the standard loader with no dataset adapter:
 #   centerlines: <root>/<sub-source>/<exam_id>/<exam_id>_skeleton_4d_exam_mask.npy
 #   raw DCE:     <dce_root>/<exam_id>/<exam_id>_NNNN.nii.gz  (+ ufast_times_seconds.npy)
-# and the DCE is the correct raw-signal, motion-corrected contract
-# (vanguard_spgr_raw_signal_v2), so no manifest / tar extraction is involved.
+# The DCE is the raw-signal, motion-corrected contract
+# (vanguard_spgr_raw_signal_v5), so no manifest / tar extraction is involved.
 #
-# The one UChicago-specific bit is the ultrafast kinetic contract, set below as
-# two config knobs (5 precontrast frames, relative signal change). node_mode
-# defaults to voxel; override model_params.gnn_node_mode for segment/junction.
+# node_mode defaults to voxel; override model_params.gnn_node_mode for
+# segment/junction.
 
 experiment_setup:
   name: "gnn_uchicago"
@@ -31,11 +30,9 @@ model_params:
   dropout: 0.2
   learning_rate: 0.001
   gnn_node_features: ["peak_time", "radius"]
-  # The ultrafast kinetic contract (baseline=5 precontrast frames, relative
-  # signal change over physical seconds) is NOT set here: it's acquisition
-  # metadata written per-case into run_summary.json by the v5 Vanguard
-  # preprocessing (kinetic_feature_policy), which the loader reads and enforces
-  # (with the alignment_qc_status gate). See gnn/data_loader.py.
+  # The kinetic contract (baseline frame count, relative signal change) is
+  # acquisition metadata: the loader reads it per case from run_summary.json's
+  # kinetic_feature_policy and gates on alignment_qc_status. See gnn/data_loader.py.
 
 data_paths:
   # v5-regenerated UChicago preprocessing (run_summary.json carries the kinetic

--- a/gnn/data_loader.py
+++ b/gnn/data_loader.py
@@ -527,9 +527,8 @@ def _build_case(
     share.
 
     The kinetic contract (baseline frame count, relative vs. absolute
-    enhancement) comes entirely from the case's ``run_summary.json`` via
-    ``_load_study_metadata`` -- it's acquisition metadata (the v5 Vanguard
-    preprocessing writes ``kinetic_feature_policy`` per case), not a build knob.
+    enhancement) is acquisition metadata, read per case from the case's
+    ``run_summary.json`` (``kinetic_feature_policy``) via ``_load_study_metadata``.
 
     ``node_mode="voxel"`` keeps one node per skeleton voxel with per-voxel
     features; ``node_mode="segment"`` contracts each vessel segment to a single


### PR DESCRIPTION
I noticed that my agent was using comments too much like agentic memory. This PR adds a line to `AGENTS.md` and cleans up some specific comments, restoring them to the proposed convention.