### PR TITLE
docs: record UChicago ultrafast cohort paths and caveats in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ require Huo-lab access.
 
 ## Project Conventions
 - Keep scripts and outputs named clearly enough that another student can understand what they are for.
+- `analysis/` is for `.ipynb` notebooks only. Do not add `.py`, `.sh`, or `.slurm` files there, including one-off diagnostics, QC helpers, and plotting scripts. Python scripts go in `scripts/` (or the owning package: `gnn/`, `deepsets/`, `graph_extraction/`, `preprocessing/`, ...); sbatch scripts go in `slurm/` or the package's own `slurm/`. If a notebook needs a helper, put the helper in `scripts/` and import it. Older `.py` files still sitting in `analysis/` are a violation to migrate, not a precedent to follow.
 - Write comments and docstrings for a newcomer reading the code as it is now, in the present tense: state what the code does and why it is shaped this way. Do not narrate the change that produced it ("now we…", "no longer…", "instead of the old…", "removed X", "backward compatible with…") or reference prior approaches. That transitional rationale belongs in the commit message, lab notebook, and agent memory — in the code it bloats and goes stale. If a comment only makes sense to someone who saw the diff, it does not belong in the code.
 - Prefer saved CSVs, plots, QC panels, and short README/provenance notes for important outputs.
 - Document split/CV policy when training or evaluating models.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,75 +75,12 @@ Raw images, labels, and masks should be treated as read-only.
 
 Derived outputs should go in clearly named output folders with enough provenance to reproduce them.
 
-### UChicago ultrafast cohorts
-
-Two published dataset roots under `/gpfs/data/karczmar-lab/vanguard/`, complete through
-cohort construction, Vanguard v5 preprocessing, and tumor/vessel artifact publication:
-
-- `uchicago_ultrafast_longitudinal_cohort_v1` — 240 exams from 196 patients. Repeated
-  visits are retained on purpose: 179 runnable legacy exams plus 61 newly transferred
-  exams from 55 patients. Patient-level pCR is 122 non-pCR / 74 pCR.
-- `uchicago_ultrafast_pretreatment_cohort_v1` — 137 exams from 137 patients, one
-  reviewed pretreatment exam per patient: 82 runnable legacy baselines plus 55
-  new-patient baselines. pCR is 78 non-pCR / 59 pCR.
-
-The cohort manifest is `dce2d_internal_ultrafast_manifest.csv` in either root. It keeps
-the existing UChicago manifest contract: `exam_id`, `patient_key`, fixed patient-grouped
-`fold`, `pcr`, physical timestamps, phase paths, and clinical/cohort metadata. Repeated
-exams from the same patient always share a label and a fold.
-
-Each root contains:
-
-- `images/<dataset>/<exam_id>/` — motion-corrected UFAST phase NIfTIs and
-  `ufast_times_seconds.npy`. The UFAST signal is raw: no clipping, no z-scoring, five
-  protocol baselines, physical DICOM times, and one spatial interpolation. Dynamics are
-  not collapsed and not independently normalized by phase.
-- `centerlines/<dataset>/<exam_id>/` — the HR-derived vessel skeleton mask, support
-  mask, `*_morphometry.json`, `run_summary.json`, and mapping QC. Vessel extraction uses
-  the higher-spatial-resolution acquisition; node kinetics come from the aligned UFAST
-  acquisition.
-- `tumor/masks/<exam_id>.nii.gz` — primary tumor masks mapped from the
-  higher-spatial-resolution segmentation onto the exact UFAST/centerline grid, plus
-  `tumor_mask_manifest.csv`, checksums, provenance, and review flags.
-- `README.md`, `SHA256SUMS`, and `pending_cases.csv`.
-
-Tumor-mask caveats:
-
-- All 240/240 longitudinal and 137/137 pretreatment masks were published with passing
-  alignment/mapping status.
-- 14 longitudinal masks are empty. All fall outside the selected pretreatment cohort,
-  and most are later visits where a visible tumor may no longer be present.
-- The manifests flag 69 longitudinal and 36 pretreatment exams as possible bilateral
-  cases requiring review and downstream exclusion. These are conservative candidates,
-  not 69 or 36 confirmed bilateral cancers.
-
-`pending_cases.csv` lists four cases explicitly rather than dropping them silently: two
-workbook patients whose images were not present in the transferred inventories, and two
-legacy exams that cannot be run through the exact HR+UFAST contract (one shared HR/UFAST
-acquisition with no distinct HR series, and one split-series exam with eight HR
-candidates but no identifiable UFAST series).
-
-### UChicago raw DICOM sources
-
-The cohort roots above expose derived outputs by symlink. Full preprocessing from raw
-DICOM uses these restricted Karczmar-lab sources:
-
-- Legacy paired HR+UFAST package:
-  `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/paired_hr_ufast_source_dicom`.
-  `archives/<dataset>/<exam_id>.zip` contains byte-for-byte selected DICOM payloads.
-  `dicom_file_manifest.parquet`, `dicom_spatial_geometry_manifest.csv`,
-  `hr_ufast_spatial_alignment_manifest.csv`, and
-  `paired_preprocessing_case_manifest.csv` are the runnable inventory/geometry contract.
-  The package README explains how to launch Vanguard's complete DICOM-to-vessel pipeline.
-- Newly transferred DICOM sources: `/gpfs/data/karczmar-lab/Retro NACT`,
-  `/gpfs/data/karczmar-lab/9127/9127 NAC`, and `/gpfs/data/karczmar-lab/9127/9127 Staging`.
-- Reviewed new-data inventories and selected-series manifests, under
-  `uchicago_ultrafast_longitudinal_cohort_v1/_build/source_inventory`,
-  `_build/zhen_extension`, and `_build/zhen_staging_extension`.
-
-The DICOM payloads are restricted and are not deidentified. Keep them within the
-approved Karczmar-lab shares. The published derived cohorts and their provenance do not
-require Huo-lab access.
+### Site-specific data
+Concrete dataset roots, cohort counts, and raw-source paths are site-specific and are not
+part of the repo's portable contract. The UChicago ultrafast cohorts and their restricted
+Karczmar-lab DICOM sources are documented in [`UCHICAGO.md`](UCHICAGO.md). Those paths are
+valid only on the UChicago cluster -- anywhere else, prepare an equivalent dataset or arrange
+access, and point `data_paths` in your own YAML at it rather than assuming those roots exist.
 
 ## Project Conventions
 - Keep scripts and outputs named clearly enough that another student can understand what they are for.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,76 @@ Raw images, labels, and masks should be treated as read-only.
 
 Derived outputs should go in clearly named output folders with enough provenance to reproduce them.
 
+### UChicago ultrafast cohorts
+
+Two published dataset roots under `/gpfs/data/karczmar-lab/vanguard/`, complete through
+cohort construction, Vanguard v5 preprocessing, and tumor/vessel artifact publication:
+
+- `uchicago_ultrafast_longitudinal_cohort_v1` — 240 exams from 196 patients. Repeated
+  visits are retained on purpose: 179 runnable legacy exams plus 61 newly transferred
+  exams from 55 patients. Patient-level pCR is 122 non-pCR / 74 pCR.
+- `uchicago_ultrafast_pretreatment_cohort_v1` — 137 exams from 137 patients, one
+  reviewed pretreatment exam per patient: 82 runnable legacy baselines plus 55
+  new-patient baselines. pCR is 78 non-pCR / 59 pCR.
+
+The cohort manifest is `dce2d_internal_ultrafast_manifest.csv` in either root. It keeps
+the existing UChicago manifest contract: `exam_id`, `patient_key`, fixed patient-grouped
+`fold`, `pcr`, physical timestamps, phase paths, and clinical/cohort metadata. Repeated
+exams from the same patient always share a label and a fold.
+
+Each root contains:
+
+- `images/<dataset>/<exam_id>/` — motion-corrected UFAST phase NIfTIs and
+  `ufast_times_seconds.npy`. The UFAST signal is raw: no clipping, no z-scoring, five
+  protocol baselines, physical DICOM times, and one spatial interpolation. Dynamics are
+  not collapsed and not independently normalized by phase.
+- `centerlines/<dataset>/<exam_id>/` — the HR-derived vessel skeleton mask, support
+  mask, `*_morphometry.json`, `run_summary.json`, and mapping QC. Vessel extraction uses
+  the higher-spatial-resolution acquisition; node kinetics come from the aligned UFAST
+  acquisition.
+- `tumor/masks/<exam_id>.nii.gz` — primary tumor masks mapped from the
+  higher-spatial-resolution segmentation onto the exact UFAST/centerline grid, plus
+  `tumor_mask_manifest.csv`, checksums, provenance, and review flags.
+- `README.md`, `SHA256SUMS`, and `pending_cases.csv`.
+
+Tumor-mask caveats:
+
+- All 240/240 longitudinal and 137/137 pretreatment masks were published with passing
+  alignment/mapping status.
+- 14 longitudinal masks are empty. All fall outside the selected pretreatment cohort,
+  and most are later visits where a visible tumor may no longer be present.
+- The manifests flag 69 longitudinal and 36 pretreatment exams as possible bilateral
+  cases requiring review and downstream exclusion. These are conservative candidates,
+  not 69 or 36 confirmed bilateral cancers.
+
+`pending_cases.csv` lists four cases explicitly rather than dropping them silently: two
+workbook patients whose images were not present in the transferred inventories, and two
+legacy exams that cannot be run through the exact HR+UFAST contract (one shared HR/UFAST
+acquisition with no distinct HR series, and one split-series exam with eight HR
+candidates but no identifiable UFAST series).
+
+### UChicago raw DICOM sources
+
+The cohort roots above expose derived outputs by symlink. Full preprocessing from raw
+DICOM uses these restricted Karczmar-lab sources:
+
+- Legacy paired HR+UFAST package:
+  `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/paired_hr_ufast_source_dicom`.
+  `archives/<dataset>/<exam_id>.zip` contains byte-for-byte selected DICOM payloads.
+  `dicom_file_manifest.parquet`, `dicom_spatial_geometry_manifest.csv`,
+  `hr_ufast_spatial_alignment_manifest.csv`, and
+  `paired_preprocessing_case_manifest.csv` are the runnable inventory/geometry contract.
+  The package README explains how to launch Vanguard's complete DICOM-to-vessel pipeline.
+- Newly transferred DICOM sources: `/gpfs/data/karczmar-lab/Retro NACT`,
+  `/gpfs/data/karczmar-lab/9127/9127 NAC`, and `/gpfs/data/karczmar-lab/9127/9127 Staging`.
+- Reviewed new-data inventories and selected-series manifests, under
+  `uchicago_ultrafast_longitudinal_cohort_v1/_build/source_inventory`,
+  `_build/zhen_extension`, and `_build/zhen_staging_extension`.
+
+The DICOM payloads are restricted and are not deidentified. Keep them within the
+approved Karczmar-lab shares. The published derived cohorts and their provenance do not
+require Huo-lab access.
+
 ## Project Conventions
 - Keep scripts and outputs named clearly enough that another student can understand what they are for.
 - Write comments and docstrings for a newcomer reading the code as it is now, in the present tense: state what the code does and why it is shaped this way. Do not narrate the change that produced it ("now we…", "no longer…", "instead of the old…", "removed X", "backward compatible with…") or reference prior approaches. That transitional rationale belongs in the commit message, lab notebook, and agent memory — in the code it bloats and goes stale. If a comment only makes sense to someone who saw the diff, it does not belong in the code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,9 @@ Derived outputs should go in clearly named output folders with enough provenance
 Concrete dataset roots, cohort counts, and raw-source paths are site-specific and are not
 part of the repo's portable contract. The UChicago ultrafast cohorts and their restricted
 Karczmar-lab DICOM sources are documented in [`UCHICAGO.md`](UCHICAGO.md). Those paths are
-valid only on the UChicago cluster -- anywhere else, prepare an equivalent dataset or arrange
-access, and point `data_paths` in your own YAML at it rather than assuming those roots exist.
+valid only on Randi, the cluster maintained by the Biological Sciences Division of the
+University of Chicago -- anywhere else, prepare an equivalent dataset or arrange access, and
+point `data_paths` in your own YAML at it rather than assuming those roots exist.
 
 ## Project Conventions
 - Keep scripts and outputs named clearly enough that another student can understand what they are for.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Supporting pieces:
 - `results/`
   - compact tracked result summaries
 - `analysis/`
-  - optional notebooks and lightweight exploratory analyses that are not part of the production pipeline
+  - optional Jupyter notebooks for exploratory analysis, not part of the production pipeline; notebooks only -- Python scripts belong in `scripts/` or the owning package
 - `docs/`
   - reference documents that are helpful but not part of the main run path
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ References:
 
 Runtime defaults now live in [`config.py`](config.py). The YAML files under [`configs/`](configs/) only need to override the values for a specific run. On the DSI cluster, many of those defaults point at shared paths under `/net/projects2/vanguard/...`. If your environment differs, override the relevant `data_paths` values in your YAML file instead of editing code.
 
+### UChicago internal cohorts (site-specific)
+
+The UChicago ultrafast DCE cohorts are internal data and are **not** distributed with this repository. Their dataset roots, cohort composition, layout, known caveats, and restricted raw DICOM sources are documented in [`UCHICAGO.md`](UCHICAGO.md); those paths only resolve on the UChicago cluster. To run the same pipelines elsewhere, prepare your own dataset against the manifest and directory contract described there, or arrange access with the Karczmar lab.
+
 ## Repository Structure
 
 This repository has four main workflows.
@@ -417,6 +421,7 @@ Optional graph-extraction analysis helpers live under:
 
 ## Additional Documentation
 
+- [`UCHICAGO.md`](UCHICAGO.md) — UChicago site-specific data paths and cohorts
 - [`docs/data_policy.md`](docs/data_policy.md)
 - [`docs/resources.md`](docs/resources.md)
 - [`docs/workflow.md`](docs/workflow.md)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Runtime defaults now live in [`config.py`](config.py). The YAML files under [`co
 
 ### UChicago internal cohorts (site-specific)
 
-The UChicago ultrafast DCE cohorts are internal data and are **not** distributed with this repository. Their dataset roots, cohort composition, layout, known caveats, and restricted raw DICOM sources are documented in [`UCHICAGO.md`](UCHICAGO.md); those paths only resolve on the UChicago cluster. To run the same pipelines elsewhere, prepare your own dataset against the manifest and directory contract described there, or arrange access with the Karczmar lab.
+The UChicago ultrafast DCE cohorts are internal data and are **not** distributed with this repository. Their dataset roots, cohort composition, layout, known caveats, and restricted raw DICOM sources are documented in [`UCHICAGO.md`](UCHICAGO.md); those paths only resolve on Randi, the cluster maintained by the Biological Sciences Division of the University of Chicago. To run the same pipelines elsewhere, prepare your own dataset against the manifest and directory contract described there, or arrange access with the Karczmar lab.
 
 ## Repository Structure
 
@@ -421,7 +421,7 @@ Optional graph-extraction analysis helpers live under:
 
 ## Additional Documentation
 
-- [`UCHICAGO.md`](UCHICAGO.md) — UChicago site-specific data paths and cohorts
+- [`UCHICAGO.md`](UCHICAGO.md) — site-specific data paths and cohorts on Randi (UChicago BSD)
 - [`docs/data_policy.md`](docs/data_policy.md)
 - [`docs/resources.md`](docs/resources.md)
 - [`docs/workflow.md`](docs/workflow.md)

--- a/UCHICAGO.md
+++ b/UCHICAGO.md
@@ -1,0 +1,92 @@
+# UChicago Site-Specific Data
+
+**Scope: this file describes one site's data only.** Every path, cohort count, and access
+rule below is valid only on the University of Chicago cluster, under the Karczmar-lab
+shares. Nothing here is bundled with the repository, and none of it is reachable from
+outside that cluster.
+
+If you are running Vanguard elsewhere, treat this file as a worked example of the data
+contract the code expects, not as something to point your configs at. You need either:
+
+- **your own dataset**, prepared to the same contract — a
+  `dce2d_internal_ultrafast_manifest.csv` with the columns described below, and the
+  `images/`, `centerlines/`, `tumor/` layout under your own root; or
+- **access to the UChicago cohorts**, which requires an agreement with the Karczmar lab.
+  The raw DICOM sources are not deidentified and are not shareable.
+
+Override the relevant `data_paths` values in your own YAML under [`configs/`](configs/)
+rather than editing code or assuming these roots exist. See
+[`docs/data_policy.md`](docs/data_policy.md) for the governing data policy.
+
+This file documents cohort composition, layout, and known caveats. It is deliberately not
+a complete provenance record.
+
+## UChicago ultrafast cohorts
+
+Two published dataset roots under `/gpfs/data/karczmar-lab/vanguard/`, complete through
+cohort construction, Vanguard v5 preprocessing, and tumor/vessel artifact publication:
+
+- `uchicago_ultrafast_longitudinal_cohort_v1` — 240 exams from 196 patients. Repeated
+  visits are retained on purpose: 179 runnable legacy exams plus 61 newly transferred
+  exams from 55 patients. Patient-level pCR is 122 non-pCR / 74 pCR.
+- `uchicago_ultrafast_pretreatment_cohort_v1` — 137 exams from 137 patients, one
+  reviewed pretreatment exam per patient: 82 runnable legacy baselines plus 55
+  new-patient baselines. pCR is 78 non-pCR / 59 pCR.
+
+The cohort manifest is `dce2d_internal_ultrafast_manifest.csv` in either root. It keeps
+the existing UChicago manifest contract: `exam_id`, `patient_key`, fixed patient-grouped
+`fold`, `pcr`, physical timestamps, phase paths, and clinical/cohort metadata. Repeated
+exams from the same patient always share a label and a fold.
+
+Each root contains:
+
+- `images/<dataset>/<exam_id>/` — motion-corrected UFAST phase NIfTIs and
+  `ufast_times_seconds.npy`. The UFAST signal is raw: no clipping, no z-scoring, five
+  protocol baselines, physical DICOM times, and one spatial interpolation. Dynamics are
+  not collapsed and not independently normalized by phase.
+- `centerlines/<dataset>/<exam_id>/` — the HR-derived vessel skeleton mask, support
+  mask, `*_morphometry.json`, `run_summary.json`, and mapping QC. Vessel extraction uses
+  the higher-spatial-resolution acquisition; node kinetics come from the aligned UFAST
+  acquisition.
+- `tumor/masks/<exam_id>.nii.gz` — primary tumor masks mapped from the
+  higher-spatial-resolution segmentation onto the exact UFAST/centerline grid, plus
+  `tumor_mask_manifest.csv`, checksums, provenance, and review flags.
+- `README.md`, `SHA256SUMS`, and `pending_cases.csv`.
+
+Tumor-mask caveats:
+
+- All 240/240 longitudinal and 137/137 pretreatment masks were published with passing
+  alignment/mapping status.
+- 14 longitudinal masks are empty. All fall outside the selected pretreatment cohort,
+  and most are later visits where a visible tumor may no longer be present.
+- The manifests flag 69 longitudinal and 36 pretreatment exams as possible bilateral
+  cases requiring review and downstream exclusion. These are conservative candidates,
+  not 69 or 36 confirmed bilateral cancers.
+
+`pending_cases.csv` lists four cases explicitly rather than dropping them silently: two
+workbook patients whose images were not present in the transferred inventories, and two
+legacy exams that cannot be run through the exact HR+UFAST contract (one shared HR/UFAST
+acquisition with no distinct HR series, and one split-series exam with eight HR
+candidates but no identifiable UFAST series).
+
+## UChicago raw DICOM sources
+
+The cohort roots above expose derived outputs by symlink. Full preprocessing from raw
+DICOM uses these restricted Karczmar-lab sources:
+
+- Legacy paired HR+UFAST package:
+  `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/paired_hr_ufast_source_dicom`.
+  `archives/<dataset>/<exam_id>.zip` contains byte-for-byte selected DICOM payloads.
+  `dicom_file_manifest.parquet`, `dicom_spatial_geometry_manifest.csv`,
+  `hr_ufast_spatial_alignment_manifest.csv`, and
+  `paired_preprocessing_case_manifest.csv` are the runnable inventory/geometry contract.
+  The package README explains how to launch Vanguard's complete DICOM-to-vessel pipeline.
+- Newly transferred DICOM sources: `/gpfs/data/karczmar-lab/Retro NACT`,
+  `/gpfs/data/karczmar-lab/9127/9127 NAC`, and `/gpfs/data/karczmar-lab/9127/9127 Staging`.
+- Reviewed new-data inventories and selected-series manifests, under
+  `uchicago_ultrafast_longitudinal_cohort_v1/_build/source_inventory`,
+  `_build/zhen_extension`, and `_build/zhen_staging_extension`.
+
+The DICOM payloads are restricted and are not deidentified. Keep them within the
+approved Karczmar-lab shares. The published derived cohorts and their provenance do not
+require Huo-lab access.

--- a/UCHICAGO.md
+++ b/UCHICAGO.md
@@ -1,9 +1,9 @@
-# UChicago Site-Specific Data
+# UChicago Site-Specific Data (Randi)
 
 **Scope: this file describes one site's data only.** Every path, cohort count, and access
-rule below is valid only on the University of Chicago cluster, under the Karczmar-lab
-shares. Nothing here is bundled with the repository, and none of it is reachable from
-outside that cluster.
+rule below is valid only on Randi, the cluster maintained by the Biological Sciences
+Division of the University of Chicago, under the Karczmar-lab shares. Nothing here is
+bundled with the repository, and none of it is reachable from outside Randi.
 
 If you are running Vanguard elsewhere, treat this file as a worked example of the data
 contract the code expects, not as something to point your configs at. You need either:
@@ -23,7 +23,7 @@ a complete provenance record.
 
 ## UChicago ultrafast cohorts
 
-Two published dataset roots under `/gpfs/data/karczmar-lab/vanguard/`, complete through
+Two published dataset roots under `/gpfs/data/karczmar-lab/vanguard/` on Randi, complete through
 cohort construction, Vanguard v5 preprocessing, and tumor/vessel artifact publication:
 
 - `uchicago_ultrafast_longitudinal_cohort_v1` — 240 exams from 196 patients. Repeated
@@ -72,7 +72,7 @@ candidates but no identifiable UFAST series).
 ## UChicago raw DICOM sources
 
 The cohort roots above expose derived outputs by symlink. Full preprocessing from raw
-DICOM uses these restricted Karczmar-lab sources:
+DICOM uses these restricted Karczmar-lab sources, also on Randi:
 
 - Legacy paired HR+UFAST package:
   `/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/paired_hr_ufast_source_dicom`.

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -2,8 +2,12 @@
 
 This directory is optional. It is not part of the production pipeline.
 
-Keep only lightweight notebooks here that help explain or inspect results after
-the main workflows have run.
+**Notebooks only.** Keep only lightweight `.ipynb` notebooks here that help
+explain or inspect results after the main workflows have run. Python scripts,
+shell scripts, and `.slurm` files do not belong here even when they are one-off
+diagnostics: put Python in `scripts/` or the owning package and sbatch scripts
+in `slurm/`. The `.py` files still present in this directory predate the rule
+and are pending migration.
 
 Current notebooks:
 


### PR DESCRIPTION
Document the two published cohort roots (longitudinal 240/196, pretreatment 137/137), the shared `dce2d_internal_ultrafast_manifest.csv` contract, and the per-root `images/centerlines/tumor` layout under Vanguard Data Layout.

Also record the tumor-mask caveats (14 empty longitudinal masks, 69/36 exams flagged as possible bilateral cases needing review, four pending_cases.csv rows) and the restricted raw DICOM sources, which are not deidentified and must stay within Karczmar-lab shares.