### PR TITLE
Support handed-off UChicago DICOM preprocessing

### DIFF
--- a/preprocessing/dicom.py
+++ b/preprocessing/dicom.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import os
 import zipfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -62,6 +63,7 @@ class LoadedDicomSeries:
     times_seconds: np.ndarray
     geometry: DicomGeometry
     archive_path: Path
+    source_kind: str
     source_sha256: str
     temporal_positions: tuple[int, ...]
 
@@ -74,18 +76,49 @@ def parse_dicom_clock_seconds(value: object) -> float:
     return float(int(text[:2]) * 3600 + int(text[2:4]) * 60 + float(text[4:]))
 
 
-def _read_inventory(path: Path, *, study_uid: str, series_uid: str) -> Any:
+def _inventory_columns(path: Path) -> set[str]:
+    """Return an inventory's columns without loading every DICOM row."""
     import pandas as pd
 
+    if path.suffix.lower() == ".parquet":
+        try:
+            from fastparquet import ParquetFile
+
+            return set(ParquetFile(path).columns)
+        except ImportError:
+            return set(pd.read_parquet(path).columns)
+    return set(pd.read_csv(path, nrows=0).columns)
+
+
+def _read_inventory(
+    path: Path, *, study_uid: str, series_uid: str
+) -> tuple[Any, str, Path]:
+    import pandas as pd
+
+    available = _inventory_columns(path)
     columns = [
         "study_instance_uid",
         "series_instance_uid",
-        "archive_path",
-        "archive_member",
         "read_ok",
         "temporal_position_identifier",
         "instance_number",
     ]
+    columns.extend(
+        column
+        for column in ("archive_path", "archive_member", "source_path")
+        if column in available
+    )
+    if "sop_instance_uid" in available:
+        columns.append("sop_instance_uid")
+    missing = set(columns[:5]).difference(available)
+    if missing:
+        raise ValueError(f"inventory is missing required columns: {sorted(missing)}")
+    has_archive = {"archive_path", "archive_member"}.issubset(available)
+    has_files = "source_path" in available
+    if not has_archive and not has_files:
+        raise ValueError(
+            "inventory requires either archive_path/archive_member or source_path"
+        )
     if path.suffix.lower() == ".parquet":
         frame = pd.read_parquet(
             path,
@@ -108,10 +141,35 @@ def _read_inventory(path: Path, *, study_uid: str, series_uid: str) -> Any:
         raise ValueError(f"no readable inventory rows for series {series_uid}")
     if frame["temporal_position_identifier"].isna().any():
         raise ValueError(f"series {series_uid} has missing temporal positions")
-    archives = sorted(set(frame["archive_path"].dropna().astype(str)))
-    if len(archives) != 1:
-        raise ValueError(f"expected one archive for {series_uid}, got {archives}")
-    return frame
+    archive_rows = (
+        frame["archive_path"].fillna("").astype(str).str.strip().ne("")
+        if has_archive
+        else pd.Series(False, index=frame.index)
+    )
+    file_rows = (
+        frame["source_path"].fillna("").astype(str).str.strip().ne("")
+        if has_files
+        else pd.Series(False, index=frame.index)
+    )
+    if archive_rows.all() and not file_rows.any():
+        archives = sorted(set(frame["archive_path"].astype(str)))
+        if len(archives) != 1:
+            raise ValueError(f"expected one archive for {series_uid}, got {archives}")
+        if frame["archive_member"].isna().any():
+            raise ValueError(f"series {series_uid} has missing archive members")
+        return frame, "zip", Path(archives[0])
+    if file_rows.all() and not archive_rows.any():
+        source_paths = [Path(value) for value in frame["source_path"].astype(str)]
+        missing_files = [str(value) for value in source_paths if not value.is_file()]
+        if missing_files:
+            raise FileNotFoundError(
+                f"series {series_uid} has missing source files: {missing_files[:3]}"
+            )
+        common_parent = Path(
+            os.path.commonpath([str(value.parent) for value in source_paths])
+        )
+        return frame, "filesystem", common_parent
+    raise ValueError(f"series {series_uid} mixes ZIP and filesystem source rows")
 
 
 def _phase_geometry(
@@ -193,12 +251,13 @@ def load_dicom_series(
     study_uid: str,
     series_uid: str,
 ) -> LoadedDicomSeries:
-    """Load all temporal positions for one exact ZIP-backed DICOM series."""
+    """Load all temporal positions from one exact ZIP- or filesystem-backed series."""
     import pydicom
 
     inventory = Path(inventory_path).expanduser().resolve()
-    rows = _read_inventory(inventory, study_uid=study_uid, series_uid=series_uid)
-    archive_path = Path(str(rows["archive_path"].iloc[0]))
+    rows, source_kind, source_location = _read_inventory(
+        inventory, study_uid=study_uid, series_uid=series_uid
+    )
     phases: list[np.ndarray] = []
     clocks: list[float] = []
     reference: DicomGeometry | None = None
@@ -209,7 +268,8 @@ def load_dicom_series(
             for value in rows["temporal_position_identifier"].unique()
         )
     )
-    with zipfile.ZipFile(archive_path) as archive:
+    archive = zipfile.ZipFile(source_location) if source_kind == "zip" else None
+    try:
         for temporal_position in temporal_positions:
             phase_rows = rows.loc[
                 np.isclose(
@@ -218,9 +278,25 @@ def load_dicom_series(
                 )
             ].sort_values("instance_number")
             datasets: list[Any] = []
-            for member in phase_rows["archive_member"].astype(str):
-                payload = archive.read(member)
-                source_digest.update(member.encode())
+            locations = (
+                phase_rows["archive_member"].astype(str)
+                if archive is not None
+                else phase_rows["source_path"].astype(str)
+            )
+            for row_index, location in zip(phase_rows.index, locations, strict=True):
+                payload = (
+                    archive.read(location)
+                    if archive is not None
+                    else Path(location).read_bytes()
+                )
+                identity = (
+                    location
+                    if archive is not None
+                    else str(phase_rows.loc[row_index, "sop_instance_uid"])
+                    if "sop_instance_uid" in phase_rows
+                    else location
+                )
+                source_digest.update(identity.encode())
                 source_digest.update(payload)
                 datasets.append(pydicom.dcmread(io.BytesIO(payload), force=True))
             geometry, order = _phase_geometry(datasets, series_uid=series_uid)
@@ -237,6 +313,9 @@ def load_dicom_series(
                 raise ValueError("DICOM MR signal must be finite and nonnegative")
             phases.append(np.asarray(volume, dtype=np.float32))
             clocks.append(parse_dicom_clock_seconds(datasets[order[0]].AcquisitionTime))
+    finally:
+        if archive is not None:
+            archive.close()
     if reference is None:
         raise ValueError(f"no DICOM phases loaded for {series_uid}")
     adjusted: list[float] = []
@@ -256,7 +335,8 @@ def load_dicom_series(
         signal_tzyx=np.stack(phases, axis=0),
         times_seconds=times,
         geometry=reference,
-        archive_path=archive_path,
+        archive_path=source_location,
+        source_kind=source_kind,
         source_sha256=source_digest.hexdigest(),
         temporal_positions=temporal_positions,
     )

--- a/preprocessing/pipeline.py
+++ b/preprocessing/pipeline.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 import SimpleITK as sitk
 
+from graph_extraction.graph_outputs import build_graph_outputs_from_centerline
 from preprocessing.cases import CaseRecord, select_case
 from preprocessing.complement import LABEL_MATLAB_COMPLEMENT_ADDED, complement_exam
 from preprocessing.dicom import (
@@ -360,7 +361,11 @@ def prepare_case(
             "case_manifest_path": str(case_manifest.expanduser().resolve()),
             "case_manifest_sha256": _sha256(case_manifest.expanduser().resolve()),
             "hr_source": {
-                "archive_path": str(hr.archive_path),
+                "source_kind": hr.source_kind,
+                "source_location": str(hr.archive_path),
+                "archive_path": (
+                    str(hr.archive_path) if hr.source_kind == "zip" else None
+                ),
                 "selected_dicom_sha256": hr.source_sha256,
                 "geometry": hr.geometry.to_dict(),
                 "times_seconds": hr.times_seconds.tolist(),
@@ -368,7 +373,11 @@ def prepare_case(
                 "shared_4d_window": _shared_window(hr.signal_tzyx),
             },
             "ufast_source": {
-                "archive_path": str(ufast.archive_path),
+                "source_kind": ufast.source_kind,
+                "source_location": str(ufast.archive_path),
+                "archive_path": (
+                    str(ufast.archive_path) if ufast.source_kind == "zip" else None
+                ),
                 "selected_dicom_sha256": ufast.source_sha256,
                 "geometry": ufast.geometry.to_dict(),
                 "times_seconds": ufast.times_seconds.tolist(),
@@ -768,6 +777,75 @@ def complement_case(*, case_root: Path) -> None:
     _write_json(provenance_path, provenance)
 
 
+def features_case(*, case_root: Path) -> None:
+    """Compute morphometry from the final complemented centerline and support."""
+    provenance_path = case_root / "preprocessing_provenance.json"
+    provenance = json.loads(provenance_path.read_text())
+    if "complement" not in provenance:
+        raise RuntimeError("morphometry requires the completed complement stage")
+
+    output_root = case_root.parents[1]
+    dataset = str(provenance["case"]["dataset"])
+    exam_id = case_root.name
+    output_dir = output_root / "centerlines" / dataset / exam_id
+    skeleton_path = output_dir / f"{exam_id}_skeleton_4d_exam_mask.npy"
+    support_path = output_dir / f"{exam_id}_skeleton_4d_exam_support_mask.npy"
+    morphometry_path = output_dir / f"{exam_id}_morphometry.json"
+    summary_path = output_dir / "run_summary.json"
+    if morphometry_path.exists():
+        raise FileExistsError(
+            f"refusing to overwrite existing morphometry: {morphometry_path}"
+        )
+
+    target_geometry = DicomGeometry.from_dict(provenance["ufast_output_geometry"])
+    spacing = np.asarray(target_geometry.spacing_xyz_mm, dtype=float)
+    if not np.allclose(spacing, TARGET_SPACING_MM):
+        raise ValueError(
+            "morphometry reports voxel distances as millimetres and requires the "
+            f"1 mm output grid, got {spacing.tolist()}"
+        )
+
+    skeleton = np.load(skeleton_path).astype(bool, copy=False)
+    support = np.load(support_path).astype(bool, copy=False)
+    temporary_path = morphometry_path.with_name(f".{morphometry_path.name}.partial")
+    temporary_path.unlink(missing_ok=True)
+    try:
+        feature_stats = build_graph_outputs_from_centerline(
+            skeleton_mask_zyx=skeleton,
+            vessel_reference_zyx=support,
+            output_json_path=temporary_path,
+            strict_qc=True,
+        )
+        temporary_path.replace(morphometry_path)
+    except Exception:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+    summary = json.loads(summary_path.read_text())
+    summary.update(
+        {
+            "skeleton_source": (
+                "HR-mapped and UFAST-direct TC4D merge plus the quality-gated "
+                "SegVessel/Jerman complement"
+            ),
+            "morphometry_path": str(morphometry_path),
+            "morphometry_status": "computed_from_final_centerline",
+            "morphometry_coordinate_units": "1 mm isotropic voxels",
+            "morphometry_feature_stats": feature_stats,
+        }
+    )
+    _write_json(summary_path, summary)
+    provenance["morphometry"] = {
+        "path": str(morphometry_path),
+        "sha256": _sha256(morphometry_path),
+        "skeleton_sha256": _sha256(skeleton_path),
+        "support_sha256": _sha256(support_path),
+        "coordinate_units": "1 mm isotropic voxels",
+        "feature_stats": feature_stats,
+    }
+    _write_json(provenance_path, provenance)
+
+
 def repair_complement_support_case(*, case_root: Path) -> None:
     """Propagate SegVessel vessel-width support for an already-complemented case.
 
@@ -919,6 +997,7 @@ def _parser() -> argparse.ArgumentParser:
             "tc4d",
             "map",
             "complement",
+            "features",
             "repair-complement-support",
             "qc",
             "all",
@@ -969,6 +1048,8 @@ def main() -> None:
         map_case(case_root=case_root)
     if args.stage in {"complement", "all"}:
         complement_case(case_root=case_root)
+    if args.stage in {"features", "all"}:
+        features_case(case_root=case_root)
     if args.stage == "repair-complement-support":
         repair_complement_support_case(case_root=case_root)
     if args.stage in {"qc", "all"}:

--- a/preprocessing/run_cohort.py
+++ b/preprocessing/run_cohort.py
@@ -13,6 +13,7 @@ from preprocessing.model import model_subject_id
 from preprocessing.pipeline import (
     POLICY_NAME,
     complement_case,
+    features_case,
     infer_case,
     map_case,
     prepare_case,
@@ -245,6 +246,24 @@ def _stage_complete(stage: str, case_root: Path) -> bool:
                 stage=stage,
             )
         return complete
+    if stage == "features":
+        morphometry = provenance.get("morphometry")
+        complete = isinstance(morphometry, dict) and "path" in morphometry
+        if complete:
+            output_dir = (
+                case_root.parents[1]
+                / "centerlines"
+                / str(provenance["case"]["dataset"])
+                / case_root.name
+            )
+            _require_files(
+                [
+                    output_dir / f"{case_root.name}_morphometry.json",
+                    output_dir / "run_summary.json",
+                ],
+                stage=stage,
+            )
+        return complete
     if stage == "qc":
         if "mapping" not in provenance or "merge" not in provenance:
             return False
@@ -260,7 +279,7 @@ def _stage_complete(stage: str, case_root: Path) -> bool:
     if stage == "postprocess":
         return all(
             _stage_complete(item, case_root)
-            for item in ("tc4d", "map", "complement", "qc")
+            for item in ("tc4d", "map", "complement", "features", "qc")
         )
     raise ValueError(f"unknown pipeline stage: {stage}")
 
@@ -309,10 +328,12 @@ def run_stage(
         map_case(case_root=case_root)
     elif stage == "complement":
         complement_case(case_root=case_root)
+    elif stage == "features":
+        features_case(case_root=case_root)
     elif stage == "qc":
         qc_case(case_root=case_root)
     elif stage == "postprocess":
-        for item in ("tc4d", "map", "complement", "qc"):
+        for item in ("tc4d", "map", "complement", "features", "qc"):
             if not _stage_complete(item, case_root):
                 run_stage(
                     stage=item,
@@ -334,7 +355,16 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "stage",
-        choices=("prepare", "infer", "tc4d", "map", "complement", "qc", "postprocess"),
+        choices=(
+            "prepare",
+            "infer",
+            "tc4d",
+            "map",
+            "complement",
+            "features",
+            "qc",
+            "postprocess",
+        ),
     )
     parser.add_argument("--inventory", required=True, type=Path)
     parser.add_argument("--case-manifest", required=True, type=Path)


### PR DESCRIPTION
## What

- Accept exact filesystem-backed DICOM inventories in addition to the existing ZIP-backed inventory format.
- Record the source kind and source location in preprocessing provenance while preserving the legacy archive field for ZIP inputs.
- Compute morphometry from the final complemented vessel centerline and make it part of restartable cohort postprocessing.

## Why

The newly handed-off UChicago exams already live as raw DICOM files on the Karczmar lab share. The loader previously required archive_path and archive_member, so those exams could not enter the Vanguard-owned preprocessing pipeline without repackaging or local code changes. The current pipeline also finalizes the vessel mask during the complement stage, so morphometry must run afterward or it can describe an earlier mask.

## Scope and impact

This changes only three existing Vanguard preprocessing files. It does not include cohort-construction logic, clinical workbook handling, tumor-mask publication, private data paths, or Spencer model code. Raw imaging remains read-only, UFAST values and physical timestamps are unchanged, and the legacy ZIP input path remains supported.

## Checks

- Ruff passed on all three changed files.
- Focused preprocessing tests: 19 passed.
- Real inventory check passed for both the legacy ZIP inventory and the new filesystem inventory.
- Final-centerline morphometry smoke passed and preserved the existing timing metadata in run_summary.json.
- Python compilation and git diff checks passed.