### PR TITLE
Integrate UChicago graph analyses and temporal pretraining

### DIFF
--- a/AUDITING_RESULTS.md
+++ b/AUDITING_RESULTS.md
@@ -365,3 +365,44 @@ failure mode it protects against), and flagged at the point of use.
 - **Where.** `tabular/gnn_feature_baseline.py` (`summarize_graph`,
   `_summary_stats`, `run_cv`); tests in
   `tests/test_tabular_gnn_feature_baseline.py`.
+
+## GNN — kinetic baseline floor (divide-by-near-zero enhancement artifact)
+
+- **What is handled.** The relative-enhancement transform in
+  `gnn/kinetics.py::baseline_relative_curve` computes `(S(t) - S0) / S0`, where
+  `S0` is the per-voxel precontrast baseline. When `S0` is a tiny-but-nonzero
+  fraction of the voxel's own signal (near-signal-void voxels, mask/registration
+  edges, noise), the ratio explodes: on the UChicago v5 cohort the raw
+  `peak_enhancement` reached 2.5e8 (physiological is ~0-5), with `auc_positive`
+  up to 1.1e10 and `washin_slope` up to 2.7e6. The pre-existing guard only
+  floored `S0` at float32-eps (~1.2e-7), i.e. it caught only *exact* zeros.
+  The new opt-in `baseline_floor_frac` parameter floors the denominator at that
+  fraction of each row's own peak `|signal|`
+  (`denom = max(S0, baseline_floor_frac * max|S|)`), capping peak relative
+  enhancement at ~`1/baseline_floor_frac` and leaving normal voxels
+  (`S0 >> floor`) untouched.
+- **Why.** Per-fold z-standardization (`gnn/train.py::fit_node_standardizer`)
+  fixes scale but not outliers: a single 2.5e8 voxel inflates the feature's std
+  so every physiological value collapses to ~0 after standardization, and
+  max-pooling reads the artifact voxel directly. Three of the seven voxel
+  features were effectively noise, making "advanced modeling didn't help"
+  uninterpretable (signal-absent vs. signal-present-but-crushed were
+  indistinguishable). This is a genuine acquisition/segmentation edge case, not
+  a modeling choice, so it is corrected at the feature source.
+- **Failure mode it protects against.** Divide-by-near-zero baselines turning a
+  handful of noise voxels into features that dominate the pooled graph
+  representation, silently destroying the real kinetic signal after
+  standardization.
+- **Default off; opt-in and audited.** `baseline_floor_frac` defaults to `0.0`
+  (historical behavior, exact-zero guard only), so every existing cache,
+  cohort, and the shared forecasting path (`gnn.pretrain.node_series`, which
+  reuses `baseline_relative_curve`) are byte-for-byte unchanged. It is currently
+  threaded only through the **voxel** kinetic path; `_build_case` raises
+  `NotImplementedError` if a nonzero floor is requested for segment/junction mode
+  or with `attach_node_series=True`, rather than silently ignoring it. When
+  active it is recorded in the cache manifest (`kinetic_baseline_floor_frac`) and
+  enforced by `_check_cache_manifest` (absent normalized to 0.0), so a floored
+  cache can never silently serve an unfloored request or vice versa. Wired via
+  `gnn/build_dataset.py --kinetic-baseline-floor-frac` and the
+  `KINETIC_BASELINE_FLOOR_FRAC` env in `gnn/slurm/submit_gnn_build.slurm`. The
+  UChicago rich-feature rebuild uses `0.05` (caps at ~20x / 2000% enhancement).

--- a/analysis/arrival_field_structure.py
+++ b/analysis/arrival_field_structure.py
@@ -1,0 +1,230 @@
+"""Does the arrival-time field have ANY spatial structure on the vessel tree?
+
+The Stage 2 relational features came out at chance
+(``experiments/uchicago_graph_relational``), with ``arrival_monotonic_frac`` sitting
+at 0.490 +/- 0.011 -- a coin flip in every case. Two very different things produce
+that number, and they imply opposite next steps:
+
+1. **The root definition is wrong.** Arrival times are spatially organized, but not
+   around the largest-radius node, so distance-from-root is the wrong coordinate.
+   Fixable: pick a better root.
+2. **The arrival field is spatially unstructured.** Adjacent voxels' arrival times
+   are essentially independent, so no root, no feature, and no architecture can
+   recover propagation -- the information is not in the acquisition.
+
+This separates them without assuming either. For each case it measures how much
+adjacent voxels' arrival times agree, against two references:
+
+- **A shuffled null.** Arrival values permuted across nodes within the case,
+  keeping the graph fixed. This is what zero spatial structure looks like.
+- **A positive control: ``radius``.** Vessel calibre is necessarily smooth along a
+  centreline, so it must show strong edge-wise agreement. If radius does and
+  arrival does not, the graph reconstruction is sound and the arrival field
+  specifically is unstructured -- which rules out "my skeleton/adjacency is broken"
+  as the explanation.
+
+Also reports ``arrival_monotonic_frac`` under the real (largest-radius) root
+against a randomly chosen root: if the real root is no better than random, the
+distance-from-root coordinate carries no information regardless of the field.
+
+Interpretation hinges on the acquisition, which is why this matters: UChicago DCE
+series are 5 fast precontrast frames, then a 29-107 s injection gap, then ~19 frames
+at ~3.3 s. Bolus wash-in happens *inside the gap*, so by the first postcontrast
+frame contrast has already reached everywhere, and "time to enhancement" is measured
+during the plateau/washout rather than during arrival.
+
+Reads the built voxel cache only -- no DCE reload, no rebuild.
+
+Usage:
+    python -m analysis.arrival_field_structure \
+        --cache-dir /ess/.../gnn_cache_voxel_richfeat_floored \
+        --out-dir experiments/uchicago_arrival_field
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import torch
+
+from gnn.relational_features import MIN_COMPONENT_NODES, _skeleton_graph
+
+_GRAPH_SUFFIX = "_graph.pt"
+_RANDOM_PAIRS = 20000
+# A correlation needs at least two pairs to be defined at all.
+_MIN_CORR_POINTS = 2
+
+
+def _edgewise_correlation(
+    graph: nx.Graph, values: np.ndarray, in_use: np.ndarray
+) -> float:
+    """Pearson r between the two endpoint values of every usable skeleton edge.
+
+    High r means the field varies smoothly along vessels; r near 0 means adjacent
+    voxels are essentially independent. Edges with a non-finite value at either end
+    are skipped (no detected arrival is a real condition, not a bug).
+    """
+    left, right = [], []
+    for source, target in graph.edges():
+        if not (in_use[source] and in_use[target]):
+            continue
+        a, b = values[source], values[target]
+        if not (np.isfinite(a) and np.isfinite(b)):
+            continue
+        left.append(a)
+        right.append(b)
+    if len(left) < _MIN_CORR_POINTS:
+        return float("nan")
+    left_arr, right_arr = np.asarray(left), np.asarray(right)
+    if left_arr.std() == 0.0 or right_arr.std() == 0.0:
+        return float("nan")
+    return float(np.corrcoef(left_arr, right_arr)[0, 1])
+
+
+def _random_pair_correlation(
+    values: np.ndarray, used: np.ndarray, rng: np.random.Generator
+) -> float:
+    """Pearson r between random *non-adjacent* node pairs -- the no-structure anchor."""
+    finite = used[np.isfinite(values[used])]
+    if finite.size < _MIN_CORR_POINTS:
+        return float("nan")
+    a = rng.choice(finite, size=_RANDOM_PAIRS)
+    b = rng.choice(finite, size=_RANDOM_PAIRS)
+    keep = a != b
+    if keep.sum() < _MIN_CORR_POINTS:
+        return float("nan")
+    return float(np.corrcoef(values[a[keep]], values[b[keep]])[0, 1])
+
+
+def _monotonic_fraction(
+    graph: nx.Graph, distance: np.ndarray, arrival: np.ndarray, in_use: np.ndarray
+) -> float:
+    """Fraction of edges where the node farther from the root enhances later.
+
+    Ties in arrival carry no ordering and are excluded, matching
+    ``gnn.relational_features``.
+    """
+    agree = comparable = 0
+    for source, target in graph.edges():
+        if not (in_use[source] and in_use[target]):
+            continue
+        d_distance = distance[target] - distance[source]
+        d_arrival = arrival[target] - arrival[source]
+        if not np.isfinite(d_arrival) or d_distance == 0.0 or d_arrival == 0.0:
+            continue
+        comparable += 1
+        agree += int(np.sign(d_distance) == np.sign(d_arrival))
+    return float(agree / comparable) if comparable else float("nan")
+
+
+def _distance_from_roots(
+    graph: nx.Graph,
+    components: list[np.ndarray],
+    num_nodes: int,
+    pick_root: Callable[[np.ndarray], int],
+) -> np.ndarray:
+    """Geodesic distance from each component's root, chosen by ``pick_root``."""
+    distance = np.full(num_nodes, np.nan, dtype=float)
+    for component in components:
+        root = int(pick_root(component))
+        for node, length in nx.single_source_dijkstra_path_length(
+            graph, root, weight="weight"
+        ).items():
+            distance[node] = float(length)
+    return distance
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Command-line interface for the arrival-field structure diagnostic."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser
+
+
+def main() -> None:
+    """Measure arrival-field spatial structure per case and summarize the cohort."""
+    args = build_parser().parse_args()
+    rng = np.random.default_rng(args.seed)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    paths = sorted((args.cache_dir / "processed").glob(f"*{_GRAPH_SUFFIX}"))
+    if not paths:
+        raise FileNotFoundError(f"No {_GRAPH_SUFFIX} files under {args.cache_dir}")
+
+    rows = []
+    for path in paths:
+        cached = torch.load(path)
+        data = cached[0] if isinstance(cached, tuple | list) else cached
+        arrival = data.time_to_enhancement_seconds.numpy().astype(float)
+        radius = data.radius.numpy().astype(float)
+        graph = _skeleton_graph(data)
+        components = [
+            np.asarray(sorted(component), dtype=int)
+            for component in nx.connected_components(graph)
+            if len(component) >= MIN_COMPONENT_NODES
+        ]
+        if not components:
+            raise ValueError(f"case={data.case_id}: no usable component")
+        used = np.concatenate(components)
+        in_use = np.zeros(int(data.num_nodes), dtype=bool)
+        in_use[used] = True
+
+        shuffled = arrival.copy()
+        shuffled[used] = rng.permutation(arrival[used])
+
+        real_distance = _distance_from_roots(
+            graph,
+            components,
+            int(data.num_nodes),
+            lambda c, r=radius: c[int(np.argmax(r[c]))],
+        )
+        random_distance = _distance_from_roots(
+            graph,
+            components,
+            int(data.num_nodes),
+            lambda c: rng.choice(c),
+        )
+
+        rows.append(
+            {
+                "case_id": str(data.case_id),
+                "pcr": int(data.y.item()),
+                "edge_r_arrival": _edgewise_correlation(graph, arrival, in_use),
+                "edge_r_arrival_shuffled": _edgewise_correlation(
+                    graph, shuffled, in_use
+                ),
+                "randompair_r_arrival": _random_pair_correlation(arrival, used, rng),
+                "edge_r_radius": _edgewise_correlation(graph, radius, in_use),
+                "edge_r_radius_shuffled": _edgewise_correlation(
+                    graph, radius[rng.permutation(len(radius))], in_use
+                ),
+                "monotonic_real_root": _monotonic_fraction(
+                    graph, real_distance, arrival, in_use
+                ),
+                "monotonic_random_root": _monotonic_fraction(
+                    graph, random_distance, arrival, in_use
+                ),
+            }
+        )
+
+    frame = pd.DataFrame(rows)
+    frame.to_csv(args.out_dir / "arrival_field_structure.csv", index=False)
+    summary = (
+        frame.drop(columns=["case_id", "pcr"])
+        .describe()
+        .loc[["mean", "std", "min", "50%", "max"]]
+    )
+    summary.to_csv(args.out_dir / "summary.csv")
+    print(f"n_cases={len(frame)}")
+    print(summary.round(4).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/edge_ablation_gate.py
+++ b/analysis/edge_ablation_gate.py
@@ -1,0 +1,131 @@
+"""Does the voxel GNN use the vessel topology at all? Paired read of the ablation.
+
+Scores the three arms of ``gnn/slurm/submit_gnn_uchicago_edge_ablation.slurm`` on
+pooled OOF AUC with bootstrap CIs, and runs the paired comparisons that matter:
+
+- ``rewire - none`` -- randomizing *which* nodes are adjacent while preserving every
+  degree. A model using the specific vessel topology should lose AUC here.
+- ``drop - none`` -- removing message passing entirely, leaving a per-node map plus
+  a permutation-invariant readout (a Deep Sets model). A model using edges at all
+  should lose AUC here.
+
+Both deltas being indistinguishable from zero means the graph contributes nothing,
+which reframes every prior graph-mode null: the bottleneck is the operator (a
+2-layer GCN plus mean-pool on a graph of diameter 290-618 hops), not the
+vasculature. See ``docs/design/gnn_graph_representation_plan.md`` Stage 0.1.
+
+Per-arm OOF predictions are averaged across the 5 seeds before scoring, matching
+``analysis/gnn_tabular_gate.py``, so seed noise does not drive the comparison.
+
+Reads only each run's ``predictions.csv`` -- head-node safe.
+
+Usage:
+    python -m analysis.edge_ablation_gate \
+        --sweep-root /ess/.../experiments/gnn_edge_ablation \
+        --out-dir experiments/uchicago_edge_ablation
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+from analysis.protocol_confound_check import (
+    bootstrap_auc_ci,
+    bootstrap_paired_delta,
+)
+
+_ARMS: tuple[str, ...] = ("none", "rewire", "drop")
+_SEEDS: tuple[int, ...] = (0, 1, 2, 3, 4)
+
+
+def load_arm_predictions(sweep_root: Path, arm: str) -> pd.DataFrame:
+    """Seed-averaged OOF probability per case for one ablation arm.
+
+    Every seed scores all 179 cases out-of-fold, so the seeds are aligned on
+    ``case_id`` and averaged. A missing or short seed run raises rather than being
+    quietly averaged over fewer seeds.
+    """
+    frames = []
+    for seed in _SEEDS:
+        matches = sorted((sweep_root / f"{arm}_seed{seed}").glob("*/*/predictions.csv"))
+        if not matches:
+            raise FileNotFoundError(f"No predictions.csv for arm={arm} seed={seed}")
+        frame = pd.read_csv(matches[0])[["case_id", "y_true", "y_prob"]]
+        frames.append(frame.set_index("case_id"))
+    sizes = {len(f) for f in frames}
+    if len(sizes) != 1:
+        raise ValueError(f"arm={arm}: seeds disagree on case count: {sizes}")
+    y_true = frames[0]["y_true"]
+    probs = pd.concat([f["y_prob"] for f in frames], axis=1)
+    if probs.isna().any().any():
+        raise ValueError(f"arm={arm}: seeds disagree on which cases were scored")
+    return pd.DataFrame({"y_true": y_true, "y_prob": probs.mean(axis=1)})
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Command-line interface for the edge-ablation gate."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sweep-root", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser
+
+
+def main() -> None:
+    """Score each arm, run the paired deltas, and write the gate outputs."""
+    args = build_parser().parse_args()
+    rng = np.random.default_rng(args.seed)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    arms = {arm: load_arm_predictions(args.sweep_root, arm) for arm in _ARMS}
+    reference = arms["none"]
+    for arm, frame in arms.items():
+        if not frame.index.equals(reference.index):
+            raise ValueError(f"arm={arm} scored a different case set than 'none'")
+        if not np.array_equal(frame["y_true"], reference["y_true"]):
+            raise ValueError(f"arm={arm} disagrees with 'none' on labels")
+
+    y = reference["y_true"].to_numpy()
+    auc_rows = []
+    for arm, frame in arms.items():
+        probs = frame["y_prob"].to_numpy()
+        low, high = bootstrap_auc_ci(y, probs, rng)
+        auc_rows.append(
+            {
+                "arm": arm,
+                "n": len(y),
+                "auc": roc_auc_score(y, probs),
+                "ci_low": low,
+                "ci_high": high,
+            }
+        )
+
+    delta_rows = []
+    for arm in ("rewire", "drop"):
+        delta, low, high = bootstrap_paired_delta(
+            y, arms[arm]["y_prob"].to_numpy(), reference["y_prob"].to_numpy(), rng
+        )
+        delta_rows.append(
+            {
+                "comparison": f"{arm} - none",
+                "mean_delta": delta,
+                "ci_low": low,
+                "ci_high": high,
+                "ci_excludes_zero": bool(low > 0.0 or high < 0.0),
+            }
+        )
+
+    pd.DataFrame(auc_rows).to_csv(args.out_dir / "auc_ci.csv", index=False)
+    pd.DataFrame(delta_rows).to_csv(args.out_dir / "paired_delta.csv", index=False)
+    print(pd.DataFrame(auc_rows).round(3).to_string(index=False))
+    print()
+    print(pd.DataFrame(delta_rows).round(3).to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -1,6 +1,6 @@
 """Verify the kinetic baseline floor: WHERE (and why) does it activate?
 
-For one case, replicates the exact per-voxel denominator logic of
+For each case, replicates the exact per-voxel denominator logic of
 ``gnn.kinetics.baseline_relative_curve`` (relative enhancement mode):
 
     baseline      = mean of the first ``baseline_frame_count`` DCE frames
@@ -14,33 +14,68 @@ those voxels on the top-down center axial slice so we can see whether they sit
 where the anatomy is genuinely near-void (mask edges / low-signal regions),
 verifying the floor targets artifacts rather than real tissue.
 
-Loads one case's raw 4D DCE -- run via Slurm, not the head node.
+Each case gets a flat directory ``<out-dir>/<case_id>/`` holding three figures:
+
+    plot.png                       every precontrast frame at one slice, twice:
+                                   floor-active voxels marked on top, pure below
+    postcontrast.png               the same layout and slice for four sampled
+                                   post-contrast frames (early/middle/end/peak)
+    precontrast_voxel_values.png   sampled floor-active voxels, one point per
+                                   precontrast frame, and mean vs max baseline
+
+``summary.csv`` at the out-dir root carries one row per case, and
+``analysis.floor_cohort_summary`` turns it into the cohort-level figures.
+
+Loads each case's raw 4D DCE -- run via Slurm, not the head node.
 
 Usage:
-    python -m analysis.floor_activation_map --case-id <id> \
+    python -m analysis.floor_activation_map \
         --centerline-root .../preprocessing_out_v5/centerlines \
         --dce-root .../preprocessing_out_v5/dce \
-        --floor-frac 0.05 --out-dir experiments/floor_activation_check
+        --floor-frac 0.05 --out-dir .../precontrast_floor_experiment
+
+``--case-id <id> [<id> ...]`` restricts the run to specific cases; omitting it
+processes every case found under ``--centerline-root``.
 """
 
 from __future__ import annotations
 
 import argparse
+import csv
 from pathlib import Path
 
-import numpy as np
+import matplotlib
 
-from gnn.data_loader import (
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+from analysis.floor_cohort_summary import render as render_cohort_figures  # noqa: E402
+from gnn.data_loader import (  # noqa: E402
     _CENTERLINE_SUFFIX,
     _SUPPORT_PATTERN,
     _load_study_metadata,
 )
-from gnn.raw_dce import (
+from gnn.raw_dce import (  # noqa: E402
     discover_raw_dce_paths,
     load_raw_dce_series,
 )
 
 _EPS = float(np.finfo(np.float32).eps)
+# A case can have hundreds of floor-active voxels; plotting every one of them
+# with a point per precontrast frame is unreadable. The per-voxel figure draws a
+# seeded random sample instead, with a two-voxel frame-by-frame detail.
+_SAMPLE_VOXELS = 20
+_DETAIL_VOXELS = 2
+_SAMPLE_SEED = 0
+
+
+def _discover_cases(centerline_root: Path) -> list[str]:
+    """Every case id with a skeleton mask under the centerline tree, sorted."""
+    return sorted(
+        path.name[: -len(_CENTERLINE_SUFFIX)]
+        for path in centerline_root.rglob(f"*{_CENTERLINE_SUFFIX}")
+    )
 
 
 def _resolve_case(centerline_root: Path, case_id: str) -> tuple[Path, Path]:
@@ -58,9 +93,15 @@ def _resolve_case(centerline_root: Path, case_id: str) -> tuple[Path, Path]:
 
 
 def main() -> None:
-    """Compute the floor-activation mask for one case and render the overlay."""
+    """Compute the floor-activation mask and render the figures for every case."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--case-id", type=str, required=True)
+    parser.add_argument(
+        "--case-id",
+        type=str,
+        nargs="+",
+        default=None,
+        help="case ids to render; default = every case under --centerline-root",
+    )
     parser.add_argument("--centerline-root", type=Path, required=True)
     parser.add_argument("--dce-root", type=Path, required=True)
     parser.add_argument("--floor-frac", type=float, default=0.05)
@@ -73,25 +114,62 @@ def main() -> None:
     parser.add_argument("--out-dir", type=Path, required=True)
     args = parser.parse_args()
 
-    mask_path, support_path = _resolve_case(args.centerline_root, args.case_id)
+    case_ids = args.case_id or _discover_cases(args.centerline_root)
+    print(f"rendering {len(case_ids)} case(s) -> {args.out_dir}")
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = [
+        _render_case(
+            case_id,
+            args.centerline_root,
+            args.dce_root,
+            args.floor_frac,
+            args.z,
+            args.out_dir / case_id,
+        )
+        for case_id in case_ids
+    ]
+
+    summary_path = args.out_dir / "summary.csv"
+    with summary_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    print(f"wrote {summary_path} ({len(rows)} cases)")
+    render_cohort_figures(summary_path)
+
+
+def _render_case(
+    case_id: str,
+    centerline_root: Path,
+    dce_root: Path,
+    floor_frac: float,
+    z_arg: int | None,
+    case_dir: Path,
+) -> dict:
+    """Run the whole diagnostic for one case and return its summary row."""
+    print(f"=================== {case_id} ===================")
+    mask_path, support_path = _resolve_case(centerline_root, case_id)
     study_dir = mask_path.parent
     skeleton = np.load(mask_path).astype(bool)
     support = np.load(support_path).astype(bool)
 
     timepoints, baseline_frame_count, relative_enhancement = _load_study_metadata(
-        args.case_id, study_dir
+        case_id, study_dir
     )
     if not relative_enhancement:
         raise ValueError(
-            f"case={args.case_id}: relative_enhancement is False (absolute "
+            f"case={case_id}: relative_enhancement is False (absolute "
             "convention) -- the floor never applies here, nothing to verify."
         )
-    dce_paths = discover_raw_dce_paths(args.dce_root, args.case_id, timepoints)
+    dce_paths = discover_raw_dce_paths(dce_root, case_id, timepoints)
     dce_4d = load_raw_dce_series(dce_paths, expected_shape_zyx=support.shape)
 
-    baseline = dce_4d[:baseline_frame_count].mean(axis=0)
+    precontrast = dce_4d[:baseline_frame_count]
+    precontrast_timepoints = [int(t) for t in timepoints[:baseline_frame_count]]
+    baseline = precontrast.mean(axis=0)
     signal_scale = np.abs(dce_4d).max(axis=0)
-    floored_denom_term = args.floor_frac * signal_scale
+    floored_denom_term = floor_frac * signal_scale
     # The floor bites exactly where it raises the denominator above the raw
     # baseline (matches np.maximum(baseline, frac*signal_scale) in kinetics.py).
     floor_active = (floored_denom_term > baseline) & (signal_scale > _EPS)
@@ -99,14 +177,25 @@ def main() -> None:
     zeroed = ~(np.isfinite(np.maximum(baseline, floored_denom_term))) | (
         np.maximum(baseline, floored_denom_term) <= _EPS
     )
+    active_mask = floor_active & support
+
+    # The alternative to flooring: build the baseline with a max over the
+    # precontrast frames instead of a mean. A voxel whose S0 is dragged to ~0 by
+    # one bad frame recovers under max and needs no floor; a voxel that is ~0 in
+    # every precontrast frame stays below the threshold either way. Counting
+    # both says which of the two the cohort actually contains.
+    baseline_max = precontrast.max(axis=0)
+    floor_active_maxop = (floored_denom_term > baseline_max) & (signal_scale > _EPS)
+    active_mask_maxop = floor_active_maxop & support
 
     supp_n = int(support.sum())
     skel_n = int(skeleton.sum())
-    supp_active = int((floor_active & support).sum())
+    supp_active = int(active_mask.sum())
     skel_active = int((floor_active & skeleton).sum())
     print(
-        f"case={args.case_id}  baseline_frames={baseline_frame_count}  "
-        f"relative_enhancement={relative_enhancement}"
+        f"case={case_id}  baseline_frames={baseline_frame_count}  "
+        f"relative_enhancement={relative_enhancement}  "
+        f"precontrast timepoints={precontrast_timepoints}"
     )
     print(
         f"support voxels: {supp_n}  floor-active: {supp_active} "
@@ -116,365 +205,410 @@ def main() -> None:
         f"skeleton (graph-node) voxels: {skel_n}  floor-active: {skel_active} "
         f"({100 * skel_active / max(skel_n, 1):.1f}%)"
     )
-    print(f"dead/zeroed voxels within support: {int((zeroed & support).sum())}")
+    n_dead = int((zeroed & support).sum())
+    print(f"dead/zeroed voxels within support: {n_dead}")
+    supp_active_maxop = int(active_mask_maxop.sum())
+    skel_active_maxop = int((floor_active_maxop & skeleton).sum())
+    print(
+        f"max-operator baseline: support floor-active {supp_active_maxop} "
+        f"({100 * supp_active_maxop / max(supp_n, 1):.1f}%), skeleton "
+        f"{skel_active_maxop} -> {supp_active - supp_active_maxop} support voxels "
+        "rescued by max instead of mean"
+    )
     ratio = baseline / np.where(signal_scale > _EPS, signal_scale, np.nan)
     supp_ratio = ratio[support]
+    median_ratio = float(np.nanmedian(supp_ratio))
     print(
-        f"baseline/signal_scale within support: median={np.nanmedian(supp_ratio):.3f} "
-        f"(floor threshold = {args.floor_frac})"
+        f"baseline/signal_scale within support: median={median_ratio:.3f} "
+        f"(floor threshold = {floor_frac})"
     )
 
     # Isolate the problematic voxels and confirm the "S0 ~ 0" claim in ABSOLUTE
     # terms (not just the relative floor trigger): their precontrast S0 should be
     # a tiny fraction of the healthy in-support S0, while their peak signal max|S|
     # stays comparable -- dark before contrast, real peak after -> blowup.
-    active_mask = floor_active & support
     med_support_s0 = float(np.median(baseline[support]))
-    if active_mask.any():
+    med_support_peak = float(np.median(signal_scale[support]))
+    med_active_s0 = float("nan")
+    med_active_peak = float("nan")
+    if supp_active:
         s0_active = baseline[active_mask]
+        med_active_s0 = float(np.median(s0_active))
+        med_active_peak = float(np.median(signal_scale[active_mask]))
         print(
-            f"floor-active S0 (absolute): median={np.median(s0_active):.2f} "
+            f"floor-active S0 (absolute): median={med_active_s0:.2f} "
             f"p90={np.percentile(s0_active, 90):.2f}  vs in-support median S0="
-            f"{med_support_s0:.2f}  (ratio={np.median(s0_active) / med_support_s0:.3f})"
+            f"{med_support_s0:.2f}  (ratio={med_active_s0 / med_support_s0:.3f})"
         )
         print(
-            f"floor-active max|S| (absolute): median={np.median(signal_scale[active_mask]):.2f} "
-            f"vs in-support median max|S|={np.median(signal_scale[support]):.2f} "
+            f"floor-active max|S| (absolute): median={med_active_peak:.2f} "
+            f"vs in-support median max|S|={med_support_peak:.2f} "
             "-> near-0 baseline but real peak (the blowup)"
         )
-    mask_path_out = args.out_dir / f"floor_active_mask_{args.case_id[:24]}.npy"
-    args.out_dir.mkdir(parents=True, exist_ok=True)
-    np.save(mask_path_out, active_mask)
-    print(
-        f"wrote isolated problematic-voxel mask {mask_path_out} "
-        f"({int(active_mask.sum())} voxels)"
-    )
 
-    # Center axial slice of the vessel-support z-extent (top-down view).
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    # The slice-level figures use the slice carrying the most floor-active
+    # voxels, so the red overlay is actually visible. With no floor-active
+    # voxels anywhere there is no such slice, and the center of the
+    # vessel-support z-extent stands in.
     z_support = np.where(support.any(axis=(1, 2)))[0]
-    z = args.z if args.z is not None else int((z_support.min() + z_support.max()) // 2)
+    z_center = int((z_support.min() + z_support.max()) // 2)
+    if z_arg is not None:
+        z = z_arg
+    elif supp_active:
+        z = int(active_mask.sum(axis=(1, 2)).argmax())
+    else:
+        z = z_center
     print(f"axial slice z={z} (support z-extent {z_support.min()}..{z_support.max()})")
 
-    args.out_dir.mkdir(parents=True, exist_ok=True)
-    _plot(
-        baseline,
-        signal_scale,
-        dce_4d.max(axis=0),
-        support,
-        skeleton,
-        floor_active,
-        z,
-        args.floor_frac,
-        args.case_id,
-        "max-over-time",
-        args.out_dir / f"floor_activation_{args.case_id[:24]}_z{z}.png",
-    )
-    # Single-panel overlay on the PRECONTRAST slice: red floor-active voxels on
-    # the raw precontrast image (where they sit on the dark near-void regions).
-    # Uses the slice carrying the most floor-active voxels so they're visible.
-    z_best = int((active_mask & support).sum(axis=(1, 2)).argmax())
-    _precontrast_overlay_plot(
-        baseline,
+    _precontrast_panel(
+        precontrast,
         support,
         active_mask,
-        z_best,
-        args.case_id,
-        args.out_dir
-        / f"floor_active_precontrast_overlay_{args.case_id[:24]}_z{z_best}.png",
+        z,
+        precontrast_timepoints,
+        case_id,
+        case_dir / "plot.png",
     )
-    _mechanism_plot(
+    _postcontrast_panel(
         dce_4d,
-        baseline,
-        active_mask,
         support,
+        active_mask,
+        z,
+        timepoints,
         baseline_frame_count,
-        z,
-        args.case_id,
-        args.out_dir / f"floor_mechanism_{args.case_id[:24]}_z{z}.png",
+        case_id,
+        case_dir / "postcontrast.png",
     )
-    _precontrast_plot(
-        baseline,
-        support,
+    _precontrast_voxel_value_plot(
+        precontrast,
         active_mask,
-        z,
-        args.case_id,
-        args.out_dir / f"precontrast_{args.case_id[:24]}_z{z}.png",
+        signal_scale,
+        precontrast_timepoints,
+        floor_frac,
+        case_id,
+        case_dir / "precontrast_voxel_values.png",
     )
 
+    row = {
+        "case_id": case_id,
+        "family": case_id.split("_1_3_")[0],
+        "n_timepoints": len(timepoints),
+        "baseline_frame_count": baseline_frame_count,
+        "precontrast_timepoints": " ".join(str(t) for t in precontrast_timepoints),
+        "support_voxels": supp_n,
+        "support_floor_active": supp_active,
+        "support_floor_active_pct": 100 * supp_active / max(supp_n, 1),
+        "skeleton_voxels": skel_n,
+        "skeleton_floor_active": skel_active,
+        "skeleton_floor_active_pct": 100 * skel_active / max(skel_n, 1),
+        "support_floor_active_maxop": supp_active_maxop,
+        "support_floor_active_maxop_pct": 100 * supp_active_maxop / max(supp_n, 1),
+        "skeleton_floor_active_maxop": skel_active_maxop,
+        "rescued_by_max": supp_active - supp_active_maxop,
+        "dead_voxels": n_dead,
+        "median_baseline_over_peak": median_ratio,
+        "median_support_s0": med_support_s0,
+        "median_active_s0": med_active_s0,
+        "median_support_peak": med_support_peak,
+        "median_active_peak": med_active_peak,
+        "z_center": z_center,
+        "z_slice_figures": z,
+    }
+    return row
 
-def _precontrast_overlay_plot(
-    baseline: np.ndarray,
+
+def _precontrast_panel(
+    precontrast: np.ndarray,
     support: np.ndarray,
     active_mask: np.ndarray,
     z: int,
+    precontrast_timepoints: list[int],
     case_id: str,
     out_path: Path,
 ) -> None:
-    """Precontrast + red floor-active voxels, beside the pure precontrast slice.
+    """Every precontrast frame twice: floor-active voxels marked, then pure.
 
-    Same slice and window on both panels, so the red voxels can be checked
-    against the pure image -- they should land where it is black (S0 ~ 0).
+    Top row carries the red floor-active voxels, bottom row is the same image
+    untouched, so each marked voxel can be checked against the unobstructed
+    version directly below it -- it should sit where that image is black. Every
+    panel shares one intensity window computed over the whole precontrast stack,
+    so differences between columns are real signal rather than windowing, and
+    the per-image in-support median under each column quantifies that.
+
+    The rightmost column is the mean of the frames -- S0 itself, the quantity
+    the floor actually compares against, set off by a divider because it is
+    derived rather than acquired. A voxel marked red while some individual frame
+    looks bright is one the mean is dragging down.
     """
-    import matplotlib
+    vmax = max(float(np.percentile(precontrast[:, support], 99)), _EPS)
+    ys, xs = np.where(active_mask[z])
+    n = len(precontrast_timepoints)
+    columns = [
+        *(
+            (f"frame {i} (t={t})", precontrast[i])
+            for i, t in enumerate(precontrast_timepoints)
+        ),
+        (f"S0 = mean of {n} frames", precontrast.mean(axis=0)),
+    ]
 
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-
-    pre = baseline[z]
-    supp = support[z]
-    ys, xs = np.where(active_mask[z] & supp)
-    vmax = max(np.percentile(pre[supp], 99) if supp.any() else 1.0, _EPS)
-
-    fig, axes = plt.subplots(1, 2, figsize=(13, 6.5))
-    axes[0].imshow(pre, cmap="gray", vmin=0, vmax=vmax)
-    axes[0].scatter(xs, ys, c="red", s=16, marker="s", linewidths=0)
-    axes[0].set_title(f"precontrast + floor-active (red, n={len(xs)})")
-    axes[1].imshow(pre, cmap="gray", vmin=0, vmax=vmax)
-    axes[1].set_title("pure precontrast (same slice)")
-    for ax in axes:
+    fig, axes = plt.subplots(2, len(columns), figsize=(3.2 * len(columns), 7.2))
+    for i, (label, volume) in enumerate(columns):
+        med = float(np.median(volume[support]))
+        axes[0, i].imshow(volume[z], cmap="gray", vmin=0, vmax=vmax)
+        axes[0, i].scatter(xs, ys, c="red", s=14, marker="s", linewidths=0)
+        axes[0, i].set_title(f"{label} + floor-active", fontsize=9)
+        axes[1, i].imshow(volume[z], cmap="gray", vmin=0, vmax=vmax)
+        axes[1, i].set_title(f"{label} pure\nin-support median {med:.1f}", fontsize=9)
+    for ax in axes.ravel():
         ax.set_xticks([])
         ax.set_yticks([])
-    fig.suptitle(f"z={z} — {case_id[:36]}")
+    fig.suptitle(
+        f"Precontrast frames + S0 at z={z} — {case_id[:36]}\n"
+        f"red = floor-active (n={len(xs)} in this slice); "
+        f"shared window [0, {vmax:.1f}]"
+    )
     fig.tight_layout()
+    # Divider between the acquired frames and the derived S0 column, placed once
+    # tight_layout has settled the axes positions it is measured from.
+    x_divider = (axes[0, n - 1].get_position().x1 + axes[0, n].get_position().x0) / 2
+    fig.add_artist(plt.Line2D([x_divider, x_divider], [0.02, 0.90], color="gray", lw=1))
     fig.savefig(out_path, dpi=150)
     plt.close(fig)
-    print(f"wrote {out_path} ({len(xs)} red voxels)")
+    print(f"wrote {out_path} ({len(xs)} red voxels, window [0, {vmax:.1f}])")
 
 
-def _precontrast_plot(
-    baseline: np.ndarray,
-    support: np.ndarray,
-    active_mask: np.ndarray,
-    z: int,
-    case_id: str,
-    out_path: Path,
-) -> None:
-    """Show that most precontrast voxels are NOT ~0.
-
-    Left: the raw precontrast S0 image (mean of the precontrast frames) at the
-    center slice -- normal grayscale anatomy, not a black frame. Right: the
-    in-support S0 distribution, with the floor-active voxels overlaid: the bulk
-    of vessel voxels sit at a healthy baseline, and only a small tail is near 0.
-    """
-    import matplotlib
-
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-
-    b = baseline[z]
-    supp_s0 = baseline[support]
-    active_s0 = baseline[active_mask]
-    med = float(np.median(supp_s0))
-
-    fig, axes = plt.subplots(1, 2, figsize=(13, 5.2))
-    hi = np.percentile(b[b > 0], 99) if (b > 0).any() else 1.0
-    im = axes[0].imshow(b, cmap="gray", vmin=0, vmax=max(hi, _EPS))
-    axes[0].set_xticks([])
-    axes[0].set_yticks([])
-    axes[0].set_title(
-        f"Raw precontrast S0 (z={z})\nin-support median S0={med:.1f} (not 0)"
-    )
-    fig.colorbar(im, ax=axes[0], fraction=0.046, pad=0.04)
-
-    axes[1].hist(
-        supp_s0, bins=80, color="steelblue", alpha=0.8, label="all vessel voxels"
-    )
-    if active_s0.size:
-        axes[1].hist(
-            active_s0, bins=80, color="red", alpha=0.9, label="floor-active (S0~0)"
-        )
-    axes[1].axvline(med, color="k", ls="--", lw=1, label=f"median {med:.1f}")
-    axes[1].set_yscale("log")
-    axes[1].set_xlabel("precontrast S0")
-    axes[1].set_ylabel("voxel count (log)")
-    axes[1].set_title("Vessel-voxel S0 distribution\nhealthy bulk + a tiny near-0 tail")
-    axes[1].legend(fontsize=8)
-    fig.suptitle(f"Are all precontrast voxels 0? No — {case_id[:32]}")
-    fig.tight_layout()
-    fig.savefig(out_path, dpi=150)
-    plt.close(fig)
-    print(f"wrote {out_path}")
-
-
-def _mechanism_plot(
+def _postcontrast_panel(
     dce_4d: np.ndarray,
-    baseline: np.ndarray,
-    active_mask: np.ndarray,
     support: np.ndarray,
+    active_mask: np.ndarray,
+    z: int,
+    timepoints: list[int],
     baseline_frame_count: int,
-    z: int,
     case_id: str,
     out_path: Path,
 ) -> None:
-    """Why S0~0 voxels are still visible: black precontrast, bright postcontrast.
+    """Post-contrast frames at the same slice, laid out like the precontrast panel.
 
-    Overlays the same problematic voxels on the precontrast S0 frame (where they
-    are ~black) and the post-contrast peak frame (where they are bright), then
-    plots the actual per-voxel S(t) curves -- problematic voxels start near 0 and
-    rise to a real peak (numerator real, denominator ~0 -> the ratio explodes),
-    healthy voxels start at a substantial baseline. The exploding quantity is the
-    derived (S-S0)/S0 feature, never the raw signal shown in grayscale.
+    Samples the post-contrast series at four points -- the first frame after
+    contrast, the middle of the series, the last frame, and the frame with the
+    highest in-support mean signal (the actual enhancement peak) -- so the
+    acquisition can be eyeballed for dropouts, motion, or wrap the precontrast
+    frames alone would not reveal. The peak frame can coincide with one of the
+    others; its label says so rather than substituting a different frame.
+
+    Top row marks the floor-active voxels, bottom row is the same image pure,
+    matching ``_precontrast_panel``. The window here is computed over the FULL
+    4D series rather than the precontrast stack, because post-contrast signal is
+    far brighter and the precontrast window would saturate every panel; it is
+    stated in the title, and it is shared across all panels of this figure so
+    frame-to-frame differences remain real signal (AGENTS.md).
     """
-    import matplotlib
+    n_post = dce_4d.shape[0] - baseline_frame_count
+    if n_post < 1:
+        raise ValueError(
+            f"case={case_id}: no post-contrast frames "
+            f"({dce_4d.shape[0]} timepoints, {baseline_frame_count} precontrast)"
+        )
+    in_support_mean = np.array(
+        [float(dce_4d[i][support].mean()) for i in range(dce_4d.shape[0])]
+    )
+    first = baseline_frame_count
+    last = dce_4d.shape[0] - 1
+    middle = baseline_frame_count + n_post // 2
+    peak = int(baseline_frame_count + np.argmax(in_support_mean[baseline_frame_count:]))
+    columns = [("early", first), ("middle", middle), ("end", last), ("peak", peak)]
 
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-    from matplotlib.colors import ListedColormap
+    vmax = max(float(np.percentile(dce_4d[:, support], 99)), _EPS)
+    ys, xs = np.where(active_mask[z])
 
-    supp = support[z]
-    pre = baseline[z]
-    post = dce_4d[baseline_frame_count:].max(axis=0)[z]
-    active_z = active_mask[z]
-    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 0.9)])
-
-    fig, axes = plt.subplots(1, 3, figsize=(16, 5))
-    pre_hi = np.percentile(pre[supp], 99) if supp.any() else 1.0
-    post_hi = np.percentile(post[supp], 99) if supp.any() else 1.0
-    axes[0].imshow(pre, cmap="gray", vmin=0, vmax=max(pre_hi, _EPS))
-    axes[0].imshow(np.where(active_z, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
-    axes[0].set_title(f"PRECONTRAST S0 (z={z})\nred voxels are ~black here (S0~0)")
-    axes[1].imshow(post, cmap="gray", vmin=0, vmax=max(post_hi, _EPS))
-    axes[1].imshow(np.where(active_z, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
-    axes[1].set_title("POSTCONTRAST peak\nsame voxels are bright (real enhancement)")
-    for ax in axes[:2]:
+    fig, axes = plt.subplots(2, len(columns), figsize=(3.2 * len(columns), 7.2))
+    for i, (label, t_idx) in enumerate(columns):
+        frame = dce_4d[t_idx, z]
+        dupes = [n for n, j in columns if j == t_idx and n != label]
+        tag = f" (= {', '.join(dupes)})" if dupes else ""
+        axes[0, i].imshow(frame, cmap="gray", vmin=0, vmax=vmax)
+        axes[0, i].scatter(xs, ys, c="red", s=14, marker="s", linewidths=0)
+        axes[0, i].set_title(
+            f"{label}{tag}: frame {t_idx} (t={timepoints[t_idx]})\n+ floor-active",
+            fontsize=9,
+        )
+        axes[1, i].imshow(frame, cmap="gray", vmin=0, vmax=vmax)
+        axes[1, i].set_title(
+            f"{label} pure\nin-support mean {in_support_mean[t_idx]:.1f}", fontsize=9
+        )
+    for ax in axes.ravel():
         ax.set_xticks([])
         ax.set_yticks([])
-
-    # S(t) for the most-extreme problematic voxels vs. near-median healthy voxels.
-    t = np.arange(dce_4d.shape[0])
-    coords = np.argwhere(active_mask)
-    s0_active = baseline[active_mask]
-    n = min(6, len(coords))
-    for i in np.argsort(s0_active)[:n]:
-        zz, yy, xx = coords[i]
-        axes[2].plot(t, dce_4d[:, zz, yy, xx], color="red", alpha=0.6, lw=1)
-    healthy = support & ~active_mask
-    hcoords = np.argwhere(healthy)
-    hs0 = baseline[healthy]
-    for i in np.argsort(np.abs(hs0 - np.median(hs0)))[:n]:
-        zz, yy, xx = hcoords[i]
-        axes[2].plot(t, dce_4d[:, zz, yy, xx], color="steelblue", alpha=0.6, lw=1)
-    axes[2].axvspan(-0.5, baseline_frame_count - 0.5, color="gray", alpha=0.15)
-    axes[2].axhline(0, color="k", lw=0.5)
-    axes[2].plot([], [], color="red", label="problematic (S0~0)")
-    axes[2].plot([], [], color="steelblue", label="healthy")
-    axes[2].axvspan(0, 0, color="gray", alpha=0.15, label="precontrast frames")
-    axes[2].legend(fontsize=8)
-    axes[2].set_xlabel("DCE frame (t)")
-    axes[2].set_ylabel("raw signal S(t)")
-    axes[2].set_title("both enhance; only the starting baseline differs")
-    fig.suptitle(f"Why S0~0 voxels are still visible — {case_id[:32]}")
+    fig.suptitle(
+        f"Post-contrast frames at z={z} — {case_id[:36]}\n"
+        f"red = floor-active (n={len(xs)} in this slice); shared window [0, {vmax:.1f}] "
+        f"over the full 4D series; {n_post} post-contrast frames"
+    )
     fig.tight_layout()
     fig.savefig(out_path, dpi=150)
     plt.close(fig)
-    print(f"wrote {out_path}")
+    print(
+        f"wrote {out_path} (frames early={first} middle={middle} end={last} "
+        f"peak={peak}, window [0, {vmax:.1f}])"
+    )
 
 
-def _isolation_plot(
+def _precontrast_voxel_value_plot(
+    precontrast: np.ndarray,
     active_mask: np.ndarray,
-    support: np.ndarray,
-    mip: np.ndarray,
-    case_id: str,
-    out_path: Path,
-) -> None:
-    """Top-down (max-over-z) projection isolating ALL floor-active voxels.
-
-    Collapses the volume along z so every problematic voxel at any depth shows in
-    one axial view, over the vessel-support footprint and a faint anatomy MIP --
-    reveals whether they cluster at the breast/mask periphery (expected for
-    near-void baselines) or sit inside the vasculature.
-    """
-    import matplotlib
-
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-    from matplotlib.colors import ListedColormap
-
-    active_proj = active_mask.any(axis=0)
-    supp_proj = support.any(axis=0)
-    mip_proj = mip.max(axis=0)
-    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 1.0)])
-
-    fig, ax = plt.subplots(figsize=(6.5, 6))
-    hi = np.percentile(mip_proj[supp_proj], 99) if supp_proj.any() else 1.0
-    ax.imshow(mip_proj, cmap="gray", vmin=0, vmax=max(hi, _EPS))
-    ax.contour(supp_proj, levels=[0.5], colors="cyan", linewidths=0.5)
-    ax.imshow(np.where(active_proj, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
-    ax.set_xticks([])
-    ax.set_yticks([])
-    ax.set_title(
-        f"Problematic voxels (S0~0), all depths — {case_id[:32]}\n"
-        f"red = floor-active (n={int(active_mask.sum())}); cyan = vessel support"
-    )
-    fig.tight_layout()
-    fig.savefig(out_path, dpi=150)
-    plt.close(fig)
-    print(f"wrote {out_path}")
-
-
-def _plot(
-    baseline: np.ndarray,
     signal_scale: np.ndarray,
-    anatomy: np.ndarray,
-    support: np.ndarray,
-    skeleton: np.ndarray,
-    floor_active: np.ndarray,
-    z: int,
-    frac: float,
+    precontrast_timepoints: list[int],
+    floor_frac: float,
     case_id: str,
-    anatomy_label: str,
     out_path: Path,
 ) -> None:
-    """Three-panel top-down slice: baseline S0, baseline/scale ratio, anatomy+red overlay.
+    """Do the floor-active voxels sit at ~0 in every precontrast frame, or one?
 
-    ``anatomy`` is the grayscale background for the overlay panel -- pass the
-    precontrast baseline to see the floor-active voxels land on the dark regions,
-    or the max-over-time image to see them on the enhancing anatomy.
+    Answers the operator question -- would a max over the precontrast frames
+    remove the need for the floor? -- at three zoom levels:
+
+    left    a random sample of at most ``_SAMPLE_VOXELS`` floor-active voxels,
+            each a column of its 5 precontrast values, with its mean (the
+            current S0), its max, and the floor it is measured against
+    middle   two of those voxels frame by frame, values annotated
+    right    mean vs max against the floor for every floor-active voxel, which
+            is what decides whether max alone clears the threshold
+
+    Sampling is seeded, so the same voxels are drawn on a rerun.
     """
-    import matplotlib
+    n_vox = int(active_mask.sum())
+    fig, axes = plt.subplots(1, 3, figsize=(17, 5.6))
+    if not n_vox:
+        for ax in axes:
+            ax.text(0.5, 0.5, "no floor-active voxels", ha="center", va="center")
+            ax.set_xticks([])
+            ax.set_yticks([])
+        fig.suptitle(f"Floor-active precontrast values — {case_id[:36]} (none)")
+        fig.tight_layout()
+        fig.savefig(out_path, dpi=150)
+        plt.close(fig)
+        print(f"wrote {out_path} (no floor-active voxels)")
+        return
 
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-    from matplotlib.colors import ListedColormap
+    values = precontrast[:, active_mask]  # (n_frames, n_active)
+    floor = floor_frac * signal_scale[active_mask]
+    rng = np.random.default_rng(_SAMPLE_SEED)
+    sample = rng.choice(n_vox, size=min(_SAMPLE_VOXELS, n_vox), replace=False)
+    sample = sample[np.argsort(values[:, sample].mean(axis=0))]
+    colors = plt.cm.viridis(np.linspace(0, 0.9, len(precontrast_timepoints)))
 
-    supp = support[z]
-    b = baseline[z]
-    anat_z = anatomy[z]
-    active = floor_active[z] & supp
-    ratio = np.full_like(b, np.nan)
-    np.divide(b, signal_scale[z], out=ratio, where=signal_scale[z] > _EPS)
-
-    # Windows from the in-support distribution (one shared window per panel).
-    b_hi = np.percentile(b[supp], 99) if supp.any() else 1.0
-    anat_hi = np.percentile(anat_z[supp], 99) if supp.any() else 1.0
-    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 0.85)])
-
-    fig, axes = plt.subplots(1, 3, figsize=(15, 5.4))
-    axes[0].imshow(b, cmap="gray", vmin=0, vmax=max(b_hi, _EPS))
-    axes[0].contour(supp, levels=[0.5], colors="cyan", linewidths=0.5)
-    axes[0].set_title(f"Precontrast baseline S0 (z={z})\ncyan = vessel support")
-
-    im = axes[1].imshow(np.where(supp, ratio, np.nan), cmap="viridis", vmin=0, vmax=0.3)
-    axes[1].contour((ratio < frac) & supp, levels=[0.5], colors="red", linewidths=0.6)
-    axes[1].set_title(f"baseline / max|S|  (red contour < {frac})")
-    fig.colorbar(im, ax=axes[1], fraction=0.046, pad=0.04)
-
-    axes[2].imshow(anat_z, cmap="gray", vmin=0, vmax=max(anat_hi, _EPS))
-    axes[2].imshow(np.where(active, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
-    axes[2].contour(skeleton[z], levels=[0.5], colors="yellow", linewidths=0.4)
-    n_active = int(active.sum())
-    axes[2].set_title(
-        f"{anatomy_label} + floor-active (red, n={n_active})\nyellow = skeleton"
+    ax = axes[0]
+    x = np.arange(len(sample))
+    for i, t in enumerate(precontrast_timepoints):
+        ax.scatter(
+            x,
+            values[i, sample],
+            s=42,
+            color=colors[i],
+            linewidths=0,
+            label=f"frame {i} (t={t})",
+        )
+    ax.scatter(
+        x,
+        values[:, sample].mean(axis=0),
+        s=70,
+        marker="_",
+        color="black",
+        label="mean = S0",
     )
+    ax.scatter(
+        x,
+        values[:, sample].max(axis=0),
+        s=70,
+        marker="_",
+        color="tab:orange",
+        label="max",
+    )
+    ax.scatter(
+        x,
+        floor[sample],
+        s=70,
+        marker="_",
+        color="crimson",
+        label=f"floor = {floor_frac}·max|S|",
+    )
+    ax.set_xlabel(f"sampled floor-active voxel ({len(sample)} of {n_vox}, random)")
+    ax.set_ylabel("precontrast signal")
+    ax.set_title(
+        f"{len(sample)} sampled floor-active voxels\nall 5 precontrast values each"
+    )
+    ax.legend(fontsize=7, loc="upper left")
 
-    for ax in axes:
-        ax.set_xticks([])
-        ax.set_yticks([])
-    fig.suptitle(f"Floor activation — {case_id[:40]}", fontsize=11)
+    ax = axes[1]
+    detail = sample[:: max(len(sample) // _DETAIL_VOXELS, 1)][:_DETAIL_VOXELS]
+    frame_x = np.arange(len(precontrast_timepoints))
+    for k, v in enumerate(detail):
+        ax.plot(frame_x, values[:, v], marker="o", lw=1.2, label=f"voxel {v}")
+        for i in frame_x:
+            ax.annotate(
+                f"{values[i, v]:.1f}",
+                (i, values[i, v]),
+                textcoords="offset points",
+                xytext=(0, 7 if k == 0 else -12),
+                ha="center",
+                fontsize=7,
+            )
+        ax.axhline(
+            floor[v],
+            color="crimson",
+            ls="--",
+            lw=0.9,
+            label=f"floor voxel {v} = {floor[v]:.1f}" if k == 0 else None,
+        )
+    ax.set_xticks(frame_x)
+    ax.set_xticklabels([f"{i}\n(t={t})" for i, t in enumerate(precontrast_timepoints)])
+    ax.set_xlabel("precontrast frame")
+    ax.set_ylabel("precontrast signal")
+    ax.set_title(
+        f"{len(detail)} voxels frame by frame\n~0 in all frames, or only some?"
+    )
+    ax.legend(fontsize=7)
+
+    ax = axes[2]
+    order = np.argsort(values.mean(axis=0))
+    vx = np.arange(n_vox)
+    ax.scatter(
+        vx,
+        values.mean(axis=0)[order],
+        s=3,
+        color="black",
+        linewidths=0,
+        label="mean = S0",
+    )
+    ax.scatter(
+        vx,
+        values.max(axis=0)[order],
+        s=3,
+        color="tab:orange",
+        linewidths=0,
+        label="max",
+    )
+    ax.plot(
+        vx, floor[order], color="crimson", lw=1.0, label=f"floor = {floor_frac}·max|S|"
+    )
+    still_floored = int((values.max(axis=0) < floor).sum())
+    ax.set_xlabel(f"floor-active voxel (n={n_vox}, sorted by mean)")
+    ax.set_ylabel("precontrast signal")
+    ax.set_title(
+        f"mean vs max operator, all {n_vox} floor-active voxels\n"
+        f"max still under the floor for {still_floored} ({100 * still_floored / n_vox:.0f}%)"
+    )
+    ax.legend(fontsize=7, markerscale=3)
+
+    fig.suptitle(
+        f"Would a max over the precontrast frames replace the floor? — {case_id[:36]}"
+    )
     fig.tight_layout()
     fig.savefig(out_path, dpi=150)
     plt.close(fig)
-    print(f"wrote {out_path}")
+    print(f"wrote {out_path} (max still below floor for {still_floored}/{n_vox})")
 
 
 if __name__ == "__main__":

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -177,7 +177,6 @@ def main() -> None:
         baseline,
         support,
         active_mask,
-        skeleton,
         z_best,
         args.case_id,
         args.out_dir
@@ -207,44 +206,39 @@ def _precontrast_overlay_plot(
     baseline: np.ndarray,
     support: np.ndarray,
     active_mask: np.ndarray,
-    skeleton: np.ndarray,
     z: int,
     case_id: str,
     out_path: Path,
 ) -> None:
-    """Single panel: floor-active voxels (red) on the raw PRECONTRAST slice.
+    """Precontrast + red floor-active voxels, beside the pure precontrast slice.
 
-    Background is the precontrast baseline image (not max-over-time), so the red
-    problematic voxels visibly land on the dark near-void regions. Cyan = vessel
-    support outline, yellow = skeleton.
+    Same slice and window on both panels, so the red voxels can be checked
+    against the pure image -- they should land where it is black (S0 ~ 0).
     """
     import matplotlib
 
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
-    from matplotlib.colors import ListedColormap
 
-    supp = support[z]
     pre = baseline[z]
-    active = active_mask[z] & supp
-    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 1.0)])
+    supp = support[z]
+    ys, xs = np.where(active_mask[z] & supp)
+    vmax = max(np.percentile(pre[supp], 99) if supp.any() else 1.0, _EPS)
 
-    fig, ax = plt.subplots(figsize=(6.5, 6))
-    hi = np.percentile(pre[supp], 99) if supp.any() else 1.0
-    ax.imshow(pre, cmap="gray", vmin=0, vmax=max(hi, _EPS))
-    ax.contour(supp, levels=[0.5], colors="cyan", linewidths=0.5)
-    ax.contour(skeleton[z], levels=[0.5], colors="yellow", linewidths=0.4)
-    ax.imshow(np.where(active, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
-    ax.set_xticks([])
-    ax.set_yticks([])
-    ax.set_title(
-        f"Floor-active voxels on PRECONTRAST slice z={z} (n={int(active.sum())})\n"
-        f"red = floor-active (S0~0); cyan = support; yellow = skeleton — {case_id[:28]}"
-    )
+    fig, axes = plt.subplots(1, 2, figsize=(13, 6.5))
+    axes[0].imshow(pre, cmap="gray", vmin=0, vmax=vmax)
+    axes[0].scatter(xs, ys, c="red", s=16, marker="s", linewidths=0)
+    axes[0].set_title(f"precontrast + floor-active (red, n={len(xs)})")
+    axes[1].imshow(pre, cmap="gray", vmin=0, vmax=vmax)
+    axes[1].set_title("pure precontrast (same slice)")
+    for ax in axes:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    fig.suptitle(f"z={z} — {case_id[:36]}")
     fig.tight_layout()
     fig.savefig(out_path, dpi=150)
     plt.close(fig)
-    print(f"wrote {out_path}")
+    print(f"wrote {out_path} ({len(xs)} red voxels)")
 
 
 def _precontrast_plot(

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -124,6 +124,32 @@ def main() -> None:
         f"(floor threshold = {args.floor_frac})"
     )
 
+    # Isolate the problematic voxels and confirm the "S0 ~ 0" claim in ABSOLUTE
+    # terms (not just the relative floor trigger): their precontrast S0 should be
+    # a tiny fraction of the healthy in-support S0, while their peak signal max|S|
+    # stays comparable -- dark before contrast, real peak after -> blowup.
+    active_mask = floor_active & support
+    med_support_s0 = float(np.median(baseline[support]))
+    if active_mask.any():
+        s0_active = baseline[active_mask]
+        print(
+            f"floor-active S0 (absolute): median={np.median(s0_active):.2f} "
+            f"p90={np.percentile(s0_active, 90):.2f}  vs in-support median S0="
+            f"{med_support_s0:.2f}  (ratio={np.median(s0_active) / med_support_s0:.3f})"
+        )
+        print(
+            f"floor-active max|S| (absolute): median={np.median(signal_scale[active_mask]):.2f} "
+            f"vs in-support median max|S|={np.median(signal_scale[support]):.2f} "
+            "-> near-0 baseline but real peak (the blowup)"
+        )
+    mask_path_out = args.out_dir / f"floor_active_mask_{args.case_id[:24]}.npy"
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    np.save(mask_path_out, active_mask)
+    print(
+        f"wrote isolated problematic-voxel mask {mask_path_out} "
+        f"({int(active_mask.sum())} voxels)"
+    )
+
     # Center axial slice of the vessel-support z-extent (top-down view).
     z_support = np.where(support.any(axis=(1, 2)))[0]
     z = args.z if args.z is not None else int((z_support.min() + z_support.max()) // 2)
@@ -142,6 +168,55 @@ def main() -> None:
         args.case_id,
         args.out_dir / f"floor_activation_{args.case_id[:24]}_z{z}.png",
     )
+    _isolation_plot(
+        active_mask,
+        support,
+        dce_4d.max(axis=0),
+        args.case_id,
+        args.out_dir / f"floor_active_zproj_{args.case_id[:24]}.png",
+    )
+
+
+def _isolation_plot(
+    active_mask: np.ndarray,
+    support: np.ndarray,
+    mip: np.ndarray,
+    case_id: str,
+    out_path: Path,
+) -> None:
+    """Top-down (max-over-z) projection isolating ALL floor-active voxels.
+
+    Collapses the volume along z so every problematic voxel at any depth shows in
+    one axial view, over the vessel-support footprint and a faint anatomy MIP --
+    reveals whether they cluster at the breast/mask periphery (expected for
+    near-void baselines) or sit inside the vasculature.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import ListedColormap
+
+    active_proj = active_mask.any(axis=0)
+    supp_proj = support.any(axis=0)
+    mip_proj = mip.max(axis=0)
+    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 1.0)])
+
+    fig, ax = plt.subplots(figsize=(6.5, 6))
+    hi = np.percentile(mip_proj[supp_proj], 99) if supp_proj.any() else 1.0
+    ax.imshow(mip_proj, cmap="gray", vmin=0, vmax=max(hi, _EPS))
+    ax.contour(supp_proj, levels=[0.5], colors="cyan", linewidths=0.5)
+    ax.imshow(np.where(active_proj, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title(
+        f"Problematic voxels (S0~0), all depths — {case_id[:32]}\n"
+        f"red = floor-active (n={int(active_mask.sum())}); cyan = vessel support"
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {out_path}")
 
 
 def _plot(

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -175,6 +175,90 @@ def main() -> None:
         args.case_id,
         args.out_dir / f"floor_active_zproj_{args.case_id[:24]}.png",
     )
+    _mechanism_plot(
+        dce_4d,
+        baseline,
+        active_mask,
+        support,
+        baseline_frame_count,
+        z,
+        args.case_id,
+        args.out_dir / f"floor_mechanism_{args.case_id[:24]}_z{z}.png",
+    )
+
+
+def _mechanism_plot(
+    dce_4d: np.ndarray,
+    baseline: np.ndarray,
+    active_mask: np.ndarray,
+    support: np.ndarray,
+    baseline_frame_count: int,
+    z: int,
+    case_id: str,
+    out_path: Path,
+) -> None:
+    """Why S0~0 voxels are still visible: black precontrast, bright postcontrast.
+
+    Overlays the same problematic voxels on the precontrast S0 frame (where they
+    are ~black) and the post-contrast peak frame (where they are bright), then
+    plots the actual per-voxel S(t) curves -- problematic voxels start near 0 and
+    rise to a real peak (numerator real, denominator ~0 -> the ratio explodes),
+    healthy voxels start at a substantial baseline. The exploding quantity is the
+    derived (S-S0)/S0 feature, never the raw signal shown in grayscale.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import ListedColormap
+
+    supp = support[z]
+    pre = baseline[z]
+    post = dce_4d[baseline_frame_count:].max(axis=0)[z]
+    active_z = active_mask[z]
+    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 0.9)])
+
+    fig, axes = plt.subplots(1, 3, figsize=(16, 5))
+    pre_hi = np.percentile(pre[supp], 99) if supp.any() else 1.0
+    post_hi = np.percentile(post[supp], 99) if supp.any() else 1.0
+    axes[0].imshow(pre, cmap="gray", vmin=0, vmax=max(pre_hi, _EPS))
+    axes[0].imshow(np.where(active_z, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
+    axes[0].set_title(f"PRECONTRAST S0 (z={z})\nred voxels are ~black here (S0~0)")
+    axes[1].imshow(post, cmap="gray", vmin=0, vmax=max(post_hi, _EPS))
+    axes[1].imshow(np.where(active_z, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
+    axes[1].set_title("POSTCONTRAST peak\nsame voxels are bright (real enhancement)")
+    for ax in axes[:2]:
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+    # S(t) for the most-extreme problematic voxels vs. near-median healthy voxels.
+    t = np.arange(dce_4d.shape[0])
+    coords = np.argwhere(active_mask)
+    s0_active = baseline[active_mask]
+    n = min(6, len(coords))
+    for i in np.argsort(s0_active)[:n]:
+        zz, yy, xx = coords[i]
+        axes[2].plot(t, dce_4d[:, zz, yy, xx], color="red", alpha=0.6, lw=1)
+    healthy = support & ~active_mask
+    hcoords = np.argwhere(healthy)
+    hs0 = baseline[healthy]
+    for i in np.argsort(np.abs(hs0 - np.median(hs0)))[:n]:
+        zz, yy, xx = hcoords[i]
+        axes[2].plot(t, dce_4d[:, zz, yy, xx], color="steelblue", alpha=0.6, lw=1)
+    axes[2].axvspan(-0.5, baseline_frame_count - 0.5, color="gray", alpha=0.15)
+    axes[2].axhline(0, color="k", lw=0.5)
+    axes[2].plot([], [], color="red", label="problematic (S0~0)")
+    axes[2].plot([], [], color="steelblue", label="healthy")
+    axes[2].axvspan(0, 0, color="gray", alpha=0.15, label="precontrast frames")
+    axes[2].legend(fontsize=8)
+    axes[2].set_xlabel("DCE frame (t)")
+    axes[2].set_ylabel("raw signal S(t)")
+    axes[2].set_title("both enhance; only the starting baseline differs")
+    fig.suptitle(f"Why S0~0 voxels are still visible — {case_id[:32]}")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {out_path}")
 
 
 def _isolation_plot(

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -166,14 +166,22 @@ def main() -> None:
         z,
         args.floor_frac,
         args.case_id,
+        "max-over-time",
         args.out_dir / f"floor_activation_{args.case_id[:24]}_z{z}.png",
     )
-    _isolation_plot(
-        active_mask,
+    # Single-panel overlay on the PRECONTRAST slice: red floor-active voxels on
+    # the raw precontrast image (where they sit on the dark near-void regions).
+    # Uses the slice carrying the most floor-active voxels so they're visible.
+    z_best = int((active_mask & support).sum(axis=(1, 2)).argmax())
+    _precontrast_overlay_plot(
+        baseline,
         support,
-        dce_4d.max(axis=0),
+        active_mask,
+        skeleton,
+        z_best,
         args.case_id,
-        args.out_dir / f"floor_active_zproj_{args.case_id[:24]}.png",
+        args.out_dir
+        / f"floor_active_precontrast_overlay_{args.case_id[:24]}_z{z_best}.png",
     )
     _mechanism_plot(
         dce_4d,
@@ -193,6 +201,50 @@ def main() -> None:
         args.case_id,
         args.out_dir / f"precontrast_{args.case_id[:24]}_z{z}.png",
     )
+
+
+def _precontrast_overlay_plot(
+    baseline: np.ndarray,
+    support: np.ndarray,
+    active_mask: np.ndarray,
+    skeleton: np.ndarray,
+    z: int,
+    case_id: str,
+    out_path: Path,
+) -> None:
+    """Single panel: floor-active voxels (red) on the raw PRECONTRAST slice.
+
+    Background is the precontrast baseline image (not max-over-time), so the red
+    problematic voxels visibly land on the dark near-void regions. Cyan = vessel
+    support outline, yellow = skeleton.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import ListedColormap
+
+    supp = support[z]
+    pre = baseline[z]
+    active = active_mask[z] & supp
+    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 1.0)])
+
+    fig, ax = plt.subplots(figsize=(6.5, 6))
+    hi = np.percentile(pre[supp], 99) if supp.any() else 1.0
+    ax.imshow(pre, cmap="gray", vmin=0, vmax=max(hi, _EPS))
+    ax.contour(supp, levels=[0.5], colors="cyan", linewidths=0.5)
+    ax.contour(skeleton[z], levels=[0.5], colors="yellow", linewidths=0.4)
+    ax.imshow(np.where(active, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title(
+        f"Floor-active voxels on PRECONTRAST slice z={z} (n={int(active.sum())})\n"
+        f"red = floor-active (S0~0); cyan = support; yellow = skeleton — {case_id[:28]}"
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {out_path}")
 
 
 def _precontrast_plot(
@@ -369,16 +421,22 @@ def _isolation_plot(
 def _plot(
     baseline: np.ndarray,
     signal_scale: np.ndarray,
-    mip: np.ndarray,
+    anatomy: np.ndarray,
     support: np.ndarray,
     skeleton: np.ndarray,
     floor_active: np.ndarray,
     z: int,
     frac: float,
     case_id: str,
+    anatomy_label: str,
     out_path: Path,
 ) -> None:
-    """Three-panel top-down slice: baseline S0, baseline/scale ratio, anatomy+red overlay."""
+    """Three-panel top-down slice: baseline S0, baseline/scale ratio, anatomy+red overlay.
+
+    ``anatomy`` is the grayscale background for the overlay panel -- pass the
+    precontrast baseline to see the floor-active voxels land on the dark regions,
+    or the max-over-time image to see them on the enhancing anatomy.
+    """
     import matplotlib
 
     matplotlib.use("Agg")
@@ -387,14 +445,14 @@ def _plot(
 
     supp = support[z]
     b = baseline[z]
-    mip_z = mip[z]
+    anat_z = anatomy[z]
     active = floor_active[z] & supp
     ratio = np.full_like(b, np.nan)
     np.divide(b, signal_scale[z], out=ratio, where=signal_scale[z] > _EPS)
 
     # Windows from the in-support distribution (one shared window per panel).
     b_hi = np.percentile(b[supp], 99) if supp.any() else 1.0
-    mip_hi = np.percentile(mip_z[supp], 99) if supp.any() else 1.0
+    anat_hi = np.percentile(anat_z[supp], 99) if supp.any() else 1.0
     red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 0.85)])
 
     fig, axes = plt.subplots(1, 3, figsize=(15, 5.4))
@@ -407,12 +465,12 @@ def _plot(
     axes[1].set_title(f"baseline / max|S|  (red contour < {frac})")
     fig.colorbar(im, ax=axes[1], fraction=0.046, pad=0.04)
 
-    axes[2].imshow(mip_z, cmap="gray", vmin=0, vmax=max(mip_hi, _EPS))
+    axes[2].imshow(anat_z, cmap="gray", vmin=0, vmax=max(anat_hi, _EPS))
     axes[2].imshow(np.where(active, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
     axes[2].contour(skeleton[z], levels=[0.5], colors="yellow", linewidths=0.4)
     n_active = int(active.sum())
     axes[2].set_title(
-        f"max-over-time + floor-active (red, n={n_active})\nyellow = skeleton"
+        f"{anatomy_label} + floor-active (red, n={n_active})\nyellow = skeleton"
     )
 
     for ax in axes:

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -1,0 +1,207 @@
+"""Verify the kinetic baseline floor: WHERE (and why) does it activate?
+
+For one case, replicates the exact per-voxel denominator logic of
+``gnn.kinetics.baseline_relative_curve`` (relative enhancement mode):
+
+    baseline      = mean of the first ``baseline_frame_count`` DCE frames
+    signal_scale  = max_t |S(t)|
+    floor active  <=>  baseline_floor_frac * signal_scale > baseline
+
+A voxel is "floor active" exactly when its precontrast baseline is a smaller
+fraction of its own peak signal than ``baseline_floor_frac`` -- i.e. the
+near-void-baseline voxels whose (S - S0)/S0 would otherwise explode. This maps
+those voxels on the top-down center axial slice so we can see whether they sit
+where the anatomy is genuinely near-void (mask edges / low-signal regions),
+verifying the floor targets artifacts rather than real tissue.
+
+Loads one case's raw 4D DCE -- run via Slurm, not the head node.
+
+Usage:
+    python -m analysis.floor_activation_map --case-id <id> \
+        --centerline-root .../preprocessing_out_v5/centerlines \
+        --dce-root .../preprocessing_out_v5/dce \
+        --floor-frac 0.05 --out-dir experiments/floor_activation_check
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from gnn.data_loader import (
+    _CENTERLINE_SUFFIX,
+    _SUPPORT_PATTERN,
+    _load_study_metadata,
+)
+from gnn.raw_dce import (
+    discover_raw_dce_paths,
+    load_raw_dce_series,
+)
+
+_EPS = float(np.finfo(np.float32).eps)
+
+
+def _resolve_case(centerline_root: Path, case_id: str) -> tuple[Path, Path]:
+    """Find the skeleton mask + support mask for one case under the tree."""
+    matches = sorted(centerline_root.rglob(f"{case_id}{_CENTERLINE_SUFFIX}"))
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one skeleton for {case_id}, found {len(matches)}"
+        )
+    mask_path = matches[0]
+    support_path = mask_path.parent / _SUPPORT_PATTERN.format(case_id=case_id)
+    if not support_path.exists():
+        raise FileNotFoundError(f"support mask not found: {support_path}")
+    return mask_path, support_path
+
+
+def main() -> None:
+    """Compute the floor-activation mask for one case and render the overlay."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--case-id", type=str, required=True)
+    parser.add_argument("--centerline-root", type=Path, required=True)
+    parser.add_argument("--dce-root", type=Path, required=True)
+    parser.add_argument("--floor-frac", type=float, default=0.05)
+    parser.add_argument(
+        "--z",
+        type=int,
+        default=None,
+        help="axial slice; default = center of the vessel-support z-extent",
+    )
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    mask_path, support_path = _resolve_case(args.centerline_root, args.case_id)
+    study_dir = mask_path.parent
+    skeleton = np.load(mask_path).astype(bool)
+    support = np.load(support_path).astype(bool)
+
+    timepoints, baseline_frame_count, relative_enhancement = _load_study_metadata(
+        args.case_id, study_dir
+    )
+    if not relative_enhancement:
+        raise ValueError(
+            f"case={args.case_id}: relative_enhancement is False (absolute "
+            "convention) -- the floor never applies here, nothing to verify."
+        )
+    dce_paths = discover_raw_dce_paths(args.dce_root, args.case_id, timepoints)
+    dce_4d = load_raw_dce_series(dce_paths, expected_shape_zyx=support.shape)
+
+    baseline = dce_4d[:baseline_frame_count].mean(axis=0)
+    signal_scale = np.abs(dce_4d).max(axis=0)
+    floored_denom_term = args.floor_frac * signal_scale
+    # The floor bites exactly where it raises the denominator above the raw
+    # baseline (matches np.maximum(baseline, frac*signal_scale) in kinetics.py).
+    floor_active = (floored_denom_term > baseline) & (signal_scale > _EPS)
+    # Truly dead voxels: even the floored denominator is ~0, so enhancement stays 0.
+    zeroed = ~(np.isfinite(np.maximum(baseline, floored_denom_term))) | (
+        np.maximum(baseline, floored_denom_term) <= _EPS
+    )
+
+    supp_n = int(support.sum())
+    skel_n = int(skeleton.sum())
+    supp_active = int((floor_active & support).sum())
+    skel_active = int((floor_active & skeleton).sum())
+    print(
+        f"case={args.case_id}  baseline_frames={baseline_frame_count}  "
+        f"relative_enhancement={relative_enhancement}"
+    )
+    print(
+        f"support voxels: {supp_n}  floor-active: {supp_active} "
+        f"({100 * supp_active / max(supp_n, 1):.1f}%)"
+    )
+    print(
+        f"skeleton (graph-node) voxels: {skel_n}  floor-active: {skel_active} "
+        f"({100 * skel_active / max(skel_n, 1):.1f}%)"
+    )
+    print(f"dead/zeroed voxels within support: {int((zeroed & support).sum())}")
+    ratio = baseline / np.where(signal_scale > _EPS, signal_scale, np.nan)
+    supp_ratio = ratio[support]
+    print(
+        f"baseline/signal_scale within support: median={np.nanmedian(supp_ratio):.3f} "
+        f"(floor threshold = {args.floor_frac})"
+    )
+
+    # Center axial slice of the vessel-support z-extent (top-down view).
+    z_support = np.where(support.any(axis=(1, 2)))[0]
+    z = args.z if args.z is not None else int((z_support.min() + z_support.max()) // 2)
+    print(f"axial slice z={z} (support z-extent {z_support.min()}..{z_support.max()})")
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    _plot(
+        baseline,
+        signal_scale,
+        dce_4d.max(axis=0),
+        support,
+        skeleton,
+        floor_active,
+        z,
+        args.floor_frac,
+        args.case_id,
+        args.out_dir / f"floor_activation_{args.case_id[:24]}_z{z}.png",
+    )
+
+
+def _plot(
+    baseline: np.ndarray,
+    signal_scale: np.ndarray,
+    mip: np.ndarray,
+    support: np.ndarray,
+    skeleton: np.ndarray,
+    floor_active: np.ndarray,
+    z: int,
+    frac: float,
+    case_id: str,
+    out_path: Path,
+) -> None:
+    """Three-panel top-down slice: baseline S0, baseline/scale ratio, anatomy+red overlay."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import ListedColormap
+
+    supp = support[z]
+    b = baseline[z]
+    mip_z = mip[z]
+    active = floor_active[z] & supp
+    ratio = np.full_like(b, np.nan)
+    np.divide(b, signal_scale[z], out=ratio, where=signal_scale[z] > _EPS)
+
+    # Windows from the in-support distribution (one shared window per panel).
+    b_hi = np.percentile(b[supp], 99) if supp.any() else 1.0
+    mip_hi = np.percentile(mip_z[supp], 99) if supp.any() else 1.0
+    red = ListedColormap([(1, 0, 0, 0), (1, 0, 0, 0.85)])
+
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5.4))
+    axes[0].imshow(b, cmap="gray", vmin=0, vmax=max(b_hi, _EPS))
+    axes[0].contour(supp, levels=[0.5], colors="cyan", linewidths=0.5)
+    axes[0].set_title(f"Precontrast baseline S0 (z={z})\ncyan = vessel support")
+
+    im = axes[1].imshow(np.where(supp, ratio, np.nan), cmap="viridis", vmin=0, vmax=0.3)
+    axes[1].contour((ratio < frac) & supp, levels=[0.5], colors="red", linewidths=0.6)
+    axes[1].set_title(f"baseline / max|S|  (red contour < {frac})")
+    fig.colorbar(im, ax=axes[1], fraction=0.046, pad=0.04)
+
+    axes[2].imshow(mip_z, cmap="gray", vmin=0, vmax=max(mip_hi, _EPS))
+    axes[2].imshow(np.where(active, 1.0, np.nan), cmap=red, vmin=0, vmax=1)
+    axes[2].contour(skeleton[z], levels=[0.5], colors="yellow", linewidths=0.4)
+    n_active = int(active.sum())
+    axes[2].set_title(
+        f"max-over-time + floor-active (red, n={n_active})\nyellow = skeleton"
+    )
+
+    for ax in axes:
+        ax.set_xticks([])
+        ax.set_yticks([])
+    fig.suptitle(f"Floor activation — {case_id[:40]}", fontsize=11)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/floor_activation_map.py
+++ b/analysis/floor_activation_map.py
@@ -185,6 +185,69 @@ def main() -> None:
         args.case_id,
         args.out_dir / f"floor_mechanism_{args.case_id[:24]}_z{z}.png",
     )
+    _precontrast_plot(
+        baseline,
+        support,
+        active_mask,
+        z,
+        args.case_id,
+        args.out_dir / f"precontrast_{args.case_id[:24]}_z{z}.png",
+    )
+
+
+def _precontrast_plot(
+    baseline: np.ndarray,
+    support: np.ndarray,
+    active_mask: np.ndarray,
+    z: int,
+    case_id: str,
+    out_path: Path,
+) -> None:
+    """Show that most precontrast voxels are NOT ~0.
+
+    Left: the raw precontrast S0 image (mean of the precontrast frames) at the
+    center slice -- normal grayscale anatomy, not a black frame. Right: the
+    in-support S0 distribution, with the floor-active voxels overlaid: the bulk
+    of vessel voxels sit at a healthy baseline, and only a small tail is near 0.
+    """
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    b = baseline[z]
+    supp_s0 = baseline[support]
+    active_s0 = baseline[active_mask]
+    med = float(np.median(supp_s0))
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5.2))
+    hi = np.percentile(b[b > 0], 99) if (b > 0).any() else 1.0
+    im = axes[0].imshow(b, cmap="gray", vmin=0, vmax=max(hi, _EPS))
+    axes[0].set_xticks([])
+    axes[0].set_yticks([])
+    axes[0].set_title(
+        f"Raw precontrast S0 (z={z})\nin-support median S0={med:.1f} (not 0)"
+    )
+    fig.colorbar(im, ax=axes[0], fraction=0.046, pad=0.04)
+
+    axes[1].hist(
+        supp_s0, bins=80, color="steelblue", alpha=0.8, label="all vessel voxels"
+    )
+    if active_s0.size:
+        axes[1].hist(
+            active_s0, bins=80, color="red", alpha=0.9, label="floor-active (S0~0)"
+        )
+    axes[1].axvline(med, color="k", ls="--", lw=1, label=f"median {med:.1f}")
+    axes[1].set_yscale("log")
+    axes[1].set_xlabel("precontrast S0")
+    axes[1].set_ylabel("voxel count (log)")
+    axes[1].set_title("Vessel-voxel S0 distribution\nhealthy bulk + a tiny near-0 tail")
+    axes[1].legend(fontsize=8)
+    fig.suptitle(f"Are all precontrast voxels 0? No — {case_id[:32]}")
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {out_path}")
 
 
 def _mechanism_plot(

--- a/analysis/floor_cohort_summary.py
+++ b/analysis/floor_cohort_summary.py
@@ -1,0 +1,182 @@
+"""Cohort-level view of the kinetic baseline floor, across every case.
+
+Reads the ``summary.csv`` that ``analysis.floor_activation_map`` writes (one row
+per case) and renders the two questions the per-case figures cannot answer:
+
+    how many voxels does the floor touch in a typical image?
+    would a max over the precontrast frames replace the floor entirely?
+
+Writes ``cohort_affected_voxel_histogram.png`` and
+``cohort_operator_comparison.png`` beside the summary.
+
+Reads a CSV only -- light enough for the head node.
+
+Usage:
+    python -m analysis.floor_cohort_summary --summary-csv <out-dir>/summary.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+_BINS = 40
+_MEAN_COLOR = "steelblue"
+_MAX_COLOR = "tab:orange"
+
+
+def _hist_zero_separated(
+    ax: plt.Axes,
+    series: list[np.ndarray],
+    colors: list[str],
+    labels: list[str | None],
+) -> None:
+    """Histogram that keeps "zero affected voxels" as its own bar.
+
+    A case with no affected voxels is a categorically different outcome from one
+    with a few, so it gets a standalone bar separated by a gap and a divider,
+    never a shared first bin. The binned range starts at the smallest nonzero
+    value; overlaid series split the zero slot side by side.
+    """
+    nonzero = [v[v > 0] for v in series]
+    pooled = np.concatenate(nonzero)
+    edges = np.linspace(pooled.min(), pooled.max(), _BINS + 1)
+    width = edges[1] - edges[0]
+    zero_center = edges[0] - 2 * width
+    sub = width / len(series)
+
+    for i, (v, color, label) in enumerate(zip(series, colors, labels)):
+        alpha = 0.75 if len(series) > 1 else 1.0
+        ax.hist(v[v > 0], bins=edges, color=color, alpha=alpha, label=label)
+        n_zero = int((v == 0).sum())
+        left = zero_center - width / 2 + i * sub
+        ax.bar(left + sub / 2, n_zero, width=sub, color=color, alpha=alpha)
+        ax.annotate(
+            str(n_zero),
+            (left + sub / 2, n_zero),
+            textcoords="offset points",
+            xytext=(0, 3),
+            ha="center",
+            fontsize=8,
+        )
+    ax.axvline(edges[0] - width, color="gray", lw=0.8, ls=":")
+    ticks = matplotlib.ticker.MaxNLocator(nbins=6).tick_values(edges[0], edges[-1])
+    ticks = [t for t in ticks if edges[0] <= t <= edges[-1]]
+    ax.set_xticks([zero_center, *ticks])
+    ax.set_xticklabels(["0", *(f"{t:g}" for t in ticks)])
+    ax.set_xlim(zero_center - 1.5 * width, edges[-1] + width)
+
+
+def main() -> None:
+    """Render both cohort figures from a per-case summary CSV."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summary-csv", type=Path, required=True)
+    args = parser.parse_args()
+    render(args.summary_csv)
+
+
+def render(summary_csv: Path) -> None:
+    """Write the cohort histogram and the mean-vs-max operator comparison."""
+    summary = pd.read_csv(summary_csv)
+    out_dir = summary_csv.parent
+    _affected_histogram(summary, out_dir / "cohort_affected_voxel_histogram.png")
+    _operator_comparison(summary, out_dir / "cohort_operator_comparison.png")
+
+
+def _affected_histogram(summary: pd.DataFrame, out_path: Path) -> None:
+    """How many vessel voxels the floor touches per image, over the cohort.
+
+    One case is one observation, so the two panels integrate to the cohort size.
+    The absolute count sets the scale of the intervention; the percentage panel
+    is what says whether the floor stays a tail correction in every image or
+    swallows a meaningful share of the vasculature in some of them.
+    """
+    counts = summary["support_floor_active"].to_numpy()
+    pcts = summary["support_floor_active_pct"].to_numpy()
+    n_cases = len(summary)
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+    _hist_zero_separated(axes[0], [counts], [_MEAN_COLOR], [None])
+    axes[0].set_xlabel("floor-affected vessel-support voxels in the image")
+    axes[0].set_ylabel("number of cases")
+    axes[0].set_title(
+        f"median {np.median(counts):.0f}, "
+        f"p90 {np.percentile(counts, 90):.0f}, max {counts.max():.0f}"
+    )
+    _hist_zero_separated(axes[1], [pcts], [_MEAN_COLOR], [None])
+    axes[1].set_xlabel("floor-affected voxels (% of vessel support)")
+    axes[1].set_ylabel("number of cases")
+    axes[1].set_title(
+        f"median {np.median(pcts):.2f}%, "
+        f"p90 {np.percentile(pcts, 90):.2f}%, max {pcts.max():.2f}%"
+    )
+    fig.suptitle(
+        f"How much of each image does the baseline floor touch? — {n_cases} cases"
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(f"wrote {out_path}")
+
+
+def _operator_comparison(summary: pd.DataFrame, out_path: Path) -> None:
+    """Mean vs max precontrast baseline: does max remove the need for the floor?
+
+    Left: the same per-case affected-voxel distribution under both baseline
+    operators. Right: the paired per-case counts -- every point below the
+    identity line is a case where switching the operator alone shrinks the
+    problem, and points on the x axis are cases max fixes outright.
+    """
+    mean_counts = summary["support_floor_active"].to_numpy()
+    max_counts = summary["support_floor_active_maxop"].to_numpy()
+    n_cases = len(summary)
+    n_solved = int((max_counts == 0).sum())
+    total_mean = int(mean_counts.sum())
+    total_max = int(max_counts.sum())
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+    _hist_zero_separated(
+        axes[0],
+        [mean_counts, max_counts],
+        [_MEAN_COLOR, _MAX_COLOR],
+        ["mean baseline (current)", "max baseline"],
+    )
+    axes[0].set_xlabel("floor-affected vessel-support voxels in the image")
+    axes[0].set_ylabel("number of cases")
+    axes[0].set_title(
+        f"cohort total {total_mean} -> {total_max} voxels "
+        f"({100 * (total_mean - total_max) / max(total_mean, 1):.0f}% rescued)"
+    )
+    axes[0].legend(fontsize=8)
+
+    lim = max(mean_counts.max(), max_counts.max(), 1) * 1.1
+    axes[1].plot([0, lim], [0, lim], color="gray", lw=0.8, ls="--", label="no change")
+    axes[1].scatter(mean_counts, max_counts, s=14, color=_MEAN_COLOR, linewidths=0)
+    axes[1].set_xlim(-0.02 * lim, lim)
+    axes[1].set_ylim(-0.02 * lim, lim)
+    axes[1].set_xlabel("affected voxels — mean baseline (current)")
+    axes[1].set_ylabel("affected voxels — max baseline")
+    axes[1].set_title(f"{n_solved} / {n_cases} cases need no floor at all under max")
+    axes[1].legend(fontsize=8)
+
+    fig.suptitle(
+        f"Could a max over the precontrast frames replace the floor? — {n_cases} cases"
+    )
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+    print(
+        f"wrote {out_path} (cohort affected voxels {total_mean} mean -> "
+        f"{total_max} max; {n_solved}/{n_cases} cases fully resolved by max)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_all_models_gate.py
+++ b/analysis/gnn_all_models_gate.py
@@ -1,0 +1,168 @@
+"""All-models summary: every UChicago pCR model on one pooled-OOF AUC + CI plot.
+
+Puts the tabular baselines and every GNN arm (2-feature and 7-feature voxel
+baseline, tier0/tier1 hygiene ladder, and the segment/junction graph modes) on
+the same footing -- pooled OOF AUC over all 179 cases with a shared-draw
+bootstrap 95% CI -- and renders one grouped forest plot with error bars. Reuses
+the pooled-OOF/CI helpers from analysis.gnn_tabular_gate. Reads only small CSVs.
+
+Usage:
+    python -m analysis.gnn_all_models_gate \
+        --tier-sweep-root /gpfs/.../experiments/gnn_uchicago_tier_sweep_floored \
+        --graph-mode-root /gpfs/.../experiments/gnn_uchicago_graph_mode_floored \
+        --twofeat-root /gpfs/.../experiments/gnn_uchicago_2feat_floored \
+        --graph-qc /ess/.../gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+        --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+        --out-dir experiments/uchicago_all_models
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.gnn_tabular_gate import (
+    _MEANS7,
+    _auc_ci,
+    _boot_index_matrix,
+    _gnn_pooled_oof,
+    _oof_logreg,
+    _oof_xgb,
+    _seed_mean_oof,
+)
+
+
+def main() -> None:
+    """Score every model, print the AUC-CI table, render the grouped forest plot."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tier-sweep-root", type=Path, required=True)
+    parser.add_argument("--graph-mode-root", type=Path, required=True)
+    parser.add_argument("--twofeat-root", type=Path, required=True)
+    parser.add_argument("--graph-qc", type=Path, required=True)
+    parser.add_argument("--tabular-features", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    feats = pd.read_csv(args.tabular_features)
+    case_order = feats["case_id"].tolist()
+    y = feats["pcr"].to_numpy()
+    folds = feats["fold"].to_numpy()
+    feat_cols = [
+        c for c in feats.columns if c not in ("case_id", "pcr", "dataset", "fold")
+    ]
+    x_full = feats[feat_cols].to_numpy()
+    qc = pd.read_csv(args.graph_qc).set_index("case_id").loc[case_order]
+    x_means7 = qc[_MEANS7].to_numpy()
+
+    boot = _boot_index_matrix(len(y))
+
+    # (label, group, oof-probability vector). GNN arms read saved OOF predictions;
+    # tabular arms are fit here from the summary features.
+    gnn_specs = [
+        ("GNN voxel 2feat", args.twofeat_root, "voxel2feat"),
+        ("GNN voxel 7feat (baseline)", args.tier_sweep_root, "baseline"),
+        ("GNN voxel tier0", args.tier_sweep_root, "tier0"),
+        ("GNN voxel tier1", args.tier_sweep_root, "tier1"),
+        ("GNN segment", args.graph_mode_root, "segment"),
+        ("GNN junction", args.graph_mode_root, "junction"),
+    ]
+    models: list[tuple[str, str, np.ndarray]] = []
+    for label, root, arm in gnn_specs:
+        models.append((label, "GNN", _gnn_pooled_oof(root, arm, case_order)))
+    models.append(
+        (
+            "tabular 7-means logreg",
+            "tabular",
+            _seed_mean_oof(_oof_logreg, x_means7, y, folds),
+        )
+    )
+    models.append(
+        (
+            "tabular 38-feat logreg",
+            "tabular",
+            _seed_mean_oof(_oof_logreg, x_full, y, folds),
+        )
+    )
+    models.append(
+        (
+            "tabular 38-feat xgboost",
+            "tabular",
+            _seed_mean_oof(_oof_xgb, x_full, y, folds),
+        )
+    )
+
+    rows = []
+    for label, group, prob in models:
+        point, lo, hi = _auc_ci(y, prob, boot)
+        rows.append(
+            {
+                "model": label,
+                "group": group,
+                "pooled_oof_auc": point,
+                "ci_lo": lo,
+                "ci_hi": hi,
+            }
+        )
+    table = pd.DataFrame(rows).sort_values("pooled_oof_auc", ascending=False)
+
+    print("=== Pooled OOF AUC (all 179 cases) with bootstrap 95% CI ===")
+    for _, r in table.iterrows():
+        print(
+            f"  {r['model']:30s} [{r['group']:7s}] {r['pooled_oof_auc']:.3f}  "
+            f"[{r['ci_lo']:.3f}, {r['ci_hi']:.3f}]"
+        )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    table.to_csv(args.out_dir / "all_models_auc_ci.csv", index=False)
+    _forest_plot(table, args.out_dir / "all_models_forest.png")
+    print(f"\nWrote {args.out_dir}/all_models_auc_ci.csv, all_models_forest.png")
+
+
+def _forest_plot(table: pd.DataFrame, out_path: Path) -> None:
+    """Grouped forest plot of every model's pooled-OOF AUC with its 95% CI."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    colors = {"GNN": "#1f77b4", "tabular": "#7f7f7f"}
+    t = table.iloc[::-1].reset_index(drop=True)  # highest AUC at top
+    ys = np.arange(len(t))
+    fig, ax = plt.subplots(figsize=(8, 0.5 * len(t) + 1.5))
+    for group, color in colors.items():
+        mask = (t["group"] == group).to_numpy()
+        if not mask.any():
+            continue
+        sub, ysub = t[mask], ys[mask]
+        ax.errorbar(
+            sub["pooled_oof_auc"],
+            ysub,
+            xerr=[
+                sub["pooled_oof_auc"] - sub["ci_lo"],
+                sub["ci_hi"] - sub["pooled_oof_auc"],
+            ],
+            fmt="o",
+            color=color,
+            ecolor=color,
+            elinewidth=2,
+            capsize=4,
+            markersize=6,
+            zorder=3,
+            label=group,
+        )
+    ax.axvline(0.5, color="k", ls=":", lw=1, label="chance")
+    ax.set_yticks(ys)
+    ax.set_yticklabels(t["model"])
+    ax.set_xlabel("Pooled OOF AUC (95% bootstrap CI), N=179")
+    ax.set_title("UChicago pCR — all models (floored)")
+    ax.legend(loc="lower right", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_clean_feature_importance.py
+++ b/analysis/gnn_clean_feature_importance.py
@@ -1,0 +1,104 @@
+"""Which of the conditioned (floored) kinetic features carry the pCR signal?
+
+Reads a cache's graph_qc.csv (per-case feature summaries) + the labels file's
+predefined folds and reports, on the SAME pooled 179 cases the GNN sees:
+  1. Univariate held-out AUC for each of the 7 node features (per-case mean),
+     using predefined-fold CV -- ranks individual feature signal.
+  2. A tabular reference: logistic regression on the 7 per-case means under the
+     same folds -- how close does a plain graph-summary model get to the GNN's
+     ~0.61? (If it matches, the graph structure isn't adding much.)
+  3. Permutation importance of that tabular model -- multivariate ranking.
+
+Pooled over all cases (UChicago sub-families are one institution, not cohorts).
+Reads small CSVs only; head-node safe.
+
+Usage:
+    python -m analysis.gnn_clean_feature_importance \
+        --graph-qc .../gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+        --labels .../uchicago_labels_folded.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.inspection import permutation_importance
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+FEATURES = [
+    "peak_time",
+    "peak_enhancement",
+    "time_to_enhancement",
+    "washin_slope",
+    "washout_slope",
+    "auc_positive",
+    "radius",
+]
+_CHANCE = 0.5
+
+
+def _oof_auc_logreg(x: np.ndarray, y: np.ndarray, folds: np.ndarray) -> float:
+    """Predefined-fold OOF AUC for logistic regression on columns of ``x``."""
+    oof = np.zeros(len(y), dtype=float)
+    for f in np.unique(folds):
+        tr, te = folds != f, folds == f
+        model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=1000))
+        model.fit(x[tr], y[tr])
+        oof[te] = model.predict_proba(x[te])[:, 1]
+    return roc_auc_score(y, oof)
+
+
+def main() -> None:
+    """Print univariate, tabular-reference, and permutation-importance tables."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--graph-qc", type=Path, required=True)
+    parser.add_argument("--labels", type=Path, required=True)
+    args = parser.parse_args()
+
+    qc = pd.read_csv(args.graph_qc)
+    labels = pd.read_csv(args.labels)[["case_id", "fold"]]
+    merged = qc.merge(labels, on="case_id", how="inner")
+    y = merged["pcr"].to_numpy()
+    folds = merged["fold"].to_numpy()
+    print(
+        f"{len(merged)} cases, pCR rate {y.mean():.3f}, {len(np.unique(folds))} folds\n"
+    )
+
+    print("=== 1. Univariate OOF AUC per feature (per-case mean, predefined folds) ===")
+    rows = []
+    for feat in FEATURES:
+        col = f"{feat}_mean"
+        auc = _oof_auc_logreg(merged[[col]].to_numpy(), y, folds)
+        # orient so AUC >= 0.5 and report the direction
+        rows.append(
+            (feat, max(auc, 1 - auc), "higher->pCR" if auc >= _CHANCE else "lower->pCR")
+        )
+    for feat, auc, direction in sorted(rows, key=lambda r: -r[1]):
+        print(f"  {feat:20s} AUC={auc:.3f}  ({direction})")
+
+    print("\n=== 2. Tabular reference: logreg on all 7 means (predefined folds) ===")
+    x = merged[[f"{f}_mean" for f in FEATURES]].to_numpy()
+    auc_all = _oof_auc_logreg(x, y, folds)
+    print(f"  OOF AUC = {auc_all:.3f}   (GNN baseline on same cache/folds ~0.61)")
+
+    print("\n=== 3. Permutation importance (logreg, refit on full data) ===")
+    model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=1000)).fit(x, y)
+    imp = permutation_importance(
+        model, x, y, scoring="roc_auc", n_repeats=50, random_state=0
+    )
+    order = np.argsort(-imp.importances_mean)
+    for i in order:
+        print(
+            f"  {FEATURES[i]:20s} Δauc={imp.importances_mean[i]:+.4f} "
+            f"± {imp.importances_std[i]:.4f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_graph_mode_gate.py
+++ b/analysis/gnn_graph_mode_gate.py
@@ -1,0 +1,156 @@
+"""Phase 2.2 gate: does any graph MODE carry pCR signal voxel-mean discards?
+
+Compares the floored UChicago GNN across the three graph representations --
+voxel (one node per skeleton voxel), segment (one node per vessel segment), and
+junction (junction nodes + segment edges) -- on the shared metric: pooled OOF
+AUC over all 179 cases with a case-resampling bootstrap 95% CI. The decisive
+test is a **paired** bootstrap dAUC of each structural mode vs. voxel (the mode
+that is nearly tabular-by-construction): if segment/junction beats voxel by a
+CI-separated margin, the vessel-tree structure carries signal the per-voxel mean
+throws away. The tabular 7-means bar is included for reference.
+
+Mirrors the Duke graph_repr_compare_v1 result (voxel 0.526 / junction 0.511 /
+segment 0.502, all ~chance) -- rerun here on data that, post-flooring, actually
+has signal. Reuses the pooled-OOF/CI/paired-dAUC helpers from
+analysis.gnn_tabular_gate. Reads only small CSVs -- head-node safe.
+
+Usage:
+    python -m analysis.gnn_graph_mode_gate \
+        --voxel-root /gpfs/.../experiments/gnn_uchicago_tier_sweep_floored \
+        --graph-mode-root /gpfs/.../experiments/gnn_uchicago_graph_mode_floored \
+        --graph-qc /ess/.../gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+        --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+        --out-dir experiments/uchicago_graph_mode_floored
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from analysis.gnn_tabular_gate import (
+    _MEANS7,
+    _auc_ci,
+    _boot_index_matrix,
+    _gnn_pooled_oof,
+    _oof_logreg,
+    _paired_delta_ci,
+    _seed_mean_oof,
+)
+
+
+def main() -> None:
+    """Score voxel/segment/junction + tabular bar, print/save table + paired deltas."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voxel-root", type=Path, required=True)
+    parser.add_argument("--voxel-arm", type=str, default="baseline")
+    parser.add_argument("--graph-mode-root", type=Path, required=True)
+    parser.add_argument("--graph-qc", type=Path, required=True)
+    parser.add_argument("--tabular-features", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    feats = pd.read_csv(args.tabular_features)
+    case_order = feats["case_id"].tolist()
+    y = feats["pcr"].to_numpy()
+    folds = feats["fold"].to_numpy()
+    qc = pd.read_csv(args.graph_qc).set_index("case_id").loc[case_order]
+    x_means7 = qc[_MEANS7].to_numpy()
+
+    boot = _boot_index_matrix(len(y))
+
+    contenders: dict[str, np.ndarray] = {
+        "gnn_voxel": _gnn_pooled_oof(args.voxel_root, args.voxel_arm, case_order),
+        "gnn_segment": _gnn_pooled_oof(args.graph_mode_root, "segment", case_order),
+        "gnn_junction": _gnn_pooled_oof(args.graph_mode_root, "junction", case_order),
+        "tabular_7means_logreg": _seed_mean_oof(_oof_logreg, x_means7, y, folds),
+    }
+
+    rows = []
+    for name, prob in contenders.items():
+        point, lo, hi = _auc_ci(y, prob, boot)
+        rows.append({"model": name, "pooled_oof_auc": point, "ci_lo": lo, "ci_hi": hi})
+    table = pd.DataFrame(rows).sort_values("pooled_oof_auc", ascending=False)
+
+    print("=== Pooled OOF AUC (all 179 cases) with bootstrap 95% CI ===")
+    for _, r in table.iterrows():
+        print(
+            f"  {r['model']:26s} {r['pooled_oof_auc']:.3f}  "
+            f"[{r['ci_lo']:.3f}, {r['ci_hi']:.3f}]"
+        )
+
+    # Paired dAUC of each structural mode vs. voxel (the near-tabular baseline).
+    print("\n=== Paired dAUC vs. voxel (structure test) ===")
+    deltas = []
+    for mode in ("gnn_segment", "gnn_junction"):
+        d = _paired_delta_ci(y, contenders[mode], contenders["gnn_voxel"], boot)
+        gate = d["ci_lo"] > 0.0
+        deltas.append({"comparison": f"{mode}_minus_voxel", **d, "gate_passed": gate})
+        print(
+            f"  {mode:14s} - voxel: dAUC={d['delta_auc']:+.3f} "
+            f"[{d['ci_lo']:+.3f}, {d['ci_hi']:+.3f}] P[>0]={d['frac_positive']:.2f} "
+            f"-> {'BEATS voxel' if gate else 'no CI-separated gain'}"
+        )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    table.to_csv(args.out_dir / "graph_mode_auc_ci.csv", index=False)
+    pd.DataFrame(deltas).to_csv(
+        args.out_dir / "graph_mode_paired_delta.csv", index=False
+    )
+    _forest_plot(table, args.out_dir / "graph_mode_forest.png")
+    print(
+        f"\nWrote {args.out_dir}/graph_mode_auc_ci.csv, graph_mode_paired_delta.csv, "
+        "graph_mode_forest.png"
+    )
+
+
+def _forest_plot(table: pd.DataFrame, out_path: Path) -> None:
+    """Forest plot of each mode's pooled-OOF AUC with its 95% CI."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    t = table.iloc[::-1].reset_index(drop=True)
+    fig, ax = plt.subplots(figsize=(7, 0.6 * len(t) + 1.2))
+    ys = np.arange(len(t))
+    is_gnn = t["model"].str.startswith("gnn_").to_numpy()
+    for mask, color, label in (
+        (is_gnn, "#1f77b4", "GNN"),
+        (~is_gnn, "#7f7f7f", "tabular"),
+    ):
+        if not mask.any():
+            continue
+        sub, ysub = t[mask], ys[mask]
+        ax.errorbar(
+            sub["pooled_oof_auc"],
+            ysub,
+            xerr=[
+                sub["pooled_oof_auc"] - sub["ci_lo"],
+                sub["ci_hi"] - sub["pooled_oof_auc"],
+            ],
+            fmt="o",
+            color=color,
+            ecolor=color,
+            elinewidth=2,
+            capsize=4,
+            markersize=6,
+            zorder=3,
+            label=label,
+        )
+    ax.axvline(0.5, color="k", ls=":", lw=1, label="chance")
+    ax.set_yticks(ys)
+    ax.set_yticklabels(t["model"])
+    ax.set_xlabel("Pooled OOF AUC (95% bootstrap CI)")
+    ax.set_title("UChicago pCR: graph-mode comparison (floored, N=179)")
+    ax.legend(loc="lower right", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_tabular_gate.py
+++ b/analysis/gnn_tabular_gate.py
@@ -1,0 +1,300 @@
+"""Phase 1 gate: does the vessel-GNN beat a tabular bar by a CI-separated margin?
+
+Puts every contender on one footing -- **pooled OOF AUC over all 179 UChicago
+cases** (the plan's metric convention) with a **case-resampling bootstrap 95%
+CI** (Phase 0.3) -- and then runs the actual gate test: a **paired** bootstrap of
+the AUC *difference* between the GNN and the strongest tabular model, resampling
+the same cases jointly so the two share sampling noise. Overlapping marginal CIs
+would be an over-conservative proxy; the paired dAUC CI is the correct read of
+"beats by a CI-separated margin."
+
+Contenders:
+  - GNN baseline / tier1: per-case OOF ``y_prob`` from each seed's
+    ``predictions.csv`` in the floored tier sweep, averaged across seeds.
+  - Tabular 7-means: logistic regression on the 7 per-case node-feature means
+    (reproduces the ~0.614 documented bar), predefined-fold OOF.
+  - Tabular 38-feat: logistic regression + XGBoost on the full vessel-summary
+    set (mean/std/q10/q50/q90 + counts) from tabular.gnn_feature_baseline.
+
+Reads only small CSVs (no graph-cache load) -- head-node safe.
+
+Usage:
+    python -m analysis.gnn_tabular_gate \
+        --gnn-sweep-root /gpfs/.../experiments/gnn_uchicago_tier_sweep_floored \
+        --graph-qc /ess/.../gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+        --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+        --out-dir experiments/uchicago_tabular_bar_floored
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from xgboost import XGBClassifier
+
+_SEEDS = (42, 142, 242)
+_GNN_SEED_DIRS = (0, 1, 2, 3, 4)
+_N_BOOTSTRAP = 2000
+_CI_PCT = (2.5, 97.5)
+_MEANS7 = [
+    "peak_time_mean",
+    "peak_enhancement_mean",
+    "time_to_enhancement_mean",
+    "washin_slope_mean",
+    "washout_slope_mean",
+    "auc_positive_mean",
+    "radius_mean",
+]
+
+
+def _oof_logreg(
+    x: np.ndarray, y: np.ndarray, folds: np.ndarray, seed: int
+) -> np.ndarray:
+    """Predefined-fold out-of-fold probabilities for logistic regression."""
+    oof = np.full(len(y), np.nan)
+    for f in np.unique(folds):
+        tr, te = folds != f, folds == f
+        model = make_pipeline(
+            SimpleImputer(strategy="mean"),
+            StandardScaler(),
+            LogisticRegression(max_iter=1000, random_state=seed),
+        )
+        model.fit(x[tr], y[tr])
+        oof[te] = model.predict_proba(x[te])[:, 1]
+    return oof
+
+
+def _oof_xgb(x: np.ndarray, y: np.ndarray, folds: np.ndarray, seed: int) -> np.ndarray:
+    """Predefined-fold out-of-fold probabilities for XGBoost."""
+    oof = np.full(len(y), np.nan)
+    for f in np.unique(folds):
+        tr, te = folds != f, folds == f
+        model = make_pipeline(
+            SimpleImputer(strategy="mean"),
+            XGBClassifier(
+                n_estimators=100, max_depth=3, random_state=seed, eval_metric="logloss"
+            ),
+        )
+        model.fit(x[tr], y[tr])
+        oof[te] = model.predict_proba(x[te])[:, 1]
+    return oof
+
+
+def _seed_mean_oof(
+    oof_fn: Callable[[np.ndarray, np.ndarray, np.ndarray, int], np.ndarray],
+    x: np.ndarray,
+    y: np.ndarray,
+    folds: np.ndarray,
+) -> np.ndarray:
+    """Average a model's OOF probabilities across seeds to damp init noise."""
+    return np.mean([oof_fn(x, y, folds, s) for s in _SEEDS], axis=0)
+
+
+def _gnn_pooled_oof(sweep_root: Path, arm: str, case_order: list[str]) -> np.ndarray:
+    """Per-case OOF prob for a GNN arm, averaged over the 5 seed runs.
+
+    Each seed dir holds one ``predictions.csv`` with one held-out row per case
+    (predefined folds). Averaging the per-case ``y_prob`` across seeds mirrors the
+    tabular seed-averaging so the two are compared on the same construction.
+    """
+    per_seed = []
+    for s in _GNN_SEED_DIRS:
+        matches = sorted(sweep_root.glob(f"{arm}_seed{s}/**/predictions.csv"))
+        if len(matches) != 1:
+            raise ValueError(
+                f"expected exactly one predictions.csv for {arm}_seed{s}, "
+                f"found {len(matches)}: {matches}"
+            )
+        preds = pd.read_csv(matches[0]).set_index("case_id")
+        per_seed.append(preds.loc[case_order, "y_prob"].to_numpy())
+    return np.mean(per_seed, axis=0)
+
+
+def _boot_index_matrix(n: int, seed: int = 0) -> np.ndarray:
+    """One shared set of case-resampling draws so every CI uses the same resamples."""
+    rng = np.random.default_rng(seed)
+    return rng.integers(0, n, size=(_N_BOOTSTRAP, n))
+
+
+def _auc_ci(
+    y: np.ndarray, prob: np.ndarray, boot: np.ndarray
+) -> tuple[float, float, float]:
+    """Point AUC on full data + percentile bootstrap CI over the shared draws."""
+    point = float(roc_auc_score(y, prob))
+    aucs = np.array([roc_auc_score(y[idx], prob[idx]) for idx in boot])
+    lo, hi = np.percentile(aucs, _CI_PCT)
+    return point, float(lo), float(hi)
+
+
+def _paired_delta_ci(
+    y: np.ndarray, prob_a: np.ndarray, prob_b: np.ndarray, boot: np.ndarray
+) -> dict[str, float]:
+    """Paired bootstrap of AUC(a) - AUC(b): same resample scores both models.
+
+    ``prob_gt_zero`` is the bootstrap fraction with a positive delta -- a one-sided
+    "how often does A win" read; the gate is cleared only if the CI excludes 0.
+    """
+    point = float(roc_auc_score(y, prob_a) - roc_auc_score(y, prob_b))
+    deltas = np.array(
+        [roc_auc_score(y[i], prob_a[i]) - roc_auc_score(y[i], prob_b[i]) for i in boot]
+    )
+    lo, hi = np.percentile(deltas, _CI_PCT)
+    return {
+        "delta_auc": point,
+        "ci_lo": float(lo),
+        "ci_hi": float(hi),
+        "frac_positive": float(np.mean(deltas > 0)),
+    }
+
+
+def main() -> None:
+    """Score every contender, print/save the AUC-CI table + paired gate + plot."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gnn-sweep-root", type=Path, required=True)
+    parser.add_argument("--graph-qc", type=Path, required=True)
+    parser.add_argument("--tabular-features", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--arms", type=str, default="baseline,tier1")
+    args = parser.parse_args()
+
+    feats = pd.read_csv(args.tabular_features)
+    case_order = feats["case_id"].tolist()
+    y = feats["pcr"].to_numpy()
+    folds = feats["fold"].to_numpy()
+    feat_cols = [
+        c for c in feats.columns if c not in ("case_id", "pcr", "dataset", "fold")
+    ]
+
+    qc = pd.read_csv(args.graph_qc).set_index("case_id").loc[case_order]
+    x_means7 = qc[_MEANS7].to_numpy()
+    x_full = feats[feat_cols].to_numpy()
+
+    boot = _boot_index_matrix(len(y))
+
+    contenders: dict[str, np.ndarray] = {}
+    for arm in args.arms.split(","):
+        contenders[f"gnn_{arm}"] = _gnn_pooled_oof(args.gnn_sweep_root, arm, case_order)
+    contenders["tabular_7means_logreg"] = _seed_mean_oof(
+        _oof_logreg, x_means7, y, folds
+    )
+    contenders["tabular_38feat_logreg"] = _seed_mean_oof(_oof_logreg, x_full, y, folds)
+    contenders["tabular_38feat_xgboost"] = _seed_mean_oof(_oof_xgb, x_full, y, folds)
+
+    rows = []
+    for name, prob in contenders.items():
+        point, lo, hi = _auc_ci(y, prob, boot)
+        rows.append({"model": name, "pooled_oof_auc": point, "ci_lo": lo, "ci_hi": hi})
+    table = pd.DataFrame(rows).sort_values("pooled_oof_auc", ascending=False)
+
+    print("=== Pooled OOF AUC (all 179 cases) with bootstrap 95% CI ===")
+    for _, r in table.iterrows():
+        print(
+            f"  {r['model']:26s} {r['pooled_oof_auc']:.3f}  [{r['ci_lo']:.3f}, {r['ci_hi']:.3f}]"
+        )
+
+    # Gate: strongest GNN arm vs strongest tabular model, paired.
+    gnn_names = [n for n in contenders if n.startswith("gnn_")]
+    tab_names = [n for n in contenders if n.startswith("tabular_")]
+    best_gnn = max(gnn_names, key=lambda n: roc_auc_score(y, contenders[n]))
+    best_tab = max(tab_names, key=lambda n: roc_auc_score(y, contenders[n]))
+    delta = _paired_delta_ci(y, contenders[best_gnn], contenders[best_tab], boot)
+
+    print()
+    print(f"=== GATE: paired dAUC ({best_gnn} - {best_tab}) ===")
+    print(
+        f"  dAUC = {delta['delta_auc']:+.3f}  95% CI [{delta['ci_lo']:+.3f}, {delta['ci_hi']:+.3f}]"
+        f"  (P[dAUC>0] = {delta['frac_positive']:.2f})"
+    )
+    gate_pass = delta["ci_lo"] > 0.0
+    print(
+        f"  GATE {'PASSED' if gate_pass else 'NOT PASSED'}: "
+        f"CI {'excludes' if gate_pass else 'includes'} 0."
+    )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    table.to_csv(args.out_dir / "gate_auc_ci.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "best_gnn": best_gnn,
+                "best_tabular": best_tab,
+                **delta,
+                "gate_passed": gate_pass,
+            }
+        ]
+    ).to_csv(args.out_dir / "gate_paired_delta.csv", index=False)
+
+    _forest_plot(table, delta, best_gnn, best_tab, args.out_dir / "gate_forest.png")
+    print(
+        f"\nWrote {args.out_dir}/gate_auc_ci.csv, gate_paired_delta.csv, gate_forest.png"
+    )
+
+
+def _forest_plot(
+    table: pd.DataFrame,
+    delta: dict[str, float],
+    best_gnn: str,
+    best_tab: str,
+    out_path: Path,
+) -> None:
+    """Forest plot of each model's pooled-OOF AUC with its 95% CI."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    t = table.iloc[::-1].reset_index(drop=True)  # highest AUC at top
+    fig, ax = plt.subplots(figsize=(7, 0.6 * len(t) + 1.2))
+    ys = np.arange(len(t))
+    is_gnn = t["model"].str.startswith("gnn_").to_numpy()
+    # errorbar's ecolor takes one color, so plot the GNN and tabular rows as two
+    # calls (blue vs grey) rather than a per-row color array.
+    for mask, color, label in (
+        (is_gnn, "#1f77b4", "GNN"),
+        (~is_gnn, "#7f7f7f", "tabular"),
+    ):
+        if not mask.any():
+            continue
+        sub, ysub = t[mask], ys[mask]
+        ax.errorbar(
+            sub["pooled_oof_auc"],
+            ysub,
+            xerr=[
+                sub["pooled_oof_auc"] - sub["ci_lo"],
+                sub["ci_hi"] - sub["pooled_oof_auc"],
+            ],
+            fmt="o",
+            color=color,
+            ecolor=color,
+            elinewidth=2,
+            capsize=4,
+            markersize=6,
+            zorder=3,
+            label=label,
+        )
+    ax.axvline(0.5, color="k", ls=":", lw=1, label="chance")
+    ax.set_yticks(ys)
+    ax.set_yticklabels(t["model"])
+    ax.set_xlabel("Pooled OOF AUC (95% bootstrap CI)")
+    ax.set_title(
+        f"UChicago pCR: GNN vs tabular bar (N=179)\n"
+        f"gate dAUC({best_gnn.replace('gnn_','')} - {best_tab.replace('tabular_','')}) "
+        f"= {delta['delta_auc']:+.3f} [{delta['ci_lo']:+.3f}, {delta['ci_hi']:+.3f}]"
+    )
+    ax.legend(loc="lower right", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_tier0_gate_g0.py
+++ b/analysis/gnn_tier0_gate_g0.py
@@ -1,0 +1,110 @@
+"""Gate G0 analysis for the GNN Tier-0 sweep (gnn/PLAN_advanced_modeling.md).
+
+Reads each run's predictions.csv from the baseline-vs-tier0 sweep and reports:
+  - OOF AUC per run + mean/std per arm,
+  - paired ΔAUC (tier0 − baseline) by seed×fold (shared folds per seed),
+  - per-arm fold-only AUC spread (stability),
+  - per-dataset OOF AUC.
+
+Summarizes an already-computed sweep (no training) -- hence analysis/, not
+tabular/. Point --out-root at the sweep's output tree; default is the gpfs
+location submit_gnn_tier0_sweep.slurm writes to.
+
+Usage:
+    python -m analysis.gnn_tier0_gate_g0 [--out-root <dir>]
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+DEFAULT_OUT_ROOT = (
+    "/gpfs/data/karczmar-lab/workspaces/spencervenancio/" "experiments/gnn_tier0_sweep"
+)
+ARMS = ("baseline", "tier0")
+SEEDS = range(5)
+_BOTH_CLASSES = 2  # both labels present -> AUC defined
+
+
+def _auc(df: pd.DataFrame) -> float:
+    """OOF AUC, NaN if a (sub)set has only one class present."""
+    if df["y_true"].nunique() < _BOTH_CLASSES:
+        return float("nan")
+    return roc_auc_score(df["y_true"], df["y_prob"])
+
+
+def load_predictions(out_root: str) -> dict[tuple[str, int], pd.DataFrame]:
+    """One predictions.csv per (arm, seed); exactly one match required."""
+    frames: dict[tuple[str, int], pd.DataFrame] = {}
+    for arm in ARMS:
+        for seed in SEEDS:
+            matches = sorted(
+                Path(out_root).glob(f"{arm}_seed{seed}/*/*/predictions.csv")
+            )
+            if len(matches) != 1:
+                raise RuntimeError(f"{arm}_seed{seed}: expected 1 file, got {matches}")
+            frames[(arm, seed)] = pd.read_csv(matches[0])
+    return frames
+
+
+def main() -> None:
+    """Print the Gate G0 tables for the sweep under --out-root."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-root", default=DEFAULT_OUT_ROOT, type=Path)
+    args = parser.parse_args()
+    frames = load_predictions(str(args.out_root))
+
+    per_fold = pd.DataFrame(
+        [
+            {"arm": arm, "seed": seed, "fold": int(fold), "auc": _auc(fdf)}
+            for (arm, seed), df in frames.items()
+            for fold, fdf in df.groupby("fold")
+        ]
+    )
+    oof = pd.DataFrame(
+        [
+            {"arm": arm, "seed": seed, "oof_auc": _auc(df)}
+            for (arm, seed), df in frames.items()
+        ]
+    )
+
+    print("=== OOF AUC per run ===")
+    print(oof.pivot_table(index="seed", columns="arm", values="oof_auc").round(4))
+    print("\n=== OOF AUC mean±std across seeds ===")
+    for arm in ARMS:
+        v = oof[oof.arm == arm]["oof_auc"]
+        print(f"  {arm:9s}: {v.mean():.4f} ± {v.std(ddof=1):.4f}")
+
+    b = per_fold[per_fold.arm == "baseline"].set_index(["seed", "fold"])["auc"]
+    t = per_fold[per_fold.arm == "tier0"].set_index(["seed", "fold"])["auc"]
+    delta = (t - b).dropna()
+    tstat = delta.mean() / (delta.std(ddof=1) / np.sqrt(len(delta)))
+    print(f"\n=== Paired ΔAUC (tier0 − baseline) by seed×fold, n={len(delta)} ===")
+    print(
+        f"  mean {delta.mean():+.4f}  median {delta.median():+.4f}  "
+        f"std {delta.std(ddof=1):.4f}"
+    )
+    print(
+        f"  frac>0 {(delta > 0).mean():.2f} ({(delta > 0).sum()}/{len(delta)})  "
+        f"paired t {tstat:+.3f}"
+    )
+
+    print("\n=== per-arm fold-only AUC spread ===")
+    for arm in ARMS:
+        a = per_fold[per_fold.arm == arm]["auc"]
+        print(f"  {arm:9s}: mean {a.mean():.4f}, std {a.std(ddof=1):.4f}")
+
+    print("\n=== Per-dataset OOF AUC (pooled across seeds) ===")
+    for arm in ARMS:
+        pooled = pd.concat([frames[(arm, s)] for s in SEEDS])
+        cells = [f"{ds}={_auc(g):.3f}" for ds, g in pooled.groupby("dataset")]
+        print(f"  {arm:9s}  " + "  ".join(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_tier1_readout_gate_g1.py
+++ b/analysis/gnn_tier1_readout_gate_g1.py
@@ -1,0 +1,97 @@
+"""Gate G1 analysis: Tier-1 mean_max readout vs Tier-0 mean pool.
+
+Pairs the Tier-1 sweep (gnn_pooling="mean_max") seed-for-seed against the
+already-computed Tier-0 (mean-pool) runs -- same cache, folds, and training
+knobs, only the readout differs -- and reports OOF AUC per arm, paired ΔAUC by
+seed×fold, and per-dataset OOF AUC. See gnn/PLAN_advanced_modeling.md Gate G1.
+
+Usage:
+    python -m analysis.gnn_tier1_readout_gate_g1 [--tier0-root D] [--tier1-root D]
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+_WS = "/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments"
+DEFAULT_T0 = f"{_WS}/gnn_tier0_sweep"
+DEFAULT_T1 = f"{_WS}/gnn_tier1_sweep"
+SEEDS = range(5)
+_BOTH_CLASSES = 2
+XGBOOST_TABULAR_REF = 0.540  # Gate G0 tabular baseline to clear
+
+
+def _auc(df: pd.DataFrame) -> float:
+    """OOF AUC, NaN if only one class is present."""
+    if df["y_true"].nunique() < _BOTH_CLASSES:
+        return float("nan")
+    return roc_auc_score(df["y_true"], df["y_prob"])
+
+
+def _load(root: str, tag: str) -> pd.DataFrame:
+    """The single predictions.csv for one run tag."""
+    matches = sorted(Path(root).glob(f"{tag}/*/*/predictions.csv"))
+    if len(matches) != 1:
+        raise RuntimeError(f"{tag}: expected 1 file, got {matches}")
+    return pd.read_csv(matches[0])
+
+
+def main() -> None:
+    """Print the Gate G1 tables."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tier0-root", default=DEFAULT_T0)
+    parser.add_argument("--tier1-root", default=DEFAULT_T1)
+    args = parser.parse_args()
+
+    frames: dict[tuple[str, int], pd.DataFrame] = {}
+    for s in SEEDS:
+        frames[("tier0", s)] = _load(args.tier0_root, f"tier0_seed{s}")
+        frames[("tier1", s)] = _load(args.tier1_root, f"tier1_seed{s}")
+
+    oof = pd.DataFrame(
+        [{"arm": a, "seed": s, "oof": _auc(df)} for (a, s), df in frames.items()]
+    )
+    piv = oof.pivot_table(index="seed", columns="arm", values="oof")
+    print("=== OOF AUC per run ===")
+    print(piv.round(4))
+    print("\n=== OOF AUC mean±std ===")
+    for a in ("tier0", "tier1"):
+        v = oof[oof.arm == a]["oof"]
+        print(f"  {a}: {v.mean():.4f} ± {v.std(ddof=1):.4f}")
+    print(f"  tier1 > tier0 on {(piv['tier1'] > piv['tier0']).sum()}/5 seeds")
+    print(
+        f"  tier1 vs XGBoost tabular ref {XGBOOST_TABULAR_REF}: "
+        f"{'clears' if oof[oof.arm=='tier1']['oof'].mean() > XGBOOST_TABULAR_REF else 'below'}"
+    )
+
+    rows = [
+        {"arm": a, "seed": s, "fold": int(fold), "auc": _auc(fdf)}
+        for (a, s), df in frames.items()
+        for fold, fdf in df.groupby("fold")
+    ]
+    pf = pd.DataFrame(rows)
+    b = pf[pf.arm == "tier0"].set_index(["seed", "fold"])["auc"]
+    t = pf[pf.arm == "tier1"].set_index(["seed", "fold"])["auc"]
+    d = (t - b).dropna()
+    tstat = d.mean() / (d.std(ddof=1) / np.sqrt(len(d)))
+    print(f"\n=== Paired ΔAUC (tier1 − tier0) by seed×fold, n={len(d)} ===")
+    print(f"  mean {d.mean():+.4f}  median {d.median():+.4f}  std {d.std(ddof=1):.4f}")
+    print(
+        f"  frac>0 {(d > 0).mean():.2f} ({(d > 0).sum()}/{len(d)})  "
+        f"paired t {tstat:+.3f}"
+    )
+
+    print("\n=== Per-dataset OOF AUC (pooled across seeds) ===")
+    for a in ("tier0", "tier1"):
+        pooled = pd.concat([frames[(a, s)] for s in SEEDS])
+        cells = [f"{ds}={_auc(g):.3f}" for ds, g in pooled.groupby("dataset")]
+        print(f"  {a}: " + "  ".join(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/gnn_tier_sweep_plot.py
+++ b/analysis/gnn_tier_sweep_plot.py
@@ -1,0 +1,454 @@
+"""Meta-level diagnostic plots for the GNN tier sweep (many runs -> one result).
+
+Reads every ``predictions.csv`` under an out-root laid out as
+``{arm}_seed{0..4}/*/*/predictions.csv`` (the layout
+``submit_gnn_uchicago_tier_sweep.slurm`` writes) and renders a single
+diagnostic figure that answers the questions you actually ask of a sweep:
+
+  A. AUC by arm, mean +/- std across seeds (the "error-bar plot") vs chance /
+     tabular references.
+  B. AUC by fold -- is the variance seed-driven or fold-driven?
+  C. AUC by sub-source -- where (if anywhere) is the signal?
+  D. Score separation -- do predicted probabilities separate the classes at all,
+     or are they collapsed? (The "is there any signal" panel.)
+  E. Paired dAUC by seed x fold -- the Gate G0 / G1 deltas, as distributions.
+  F. Prediction vs graph size -- is the model keying on vessel-graph size rather
+     than biology? Needs the cache's graph_qc.csv (--graph-qc).
+
+Summarizes an already-computed sweep (no training) -- hence analysis/. Reads
+small CSVs only; safe on the head node.
+
+Usage:
+    python -m analysis.gnn_tier_sweep_plot \
+        --out-root /gpfs/.../experiments/gnn_uchicago_tier_sweep \
+        --graph-qc /ess/scratch/.../gnn_cache_voxel_richfeat/processed/graph_qc.csv \
+        --out analysis/figures/gnn_uchicago_tier_sweep_diagnostics.png
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from sklearn.metrics import roc_auc_score
+
+ARMS = ("baseline", "tier0", "tier1")
+SEEDS = range(5)
+_BOTH_CLASSES = 2
+
+# Okabe-Ito (colorblind-safe), assigned in fixed arm order. Baseline is neutral
+# gray to read as the reference; tier0/tier1 are the two intervention hues.
+ARM_COLOR = {"baseline": "#999999", "tier0": "#0072B2", "tier1": "#D55E00"}
+CHANCE = 0.5
+TABULAR_REF = 0.540  # XGBoost tabular baseline (PLAN_advanced_modeling.md)
+
+
+def _sub(df: pd.DataFrame, col: str, val: object) -> pd.DataFrame:
+    """Rows where ``df[col] == val`` (avoids DataFrame.query's @-scope gotcha)."""
+    return df[df[col] == val]
+
+
+def _mstd(vals: object) -> tuple[float, float]:
+    """(mean, std) ignoring NaN, or (nan, nan) when every value is NaN.
+
+    All-NaN happens e.g. for a single-class sub-source whose AUC is undefined;
+    handled explicitly to avoid a numpy empty-slice warning.
+    """
+    a = np.asarray(vals, dtype=float)
+    if np.all(np.isnan(a)):
+        return float("nan"), float("nan")
+    return float(np.nanmean(a)), float(np.nanstd(a))
+
+
+def _auc(df: pd.DataFrame) -> float:
+    """OOF AUC; NaN when a (sub)set has only one class present."""
+    if df["y_true"].nunique() < _BOTH_CLASSES:
+        return float("nan")
+    return roc_auc_score(df["y_true"], df["y_prob"])
+
+
+def load_predictions(out_root: Path) -> dict[tuple[str, int], pd.DataFrame]:
+    """One predictions.csv per (arm, seed); exactly one match required."""
+    frames: dict[tuple[str, int], pd.DataFrame] = {}
+    for arm in ARMS:
+        for seed in SEEDS:
+            matches = sorted(out_root.glob(f"{arm}_seed{seed}/*/*/predictions.csv"))
+            if len(matches) != 1:
+                raise RuntimeError(f"{arm}_seed{seed}: expected 1 file, got {matches}")
+            frames[(arm, seed)] = pd.read_csv(matches[0])
+    return frames
+
+
+def _style(ax: plt.Axes) -> None:
+    ax.grid(True, axis="y", color="0.9", linewidth=0.8, zorder=0)
+    ax.set_axisbelow(True)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+
+
+def _refs(ax: plt.Axes, tabular: bool = True) -> None:
+    ax.axhline(CHANCE, color="0.4", ls="--", lw=1, zorder=1)
+    ax.text(
+        0.995,
+        CHANCE,
+        " chance",
+        va="bottom",
+        ha="right",
+        color="0.4",
+        fontsize=8,
+        transform=ax.get_yaxis_transform(),
+    )
+    if tabular:
+        ax.axhline(TABULAR_REF, color="0.6", ls=":", lw=1, zorder=1)
+        ax.text(
+            0.995,
+            TABULAR_REF,
+            " tabular 0.54",
+            va="bottom",
+            ha="right",
+            color="0.6",
+            fontsize=8,
+            transform=ax.get_yaxis_transform(),
+        )
+
+
+def panel_auc_by_arm(ax: plt.Axes, frames: dict) -> None:
+    """A. OOF AUC per arm: mean +/- std across seeds, seeds overlaid."""
+    for x, arm in enumerate(ARMS):
+        vals = np.array([_auc(frames[(arm, s)]) for s in SEEDS])
+        m, sd = _mstd(vals)
+        ax.errorbar(
+            x,
+            m,
+            yerr=sd,
+            fmt="o",
+            color=ARM_COLOR[arm],
+            ms=10,
+            capsize=5,
+            lw=2,
+            zorder=3,
+        )
+        ax.scatter(
+            np.full_like(vals, x) + 0.14,
+            vals,
+            s=22,
+            color=ARM_COLOR[arm],
+            alpha=0.55,
+            zorder=2,
+        )
+        ax.text(
+            x,
+            m + sd + 0.006,
+            f"{m:.3f}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+            color=ARM_COLOR[arm],
+            fontweight="bold",
+        )
+    ax.set_xticks(range(len(ARMS)))
+    ax.set_xticklabels(ARMS)
+    ax.set_ylabel("OOF AUC")
+    ax.set_title("A. AUC by arm (mean ± std over 5 seeds)", fontsize=10)
+    ax.set_xlim(-0.5, len(ARMS) - 0.3)
+    _refs(ax)
+    _style(ax)
+
+
+def panel_auc_by_fold(ax: plt.Axes, frames: dict) -> None:
+    """B. AUC by fold, grouped by arm -- exposes fold-driven variance."""
+    folds = sorted(next(iter(frames.values()))["fold"].unique())
+    width = 0.25
+    for ai, arm in enumerate(ARMS):
+        means, sds = [], []
+        for f in folds:
+            vals = [_auc(_sub(frames[(arm, s)], "fold", f)) for s in SEEDS]
+            m, sd = _mstd(vals)
+            means.append(m)
+            sds.append(sd)
+        xs = np.arange(len(folds)) + (ai - 1) * width
+        ax.bar(
+            xs,
+            means,
+            width,
+            yerr=sds,
+            color=ARM_COLOR[arm],
+            label=arm,
+            capsize=3,
+            zorder=2,
+            ecolor="0.3",
+        )
+    ax.set_xticks(range(len(folds)))
+    ax.set_xticklabels([f"fold {f}" for f in folds])
+    ax.set_ylabel("AUC (mean ± std over seeds)")
+    ax.set_title(
+        "B. AUC by fold — variance is fold-driven, not arm-driven", fontsize=10
+    )
+    ax.axhline(CHANCE, color="0.4", ls="--", lw=1, zorder=1)
+    ax.legend(frameon=False, fontsize=8, ncol=3, loc="upper center")
+    ax.set_ylim(0, 0.9)
+    _style(ax)
+
+
+def panel_auc_by_subsource(ax: plt.Axes, frames: dict) -> None:
+    """C. Per-sub-source AUC, grouped by arm."""
+    subs = sorted(next(iter(frames.values()))["dataset"].unique())
+    width = 0.25
+    notes = []
+    for ai, arm in enumerate(ARMS):
+        means, sds = [], []
+        for sub in subs:
+            vals = [_auc(_sub(frames[(arm, s)], "dataset", sub)) for s in SEEDS]
+            m, sd = _mstd(vals)
+            means.append(m)
+            sds.append(sd)
+        xs = np.arange(len(subs)) + (ai - 1) * width
+        ax.bar(
+            xs,
+            np.nan_to_num(means),
+            width,
+            yerr=sds,
+            color=ARM_COLOR[arm],
+            label=arm,
+            capsize=3,
+            zorder=2,
+            ecolor="0.3",
+        )
+    # annotate any single-class (undefined-AUC) sub-source
+    ref = next(iter(frames.values()))
+    for xi, sub in enumerate(subs):
+        d = _sub(ref, "dataset", sub)
+        if d["y_true"].nunique() < _BOTH_CLASSES:
+            ax.text(
+                xi,
+                0.02,
+                f"{sub}\n(single-class,\nAUC undefined)",
+                ha="center",
+                va="bottom",
+                fontsize=7.5,
+                color="#B22222",
+            )
+            notes.append(sub)
+    ax.set_xticks(range(len(subs)))
+    ax.set_xticklabels(subs, fontsize=8)
+    ax.set_ylabel("AUC (mean ± std over seeds)")
+    ax.set_title("C. AUC by sub-source", fontsize=10)
+    ax.axhline(CHANCE, color="0.4", ls="--", lw=1, zorder=1)
+    ax.legend(frameon=False, fontsize=8, ncol=3, loc="upper center")
+    ax.set_ylim(0, 0.9)
+    _style(ax)
+
+
+def panel_score_separation(ax: plt.Axes, frames: dict, arm: str = "tier1") -> None:
+    """D. Pooled predicted-probability distributions by true class."""
+    pooled = pd.concat([frames[(arm, s)] for s in SEEDS])
+    bins = np.linspace(0, 1, 26)
+    for cls, color, lab in ((0, "#0072B2", "no pCR"), (1, "#D55E00", "pCR")):
+        v = pooled.loc[pooled["y_true"] == cls, "y_prob"]
+        ax.hist(v, bins=bins, density=True, color=color, alpha=0.5, label=lab, zorder=2)
+        ax.axvline(v.mean(), color=color, ls="-", lw=2, zorder=3)
+    ax.set_xlabel("predicted P(pCR)")
+    ax.set_ylabel("density")
+    ax.set_title(
+        f"D. Score separation ({arm}, pooled) — overlap = no signal", fontsize=10
+    )
+    ax.legend(frameon=False, fontsize=8)
+    _style(ax)
+    ax.grid(True, axis="both", color="0.92", lw=0.7, zorder=0)
+
+
+def panel_paired_delta(ax: plt.Axes, frames: dict) -> None:
+    """E. Paired dAUC by seed x fold for the two gate comparisons."""
+    folds = sorted(next(iter(frames.values()))["fold"].unique())
+    comps = [
+        ("tier0", "baseline", "G0:\ntier0−baseline"),
+        ("tier1", "tier0", "G1:\ntier1−tier0"),
+    ]
+    for xi, (a, b, _lab) in enumerate(comps):
+        deltas = []
+        for s in SEEDS:
+            for f in folds:
+                da = _auc(_sub(frames[(a, s)], "fold", f))
+                db = _auc(_sub(frames[(b, s)], "fold", f))
+                if not (np.isnan(da) or np.isnan(db)):
+                    deltas.append(da - db)
+        deltas = np.array(deltas)
+        jitter = xi + (np.random.default_rng(0).random(len(deltas)) - 0.5) * 0.25
+        colors = np.where(deltas >= 0, "#0072B2", "#D55E00")
+        ax.scatter(jitter, deltas, c=colors, s=26, alpha=0.7, zorder=2)
+        m = deltas.mean()
+        ax.hlines(m, xi - 0.2, xi + 0.2, color="black", lw=2.5, zorder=3)
+        ax.text(
+            xi,
+            ax.get_ylim()[1],
+            f"mean {m:+.3f}\n{(deltas>0).mean()*100:.0f}% > 0",
+            ha="center",
+            va="top",
+            fontsize=8,
+        )
+    ax.axhline(0, color="0.4", ls="--", lw=1, zorder=1)
+    ax.set_xticks(range(len(comps)))
+    ax.set_xticklabels([c[2] for c in comps], fontsize=8)
+    ax.set_ylabel("ΔAUC (per seed×fold)")
+    ax.set_title("E. Paired ΔAUC — the gate deltas", fontsize=10)
+    _style(ax)
+
+
+def panel_pred_vs_size(
+    ax: plt.Axes, frames: dict, qc: pd.DataFrame, arm: str = "tier1"
+) -> None:
+    """F. Predicted prob vs graph size -- is the model reading size?"""
+    pooled = (
+        pd.concat([frames[(arm, s)] for s in SEEDS])
+        .groupby("case_id", as_index=False)
+        .agg(y_prob=("y_prob", "mean"), y_true=("y_true", "first"))
+    )
+    merged = pooled.merge(qc[["case_id", "num_nodes"]], on="case_id", how="inner")
+    for cls, color, lab in ((0, "#0072B2", "no pCR"), (1, "#D55E00", "pCR")):
+        m = merged[merged["y_true"] == cls]
+        ax.scatter(
+            m["num_nodes"],
+            m["y_prob"],
+            s=22,
+            color=color,
+            alpha=0.6,
+            label=lab,
+            zorder=2,
+        )
+    r_ps = np.corrcoef(merged["num_nodes"], merged["y_prob"])[0, 1]
+    r_pt = np.corrcoef(qc["num_nodes"], qc["pcr"])[0, 1]
+    ax.set_xlabel("graph size (num_nodes)")
+    ax.set_ylabel(f"mean predicted P(pCR) ({arm})")
+    ax.set_title(
+        f"F. Prediction vs graph size — "
+        f"corr(pred,size)={r_ps:+.2f}, corr(pcr,size)={r_pt:+.2f}",
+        fontsize=10,
+    )
+    ax.legend(frameon=False, fontsize=8)
+    _style(ax)
+    ax.grid(True, axis="both", color="0.92", lw=0.7, zorder=0)
+
+
+def panel_before_after(
+    ax: plt.Axes, frames: dict, compare: dict, this_label: str, compare_label: str
+) -> None:
+    """Pooled OOF AUC by arm for two sweeps (e.g. unfloored vs floored)."""
+    width = 0.38
+    for gi, (fr, lab, color) in enumerate(
+        ((compare, compare_label, "#E69F00"), (frames, this_label, "#0072B2"))
+    ):
+        means, sds = [], []
+        for arm in ARMS:
+            vals = np.array([_auc(fr[(arm, s)]) for s in SEEDS])
+            m, sd = _mstd(vals)
+            means.append(m)
+            sds.append(sd)
+        xs = np.arange(len(ARMS)) + (gi - 0.5) * width
+        ax.bar(
+            xs,
+            means,
+            width,
+            yerr=sds,
+            color=color,
+            label=lab,
+            capsize=3,
+            ecolor="0.3",
+            zorder=2,
+        )
+        for x, m in zip(xs, means):
+            ax.text(
+                x,
+                m + 0.008,
+                f"{m:.2f}",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color=color,
+            )
+    ax.set_xticks(range(len(ARMS)))
+    ax.set_xticklabels(ARMS)
+    ax.set_ylabel("pooled OOF AUC (mean ± std)")
+    ax.set_title(
+        "C. Feature conditioning: before vs after (pooled, all cases)", fontsize=10
+    )
+    ax.axhline(CHANCE, color="0.4", ls="--", lw=1, zorder=1)
+    ax.legend(frameon=False, fontsize=8, loc="upper center", ncol=2)
+    ax.set_ylim(0, 0.75)
+    _style(ax)
+
+
+def main() -> None:
+    """Render the 6-panel tier-sweep diagnostic figure from --out-root."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-root", type=Path, required=True)
+    parser.add_argument(
+        "--graph-qc",
+        type=Path,
+        default=None,
+        help="cache processed/graph_qc.csv for panel F (num_nodes)",
+    )
+    parser.add_argument(
+        "--compare-root",
+        type=Path,
+        default=None,
+        help="a second sweep to overlay in panel C as a before/after "
+        "(e.g. the unfloored sweep); replaces the per-sub-source panel",
+    )
+    parser.add_argument("--this-label", type=str, default="this")
+    parser.add_argument("--compare-label", type=str, default="compare")
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("analysis/figures/gnn_tier_sweep_diagnostics.png"),
+    )
+    args = parser.parse_args()
+
+    frames = load_predictions(args.out_root)
+    qc = pd.read_csv(args.graph_qc) if args.graph_qc else None
+    compare = load_predictions(args.compare_root) if args.compare_root else None
+
+    fig, axes = plt.subplots(2, 3, figsize=(17, 10))
+    panel_auc_by_arm(axes[0, 0], frames)
+    panel_auc_by_fold(axes[0, 1], frames)
+    if compare is not None:
+        panel_before_after(
+            axes[0, 2], frames, compare, args.this_label, args.compare_label
+        )
+    else:
+        panel_auc_by_subsource(axes[0, 2], frames)
+    panel_score_separation(axes[1, 0], frames)
+    panel_paired_delta(axes[1, 1], frames)
+    if qc is not None:
+        panel_pred_vs_size(axes[1, 2], frames, qc)
+    else:
+        axes[1, 2].axis("off")
+        axes[1, 2].text(
+            0.5,
+            0.5,
+            "panel F needs --graph-qc",
+            ha="center",
+            va="center",
+            fontsize=9,
+            color="0.5",
+        )
+
+    fig.suptitle(
+        f"GNN tier sweep diagnostics — {args.out_root.name} "
+        f"(3 arms × 5 seeds, 7-feature voxel, predefined folds)",
+        fontsize=12,
+        fontweight="bold",
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.out, dpi=130)
+    print(f"wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/graph_relational_gate.py
+++ b/analysis/graph_relational_gate.py
@@ -1,0 +1,213 @@
+"""Stage 2 gate: does the vessel GRAPH carry pCR signal the per-node means discard?
+
+The cheapest decisive test of the graph question. Every gate so far compared a GNN
+against a tabular model on per-case node-feature *means* and found them equal
+(``experiments/uchicago_tabular_bar_floored``, ``..._graph_mode_floored``) -- but
+both sides were built from node-intrinsic scalars, so neither could use topology.
+Rather than building a better architecture first, this computes the missing
+*relational* quantities explicitly (``gnn.relational_features``: transit slope,
+arrival monotonicity, sibling asymmetry, radius tapering) and tests them with a
+plain logistic regression.
+
+Why that is the right first move at N=179: these scalars are joint properties of
+(kinetics, tree position), so they are **not computable from per-case means**. If a
+7-feature logreg on them clears the bar, the graph carries signal -- proven with a
+model too simple to be winning on capacity, and no GNN required to find out. If it
+does not, no architecture will save it, and that answer costs one CPU job instead
+of another sweep.
+
+Bars it is measured against, all pooled OOF AUC over the same 179 cases and the
+same predefined folds:
+
+- ``tabular_7means`` -- the published 0.613 bar.
+- ``tabular_7means_protocol_residualized`` -- 0.539, the physiology-only bar after
+  acquisition protocol is regressed out (``experiments/uchicago_protocol_confound``).
+  **This is the gate's reference**, since the raw 0.613 is substantially protocol.
+- ``protocol_only`` -- 0.593, reachable with no imaging at all. Any arm that fails
+  to beat this is not doing imaging-based prediction.
+
+Also checks the claim that motivates these features -- that being expressed in
+differences of seconds over millimetres makes them protocol-invariant -- by
+correlating each against the acquisition descriptors and by residualizing them the
+same way. If they turn out protocol-coupled too, that is reported, not buried.
+
+Reads the built voxel cache (no DCE reload, no rebuild) plus small CSVs.
+
+Usage:
+    python -m analysis.graph_relational_gate \
+        --cache-dir /ess/.../gnn_cache_voxel_richfeat_floored \
+        --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+        --dce-root /ess/.../preprocessing_out_v5/dce \
+        --out-dir experiments/uchicago_graph_relational
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import roc_auc_score
+
+from analysis.protocol_confound_check import (
+    _MEANS7,
+    _PROTOCOL,
+    bootstrap_auc_ci,
+    bootstrap_paired_delta,
+    load_protocol,
+    oof_predictions,
+    residualize_on_protocol,
+)
+from gnn.relational_features import (
+    RELATIONAL_FEATURE_COLUMNS,
+    case_relational_features,
+)
+
+_GRAPH_SUFFIX = "_graph.pt"
+
+
+def extract_relational_features(cache_dir: Path) -> pd.DataFrame:
+    """One row of relational features per cached graph, keyed by ``case_id``."""
+    paths = sorted((cache_dir / "processed").glob(f"*{_GRAPH_SUFFIX}"))
+    if not paths:
+        raise FileNotFoundError(f"No {_GRAPH_SUFFIX} files under {cache_dir}/processed")
+    rows = []
+    for path in paths:
+        cached = torch.load(path)
+        data = cached[0] if isinstance(cached, tuple | list) else cached
+        rows.append({"case_id": str(data.case_id), **case_relational_features(data)})
+    return pd.DataFrame(rows)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Command-line interface for the Stage 2 relational-feature gate."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument("--tabular-features", type=Path, required=True)
+    parser.add_argument("--dce-root", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser
+
+
+def main() -> None:
+    """Extract relational features, score every arm, and write the gate outputs."""
+    args = build_parser().parse_args()
+    rng = np.random.default_rng(args.seed)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    relational = extract_relational_features(args.cache_dir)
+    relational.to_csv(args.out_dir / "relational_features.csv", index=False)
+    print(f"extracted relational features for {len(relational)} cases")
+    print(relational[list(RELATIONAL_FEATURE_COLUMNS)].describe().round(4).to_string())
+
+    tabular = pd.read_csv(args.tabular_features)
+    data = tabular.merge(relational, on="case_id", validate="one_to_one")
+    data = data.merge(
+        load_protocol(args.dce_root, data["case_id"].tolist()), on="case_id"
+    )
+    features = list(RELATIONAL_FEATURE_COLUMNS)
+    # A relational feature is NaN when a case cannot support the measurement at all
+    # (e.g. no bifurcation with two arrival-bearing downstream branches). Logistic
+    # regression cannot consume NaN, and imputing would invent geometry, so a
+    # feature missing for any case is dropped from the gate and reported.
+    missing = {f: int(data[f].isna().sum()) for f in features}
+    dropped = [f for f, n in missing.items() if n > 0]
+    if dropped:
+        print(f"\nDropped feature(s) with missing values: {missing}")
+        features = [f for f in features if f not in dropped]
+    if not features:
+        raise ValueError(
+            "Every relational feature had missing values; nothing to gate."
+        )
+
+    y = data["pcr"].to_numpy()
+    folds = data["fold"].to_numpy()
+
+    # Is the protocol-invariance claim true? Correlate each feature with acquisition.
+    coupling = pd.DataFrame(
+        [
+            {
+                "feature": name,
+                **{
+                    f"abs_corr_{p}": abs(np.corrcoef(data[name], data[p])[0, 1])
+                    for p in _PROTOCOL
+                },
+                "univariate_auc": max(
+                    roc_auc_score(y, data[name]), 1.0 - roc_auc_score(y, data[name])
+                ),
+            }
+            for name in features
+        ]
+    )
+
+    arms = {
+        "relational_graph": oof_predictions(data[features].to_numpy(), y, folds),
+        "relational_graph_protocol_residualized": oof_predictions(
+            residualize_on_protocol(data, tuple(features), folds), y, folds
+        ),
+        "tabular_7means": oof_predictions(data[list(_MEANS7)].to_numpy(), y, folds),
+        "tabular_7means_protocol_residualized": oof_predictions(
+            residualize_on_protocol(data, _MEANS7, folds), y, folds
+        ),
+        "protocol_only": oof_predictions(data[list(_PROTOCOL)].to_numpy(), y, folds),
+        "relational_plus_7means": oof_predictions(
+            data[features + list(_MEANS7)].to_numpy(), y, folds
+        ),
+    }
+    auc_rows = []
+    for name, probs in arms.items():
+        low, high = bootstrap_auc_ci(y, probs, rng)
+        auc_rows.append(
+            {
+                "model": name,
+                "n": len(y),
+                "auc": roc_auc_score(y, probs),
+                "ci_low": low,
+                "ci_high": high,
+            }
+        )
+
+    # The gate, plus the two comparisons needed to interpret it.
+    gate_rows = []
+    for label, arm_a, arm_b in (
+        (
+            "GATE: relational - tabular_7means_protocol_residualized",
+            "relational_graph",
+            "tabular_7means_protocol_residualized",
+        ),
+        ("relational - tabular_7means", "relational_graph", "tabular_7means"),
+        ("relational - protocol_only", "relational_graph", "protocol_only"),
+        (
+            "relational_plus_7means - tabular_7means",
+            "relational_plus_7means",
+            "tabular_7means",
+        ),
+    ):
+        delta, low, high = bootstrap_paired_delta(y, arms[arm_a], arms[arm_b], rng)
+        gate_rows.append(
+            {
+                "comparison": label,
+                "mean_delta": delta,
+                "ci_low": low,
+                "ci_high": high,
+                "ci_excludes_zero": bool(low > 0.0 or high < 0.0),
+            }
+        )
+
+    coupling.to_csv(args.out_dir / "feature_protocol_coupling.csv", index=False)
+    pd.DataFrame(auc_rows).to_csv(args.out_dir / "auc_ci.csv", index=False)
+    pd.DataFrame(gate_rows).to_csv(args.out_dir / "gate_paired_delta.csv", index=False)
+
+    print("\n=== relational feature vs acquisition protocol ===")
+    print(coupling.round(3).to_string(index=False))
+    print("\n=== pooled OOF AUC ===")
+    print(pd.DataFrame(auc_rows).round(3).to_string(index=False))
+    print("\n=== paired deltas ===")
+    print(pd.DataFrame(gate_rows).round(3).to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/protocol_confound_check.py
+++ b/analysis/protocol_confound_check.py
@@ -1,0 +1,314 @@
+"""Is the UChicago ~0.61 vessel-kinetics AUC physiology, or acquisition protocol?
+
+The published Phase 1 bar (``experiments/uchicago_tabular_bar_floored``) is a
+logistic regression on 7 per-case vessel-kinetic means, pooled OOF AUC 0.614.
+Three of those features carry the acquisition timing directly:
+
+- ``peak_time`` and ``time_to_enhancement`` are divided by that case's own
+  acquisition duration (``gnn.data_loader._attach_node_features``), which ranges
+  95.6-480.3 s across the cohort;
+- ``auc_positive`` is a trapezoid over physical seconds, so it grows with how
+  long the scan ran;
+- ``washout_slope`` is measured to the last acquired frame, so it depends on
+  when acquisition stopped.
+
+Acquisition protocol is not randomly distributed here: the three UChicago
+sub-families differ systematically in frame count and sampling interval, and one
+of them (``her2_naclike``, 35 cases) is 100% non-pCR. That opens a
+protocol -> sub-family -> label path a vessel model can ride without measuring
+any vasculature. This script measures how much of the 0.61 travels that path.
+
+Three independent reads, none of which requires trusting the others:
+
+1. **Protocol alone.** Fit the same OOF logistic regression on nothing but
+   ``(n_frames, duration, dt_med)``. Whatever AUC that reaches is available with
+   zero imaging content.
+2. **Protocol regressed out.** Per fold, residualize each of the 7 means on the
+   protocol descriptors (fit on train, apply to test, so the correction leaks
+   nothing), then refit. What survives is the physiology-only bar.
+3. **Protocol held fixed.** Refit within the ``n_frames == 13`` stratum and
+   within each sub-family, where protocol varies far less.
+
+Bootstrap CIs use case resampling, and the drop from residualizing is a
+**paired** bootstrap (shared resamples) since the two models score the same
+cases.
+
+Reads only small CSVs and the per-case ``ufast_times_seconds.npy`` sidecars (no
+graph-cache load) -- head-node safe.
+
+Usage:
+    python -m analysis.protocol_confound_check \
+        --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+        --dce-root /ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce \
+        --out-dir experiments/uchicago_protocol_confound
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+_N_BOOTSTRAP = 2000
+_CI_PCT = (2.5, 97.5)
+_TIMES_SIDECAR = "ufast_times_seconds.npy"
+# A bootstrap resample or stratum with only one class present has no defined AUC.
+_MIN_CLASSES = 2
+# The frame count 112 of the 179 cases share -- the largest protocol-matched
+# stratum available, used as the non-parametric counterpart to residualizing.
+_MATCHED_FRAME_COUNT = 13
+
+# The 7 per-case node-feature means that constitute the published tabular bar.
+_MEANS7 = (
+    "peak_time_mean",
+    "peak_enhancement_mean",
+    "time_to_enhancement_mean",
+    "washin_slope_mean",
+    "washout_slope_mean",
+    "auc_positive_mean",
+    "radius_mean",
+)
+# Acquisition descriptors, all derived from the physical-time sidecar alone --
+# no voxel, no vessel, no patient anatomy.
+_PROTOCOL = ("n_frames", "duration", "dt_med")
+
+
+def load_protocol(dce_root: Path, case_ids: list[str]) -> pd.DataFrame:
+    """Read each case's physical acquisition times into protocol descriptors.
+
+    ``dt_med`` is the median inter-frame interval -- the temporal resolution the
+    scanner ran at. A missing sidecar raises: every UChicago v5 case ships one,
+    and silently dropping cases would change the cohort this analysis reports on.
+    """
+    rows = []
+    for case_id in case_ids:
+        path = dce_root / case_id / _TIMES_SIDECAR
+        if not path.is_file():
+            raise FileNotFoundError(f"case={case_id}: missing {path}")
+        times = np.load(path, allow_pickle=False)
+        rows.append(
+            {
+                "case_id": case_id,
+                "n_frames": int(times.size),
+                "duration": float(times[-1] - times[0]),
+                "dt_med": float(np.median(np.diff(times))),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def oof_predictions(
+    features: np.ndarray, y: np.ndarray, folds: np.ndarray
+) -> np.ndarray:
+    """Out-of-fold probabilities from a standardized logistic regression.
+
+    Matches the estimator the published tabular bar uses, so AUCs here are
+    directly comparable to ``experiments/uchicago_tabular_bar_floored``.
+    """
+    probs = np.zeros(len(y), dtype=float)
+    for fold in np.unique(folds):
+        train, test = folds != fold, folds == fold
+        model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=2000))
+        model.fit(features[train], y[train])
+        probs[test] = model.predict_proba(features[test])[:, 1]
+    return probs
+
+
+def residualize_on_protocol(
+    frame: pd.DataFrame, feature_names: tuple[str, ...], folds: np.ndarray
+) -> np.ndarray:
+    """Remove the protocol-predictable part of each feature, fold-honestly.
+
+    The linear map from protocol to feature is fit on the training split only and
+    applied to the held-out split, so the correction carries no test information.
+    What remains is the part of each vessel summary that acquisition timing does
+    *not* explain.
+    """
+    residuals = np.zeros((len(frame), len(feature_names)), dtype=float)
+    for fold in np.unique(folds):
+        train, test = folds != fold, folds == fold
+        for column, name in enumerate(feature_names):
+            fit = LinearRegression().fit(
+                frame.loc[train, list(_PROTOCOL)], frame.loc[train, name]
+            )
+            residuals[test, column] = frame.loc[test, name] - fit.predict(
+                frame.loc[test, list(_PROTOCOL)]
+            )
+    return residuals
+
+
+def bootstrap_auc_ci(
+    y: np.ndarray, probs: np.ndarray, rng: np.random.Generator
+) -> tuple[float, float]:
+    """Case-resampling bootstrap CI for a single model's pooled OOF AUC."""
+    draws = []
+    for _ in range(_N_BOOTSTRAP):
+        idx = rng.integers(0, len(y), len(y))
+        if len(np.unique(y[idx])) < _MIN_CLASSES:
+            continue
+        draws.append(roc_auc_score(y[idx], probs[idx]))
+    return tuple(np.percentile(draws, _CI_PCT))
+
+
+def bootstrap_paired_delta(
+    y: np.ndarray, probs_a: np.ndarray, probs_b: np.ndarray, rng: np.random.Generator
+) -> tuple[float, float, float]:
+    """Paired bootstrap of ``AUC(a) - AUC(b)``: mean delta, CI low, CI high.
+
+    Both models score the same cases, so resampling them jointly cancels the
+    shared sampling noise that would make two marginal CIs look inconclusive.
+    """
+    draws = []
+    for _ in range(_N_BOOTSTRAP):
+        idx = rng.integers(0, len(y), len(y))
+        if len(np.unique(y[idx])) < _MIN_CLASSES:
+            continue
+        draws.append(
+            roc_auc_score(y[idx], probs_a[idx]) - roc_auc_score(y[idx], probs_b[idx])
+        )
+    return float(np.mean(draws)), *np.percentile(draws, _CI_PCT)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Command-line interface for the protocol-confound audit."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tabular-features", type=Path, required=True)
+    parser.add_argument("--dce-root", type=Path, required=True)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser
+
+
+def main() -> None:
+    """Run the three reads, print them, and write the CSVs to ``--out-dir``."""
+    args = build_parser().parse_args()
+    rng = np.random.default_rng(args.seed)
+
+    data = pd.read_csv(args.tabular_features)
+    data = data.merge(
+        load_protocol(args.dce_root, data["case_id"].tolist()), on="case_id"
+    )
+    data["sub_family"] = data["case_id"].str.split("_1_3_").str[0]
+    y = data["pcr"].to_numpy()
+    folds = data["fold"].to_numpy()
+
+    # 1. How much acquisition timing does each modeled feature carry?
+    leakage = pd.DataFrame(
+        [
+            {
+                "feature": name,
+                **{
+                    f"abs_corr_{p}": abs(np.corrcoef(data[name], data[p])[0, 1])
+                    for p in _PROTOCOL
+                },
+                "univariate_auc": max(
+                    roc_auc_score(y, data[name]), 1.0 - roc_auc_score(y, data[name])
+                ),
+            }
+            for name in _MEANS7
+        ]
+    )
+
+    # 2. The three reads.
+    probs_full = oof_predictions(data[list(_MEANS7)].to_numpy(), y, folds)
+    probs_protocol = oof_predictions(data[list(_PROTOCOL)].to_numpy(), y, folds)
+    probs_resid = oof_predictions(
+        residualize_on_protocol(data, _MEANS7, folds), y, folds
+    )
+
+    arms = {
+        "tabular_7means (published bar)": probs_full,
+        "protocol_only (n_frames,duration,dt_med)": probs_protocol,
+        "tabular_7means_protocol_residualized": probs_resid,
+    }
+    auc_rows = []
+    for name, probs in arms.items():
+        low, high = bootstrap_auc_ci(y, probs, rng)
+        auc_rows.append(
+            {
+                "model": name,
+                "n": len(y),
+                "auc": roc_auc_score(y, probs),
+                "ci_low": low,
+                "ci_high": high,
+            }
+        )
+
+    # 3. Protocol held fixed: the shared-frame-count stratum and each sub-family.
+    strata = [
+        (
+            f"n_frames=={_MATCHED_FRAME_COUNT}",
+            data[data["n_frames"] == _MATCHED_FRAME_COUNT],
+        )
+    ]
+    strata += [(f"sub_family={fam}", part) for fam, part in data.groupby("sub_family")]
+    strata_rows = []
+    for label, part in strata:
+        if part["pcr"].nunique() < _MIN_CLASSES:
+            strata_rows.append(
+                {
+                    "stratum": label,
+                    "n": len(part),
+                    "pcr_rate": part["pcr"].mean(),
+                    "auc_7means": np.nan,
+                    "auc_dt_med_alone": np.nan,
+                }
+            )
+            continue
+        part = part.reset_index(drop=True)
+        probs = oof_predictions(
+            part[list(_MEANS7)].to_numpy(),
+            part["pcr"].to_numpy(),
+            part["fold"].to_numpy(),
+        )
+        auc_dt = roc_auc_score(part["pcr"], part["dt_med"])
+        strata_rows.append(
+            {
+                "stratum": label,
+                "n": len(part),
+                "pcr_rate": part["pcr"].mean(),
+                "auc_7means": roc_auc_score(part["pcr"], probs),
+                "auc_dt_med_alone": max(auc_dt, 1.0 - auc_dt),
+            }
+        )
+
+    # 4. Paired: how much AUC does removing protocol cost?
+    delta, delta_low, delta_high = bootstrap_paired_delta(
+        y, probs_full, probs_resid, rng
+    )
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    leakage.to_csv(args.out_dir / "feature_protocol_coupling.csv", index=False)
+    pd.DataFrame(auc_rows).to_csv(args.out_dir / "auc_ci.csv", index=False)
+    pd.DataFrame(strata_rows).to_csv(args.out_dir / "stratified_auc.csv", index=False)
+    pd.DataFrame(
+        [
+            {
+                "comparison": "tabular_7means - protocol_residualized",
+                "mean_delta": delta,
+                "ci_low": delta_low,
+                "ci_high": delta_high,
+            }
+        ]
+    ).to_csv(args.out_dir / "paired_delta.csv", index=False)
+
+    print(leakage.round(3).to_string(index=False))
+    print()
+    print(pd.DataFrame(auc_rows).round(3).to_string(index=False))
+    print()
+    print(pd.DataFrame(strata_rows).round(3).to_string(index=False))
+    print()
+    print(
+        f"paired dAUC (published bar - protocol removed): {delta:+.3f} "
+        f"[{delta_low:+.3f}, {delta_high:+.3f}]"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/config.py
+++ b/config.py
@@ -163,6 +163,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # gnn/DESIGN_segment_graph.md.
         "gnn_node_mode": "voxel",
         "gnn_node_features": ["peak_time", "radius"],
+        # Kinetic baseline floor the cache was built with (gnn/kinetics.py). A
+        # build-time property of the cache; declared here so the train-time
+        # dataset load requests the same value and the cache-manifest check
+        # matches (0.0 = historical/unfloored; e.g. 0.05 for a floored cache).
+        "gnn_kinetic_baseline_floor_frac": 0.0,
         # Whole-graph readout for GCNClassifier (voxel/segment): "mean"
         # (default, the original single global_mean_pool -- fully backward
         # compatible), "mean_max", or "mean_max_sum". Concatenating max/sum

--- a/config.py
+++ b/config.py
@@ -168,6 +168,18 @@ DEFAULT_CONFIG: dict[str, Any] = {
         # dataset load requests the same value and the cache-manifest check
         # matches (0.0 = historical/unfloored; e.g. 0.05 for a floored cache).
         "gnn_kinetic_baseline_floor_frac": 0.0,
+        # Edge-ablation control: does the model use the vessel topology at all?
+        # "none" (default) trains on the real skeleton adjacency; "rewire"
+        # randomizes which nodes are adjacent while preserving every node's
+        # degree; "drop" removes edges entirely, reducing the GCN to a per-node
+        # map plus a permutation-invariant readout. Applied at TRAIN time to the
+        # cloned per-fold graphs, so all three arms share one cache -- no rebuild.
+        # Not defined for junction mode (edge_attr is aligned with edge_index).
+        # See gnn/train.py::_apply_edge_ablation.
+        "gnn_edge_ablation": "none",
+        # Seed for the "rewire" arm's degree-preserving swaps, offset per graph by
+        # the graph's cache index so a case rewires identically across folds/seeds.
+        "gnn_edge_ablation_seed": 0,
         # Whole-graph readout for GCNClassifier (voxel/segment): "mean"
         # (default, the original single global_mean_pool -- fully backward
         # compatible), "mean_max", or "mean_max_sum". Concatenating max/sum

--- a/configs/uchicago_gnn_2feat_floored.yaml
+++ b/configs/uchicago_gnn_2feat_floored.yaml
@@ -1,0 +1,47 @@
+# UChicago 2-feature voxel GNN (floored), for the all-models comparison.
+# Identical to configs/uchicago_gnn_tier_baseline_floored.yaml except the node
+# feature set is the minimal [peak_time, radius] pair (the two features that were
+# never corrupted by the near-void-baseline blowup -- see LAB_NOTEBOOK). Tests
+# whether the richer 7-feature set actually buys signal over this 2-feature floor.
+# Reads the SAME 7-feature floored voxel cache and selects the 2-feature subset at
+# load (manifest allows a node_features subset without a rebuild).
+
+experiment_setup:
+  name: "uchicago_gnn_2feat_floored"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  gnn_kinetic_baseline_floor_frac: 0.05
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_mode: "voxel"
+  gnn_node_features:
+    - "peak_time"
+    - "radius"
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_edge_drop.yaml
+++ b/configs/uchicago_gnn_edge_drop.yaml
@@ -1,0 +1,56 @@
+# UChicago voxel GNN -- edge-ablation control, NO-EDGES arm.
+#
+# Every knob matches configs/uchicago_gnn_edge_none.yaml except that edge_index is
+# emptied at train time (gnn/train.py::_apply_edge_ablation). GCNConv adds
+# self-loops, so each node reduces to a per-node linear map and the model becomes a
+# Deep Sets-style permutation-invariant readout over node features -- message
+# passing removed entirely. A paired dAUC against the none arm is the strongest
+# form of "do edges contribute anything?"
+
+experiment_setup:
+  name: "uchicago_gnn_edge_drop"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  # Declares the cache was built with the kinetics.py baseline floor (0.05);
+  # must match the cache manifest's kinetic_baseline_floor_frac.
+  gnn_kinetic_baseline_floor_frac: 0.05
+  gnn_edge_ablation: "drop"
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Frozen historical baseline (D0.6): pin to pre-hygiene behavior.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_edge_none.yaml
+++ b/configs/uchicago_gnn_edge_none.yaml
@@ -1,0 +1,60 @@
+# UChicago voxel GNN -- edge-ablation control, REAL-ADJACENCY arm.
+#
+# Reference arm for the "does this model use the vessel topology at all?" control
+# (gnn/train.py::_apply_edge_ablation). Identical to
+# configs/uchicago_gnn_tier_baseline_floored.yaml -- same frozen pre-hygiene knobs
+# (unweighted BCE, no weight decay, no scheduler, no early stopping, final-epoch
+# model), same 7-feature voxel set, same floored cache, same predefined folds --
+# and trains on the real skeleton adjacency.
+#
+# Re-run here rather than reusing the existing tier-sweep baseline results so all
+# three arms come from one code version and one submission, making the paired
+# dAUC a comparison of the ablation and nothing else.
+
+experiment_setup:
+  name: "uchicago_gnn_edge_none"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  # Declares the cache was built with the kinetics.py baseline floor (0.05);
+  # must match the cache manifest's kinetic_baseline_floor_frac.
+  gnn_kinetic_baseline_floor_frac: 0.05
+  gnn_edge_ablation: "none"
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Frozen historical baseline (D0.6): pin to pre-hygiene behavior.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_edge_rewire.yaml
+++ b/configs/uchicago_gnn_edge_rewire.yaml
@@ -1,0 +1,59 @@
+# UChicago voxel GNN -- edge-ablation control, DEGREE-PRESERVING REWIRE arm.
+#
+# Every knob matches configs/uchicago_gnn_edge_none.yaml except that each graph's
+# adjacency is randomly rewired at train time while preserving every node's degree
+# (gnn/train.py::_apply_edge_ablation). Node features, node count, edge count and
+# degree sequence are untouched, so a paired dAUC against the none arm isolates
+# *which nodes are adjacent* -- the specific vessel topology -- from "some graph
+# with this degree sequence."
+#
+# Rewiring is keyed by each graph's cache index, so a case rewires identically
+# across folds and seeds.
+
+experiment_setup:
+  name: "uchicago_gnn_edge_rewire"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  # Declares the cache was built with the kinetics.py baseline floor (0.05);
+  # must match the cache manifest's kinetic_baseline_floor_frac.
+  gnn_kinetic_baseline_floor_frac: 0.05
+  gnn_edge_ablation: "rewire"
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Frozen historical baseline (D0.6): pin to pre-hygiene behavior.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_junction_floored.yaml
+++ b/configs/uchicago_gnn_junction_floored.yaml
@@ -1,0 +1,69 @@
+# UChicago JUNCTION arm of the floored voxel/segment/junction graph-mode
+# comparison. node_mode="junction": junction/endpoint voxels are nodes, each
+# vessel segment is an edge (segment-as-edge, Option A) -- the topological dual
+# of the segment line graph. Matched to the voxel baseline arm
+# (configs/uchicago_gnn_tier_baseline_floored.yaml): every model/training knob
+# is identical so the ONLY difference is the graph representation.
+#
+# The 7 node features are the same per-voxel signals the voxel arm uses
+# (identical names); the 7 edge features are the seg_*_mean segment summaries
+# (identical to the segment arm's node features). Kinetic node/edge features
+# are NOT augmented with degree/bifurcation geometry, so the comparison
+# isolates the representation, not extra structural inputs.
+#
+# Floored: gnn_kinetic_baseline_floor_frac 0.05 must match the cache manifest
+# (built with KINETIC_BASELINE_FLOOR_FRAC=0.05 via submit_gnn_build.slurm).
+
+experiment_setup:
+  name: "uchicago_gnn_junction_floored"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  gnn_kinetic_baseline_floor_frac: 0.05
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_mode: "junction"
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  gnn_edge_features:
+    - "seg_peak_time_mean"
+    - "seg_peak_enhancement_mean"
+    - "seg_time_to_enhancement_mean"
+    - "seg_washin_slope_mean"
+    - "seg_washout_slope_mean"
+    - "seg_auc_positive_mean"
+    - "seg_radius_mean"
+  # Frozen historical baseline (D0.6), identical to the voxel baseline arm.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_junction_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_richfeat.yaml
+++ b/configs/uchicago_gnn_richfeat.yaml
@@ -1,0 +1,54 @@
+# GNN training on the UChicago internal ultrafast DCE cohort (gnn/train.py) --
+# "rich feature" baseline: identical voxel-GCN model to configs/uchicago_gnn.yaml,
+# but with the full set of legitimate voxel node features instead of just
+# [peak_time, radius]. This is the "richer node features" next step flagged in
+# LAB_NOTEBOOK.md after the 2026-07-22 null result (AUC 0.527 with 2 features).
+#
+# Feature set = every non-leakage voxel feature the loader exposes
+# (gnn/data_loader.py _FEATURE_ATTR): the four kinetic curve descriptors named
+# in the notebook (peak_enhancement, time_to_enhancement, washin_slope,
+# auc_positive) plus washout_slope, plus the two originals (peak_time, radius).
+# pcr_dummy is deliberately excluded -- it is a leakage diagnostic, not a feature.
+#
+# Requires a cache built with (a superset of) this feature list; see
+# gnn/slurm/submit_gnn_build.slurm with NODE_FEATURES set to match.
+#
+# Paths, folds, kinetic contract, and all model hyperparameters are copied
+# verbatim from configs/uchicago_gnn.yaml so the ONLY change vs. the baseline
+# is the node feature set (and the cache it reads).
+
+experiment_setup:
+  name: "gnn_uchicago_richfeat"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  split_mode: "predefined"
+  split_col: "fold"
+  use_group_split: false
+  n_splits: 5
+  random_state: 42
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_segment_floored.yaml
+++ b/configs/uchicago_gnn_segment_floored.yaml
@@ -1,0 +1,56 @@
+# UChicago SEGMENT arm of the floored voxel/segment/junction graph-mode
+# comparison. node_mode="segment": one node per vessel segment (line graph,
+# Option B). Matched to configs/uchicago_gnn_tier_baseline_floored.yaml (voxel
+# baseline) -- every model/training knob is identical so the ONLY difference is
+# the graph representation. The 7 node features are the seg_*_mean summaries of
+# the same 7 signals the voxel arm uses per voxel (peak_time, peak_enhancement,
+# time_to_enhancement, washin_slope, washout_slope, auc_positive, radius).
+#
+# Floored: gnn_kinetic_baseline_floor_frac 0.05 must match the cache manifest
+# (built with KINETIC_BASELINE_FLOOR_FRAC=0.05 via submit_gnn_build.slurm).
+
+experiment_setup:
+  name: "uchicago_gnn_segment_floored"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  gnn_kinetic_baseline_floor_frac: 0.05
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_mode: "segment"
+  gnn_node_features:
+    - "seg_peak_time_mean"
+    - "seg_peak_enhancement_mean"
+    - "seg_time_to_enhancement_mean"
+    - "seg_washin_slope_mean"
+    - "seg_washout_slope_mean"
+    - "seg_auc_positive_mean"
+    - "seg_radius_mean"
+  # Frozen historical baseline (D0.6), identical to the voxel baseline arm.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_segment_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_tier0.yaml
+++ b/configs/uchicago_gnn_tier0.yaml
@@ -1,0 +1,56 @@
+# UChicago tier ladder -- TIER-0 arm (optimization hygiene).
+#
+# Only deltas vs. uchicago_gnn_tier_baseline.yaml are the Tier-0 training knobs
+# (PLAN_advanced_modeling.md Tier 0, decisions D1.1-D1.5): weighted BCE +
+# weight decay + gradient clipping + LR plateau scheduler + early stopping +
+# best-epoch restore. Feature set, folds, and all architecture knobs are held
+# identical to the baseline arm (D5: one change-set per tier). Turning on any
+# of scheduler/early-stopping/restore activates the CV-safe inner-val model
+# selection in gnn/train.py (the 2026-07-23 leakage fix).
+
+experiment_setup:
+  name: "uchicago_gnn_tier0"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Tier-0 hygiene stack (the only deltas vs. the baseline arm).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+  inner_val_fraction: 0.2
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_tier0_floored.yaml
+++ b/configs/uchicago_gnn_tier0_floored.yaml
@@ -1,0 +1,59 @@
+# UChicago tier ladder -- TIER-0 arm (optimization hygiene).
+#
+# Only deltas vs. uchicago_gnn_tier_baseline.yaml are the Tier-0 training knobs
+# (PLAN_advanced_modeling.md Tier 0, decisions D1.1-D1.5): weighted BCE +
+# weight decay + gradient clipping + LR plateau scheduler + early stopping +
+# best-epoch restore. Feature set, folds, and all architecture knobs are held
+# identical to the baseline arm (D5: one change-set per tier). Turning on any
+# of scheduler/early-stopping/restore activates the CV-safe inner-val model
+# selection in gnn/train.py (the 2026-07-23 leakage fix).
+
+experiment_setup:
+  name: "uchicago_gnn_tier0_floored"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  # Declares the cache was built with the kinetics.py baseline floor (0.05);
+  # must match the cache manifest's kinetic_baseline_floor_frac.
+  gnn_kinetic_baseline_floor_frac: 0.05
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Tier-0 hygiene stack (the only deltas vs. the baseline arm).
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+  inner_val_fraction: 0.2
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_tier1.yaml
+++ b/configs/uchicago_gnn_tier1.yaml
@@ -1,0 +1,56 @@
+# UChicago tier ladder -- TIER-1 arm (readout: mean+max pooling).
+#
+# Only delta vs. uchicago_gnn_tier0.yaml is gnn_pooling: mean -> mean_max
+# (PLAN_advanced_modeling.md Tier 1, decision D2.1 -- the first readout change,
+# the highest-value lever on the Duke cohort where mean+max was the first arm to
+# clear the tabular baseline). Everything else (Tier-0 hygiene stack, 7-feature
+# set, folds, conv, depth) is held identical, so the paired comparison isolates
+# the readout change (D5). Reuses the same cache -- readout is a model change, no
+# rebuild.
+
+experiment_setup:
+  name: "uchicago_gnn_tier1"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+  inner_val_fraction: 0.2
+  # Tier-1 readout change (the only delta vs. the Tier-0 arm).
+  gnn_pooling: "mean_max"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_tier1_floored.yaml
+++ b/configs/uchicago_gnn_tier1_floored.yaml
@@ -1,0 +1,59 @@
+# UChicago tier ladder -- TIER-1 arm (readout: mean+max pooling).
+#
+# Only delta vs. uchicago_gnn_tier0.yaml is gnn_pooling: mean -> mean_max
+# (PLAN_advanced_modeling.md Tier 1, decision D2.1 -- the first readout change,
+# the highest-value lever on the Duke cohort where mean+max was the first arm to
+# clear the tabular baseline). Everything else (Tier-0 hygiene stack, 7-feature
+# set, folds, conv, depth) is held identical, so the paired comparison isolates
+# the readout change (D5). Reuses the same cache -- readout is a model change, no
+# rebuild.
+
+experiment_setup:
+  name: "uchicago_gnn_tier1_floored"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  # Declares the cache was built with the kinetics.py baseline floor (0.05);
+  # must match the cache manifest's kinetic_baseline_floor_frac.
+  gnn_kinetic_baseline_floor_frac: 0.05
+  batch_size: 8
+  epochs: 100
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  loss: "weighted_bce"
+  weight_decay: 1.0e-4
+  max_grad_norm: 1.0
+  lr_scheduler: "plateau"
+  lr_scheduler_factor: 0.5
+  lr_scheduler_patience: 5
+  early_stopping_patience: 10
+  restore_best_epoch: true
+  inner_val_fraction: 0.2
+  # Tier-1 readout change (the only delta vs. the Tier-0 arm).
+  gnn_pooling: "mean_max"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_tier_baseline.yaml
+++ b/configs/uchicago_gnn_tier_baseline.yaml
@@ -1,0 +1,58 @@
+# UChicago tier ladder -- BASELINE arm (PLAN_advanced_modeling.md D0.6 frozen
+# historical behavior), replicated on the UChicago v5 ultrafast cohort.
+#
+# This is the reference the Tier-0/Tier-1 arms are paired against. It pins the
+# knobs to the HISTORICAL pre-hygiene behavior (unweighted BCE, no weight decay,
+# no scheduler, no early stopping, final-epoch model), so it reproduces the plain
+# GCN exactly -- the same posture as configs/gnn_tier0_sweep_baseline.yaml, but
+# on UChicago data with the 7-feature voxel set held fixed across the whole ladder.
+#
+# Differences vs. the Duke sweep baseline (both forced by the cohort, see
+# LAB_NOTEBOOK 2026-07-26): split_mode is "predefined" (UChicago ships patient-
+# grouped, pcr-stratified folds and exposes no patient column, so random reshuffle
+# would risk leakage -- folds are frozen, seeds vary torch init only), and the
+# node feature set is the full 7-feature voxel set instead of [peak_time, radius].
+
+experiment_setup:
+  name: "uchicago_gnn_tier_baseline"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Frozen historical baseline (D0.6): pin to pre-hygiene behavior.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/configs/uchicago_gnn_tier_baseline_floored.yaml
+++ b/configs/uchicago_gnn_tier_baseline_floored.yaml
@@ -1,0 +1,61 @@
+# UChicago tier ladder -- BASELINE arm (PLAN_advanced_modeling.md D0.6 frozen
+# historical behavior), replicated on the UChicago v5 ultrafast cohort.
+#
+# This is the reference the Tier-0/Tier-1 arms are paired against. It pins the
+# knobs to the HISTORICAL pre-hygiene behavior (unweighted BCE, no weight decay,
+# no scheduler, no early stopping, final-epoch model), so it reproduces the plain
+# GCN exactly -- the same posture as configs/gnn_tier0_sweep_baseline.yaml, but
+# on UChicago data with the 7-feature voxel set held fixed across the whole ladder.
+#
+# Differences vs. the Duke sweep baseline (both forced by the cohort, see
+# LAB_NOTEBOOK 2026-07-26): split_mode is "predefined" (UChicago ships patient-
+# grouped, pcr-stratified folds and exposes no patient column, so random reshuffle
+# would risk leakage -- folds are frozen, seeds vary torch init only), and the
+# node feature set is the full 7-feature voxel set instead of [peak_time, radius].
+
+experiment_setup:
+  name: "uchicago_gnn_tier_baseline_floored"
+  base_outdir: "./experiments"
+
+model_params:
+  device: "cpu"
+  n_splits: 5
+  random_state: 42
+  use_group_split: false
+  split_mode: "predefined"
+  split_col: "fold"
+  # Declares the cache was built with the kinetics.py baseline floor (0.05);
+  # must match the cache manifest's kinetic_baseline_floor_frac.
+  gnn_kinetic_baseline_floor_frac: 0.05
+  batch_size: 8
+  epochs: 25
+  hidden_dim: 32
+  num_layers: 2
+  dropout: 0.2
+  learning_rate: 0.001
+  gnn_node_features:
+    - "peak_time"
+    - "peak_enhancement"
+    - "time_to_enhancement"
+    - "washin_slope"
+    - "washout_slope"
+    - "auc_positive"
+    - "radius"
+  # Frozen historical baseline (D0.6): pin to pre-hygiene behavior.
+  weight_decay: 0.0
+  loss: "unweighted_bce"
+  lr_scheduler: "none"
+  max_grad_norm: 0.0
+  early_stopping_patience: 0
+  restore_best_epoch: false
+  gnn_pooling: "mean"
+
+data_paths:
+  gnn_centerline_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/centerlines"
+  gnn_dce_root: "/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce"
+  gnn_labels_path: "/gpfs/data/karczmar-lab/workspaces/spencervenancio/uchicago/uchicago_labels_folded.csv"
+  gnn_cache_dir: "/ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored"
+  gnn_id_column: "case_id"
+  gnn_label_column: "pcr"
+  gnn_cases: null
+  gnn_dataset_include: null

--- a/gnn/baseline_validity.py
+++ b/gnn/baseline_validity.py
@@ -1,0 +1,220 @@
+"""Per-node precontrast-baseline validity, and local repair of invalid baselines.
+
+Relative enhancement divides by S0, the mean of a voxel's precontrast frames. A
+small tail of vessel voxels has S0 ~ 0 -- an acquisition dropout before contrast
+rather than absent tissue, since those same voxels enhance normally afterwards
+-- and dividing by it turns (S - S0)/S0 into a divide-by-noise artifact.
+
+This module records **which** baselines were actually observed, and repairs the
+rest locally so the affected nodes still carry usable inputs:
+
+1. ``observed_valid`` marks nodes whose own baseline was finite and above a
+   per-case validity threshold. It is the record of what was measured and is
+   never overwritten -- downstream it is what gates the graph readout, so an
+   unobserved baseline can never influence the loss.
+2. ``repair_baselines`` fills an invalid node's S0 from the median of its
+   graph neighbours that already have one, spreading one hop per round until
+   nothing more can be filled. The filled value gives the node a locally
+   plausible scale so it can carry messages between its valid neighbours
+   without claiming its baseline was observed.
+
+Keeping the node rather than deleting it matters here: the graph is a vessel
+centerline, so dropping a mid-segment voxel severs the path between its two
+neighbours and fragments exactly the topology the model is meant to use.
+
+The repair reads only the case's own neighbouring voxels, never cohort
+statistics, so a case's imputed values do not depend on which cross-validation
+fold it lands in. That is why this can run once at cache-build time, unlike the
+clinical/morphometry imputers which must be fit per fold (see
+``gnn.data_loader``).
+
+An alternative that needs no imputation at all is to mark the invalid nodes and
+mask them at the readout, leaving their features as-is. ``gnn.data_loader``
+exposes both via ``baseline_repair={"off","mask","impute"}`` so the two can be
+compared rather than assumed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import networkx as nx
+import numpy as np
+
+# A node's baseline counts as observed when it exceeds this fraction of the
+# case's own median node baseline. The threshold is deliberately relative to the
+# case's precontrast intensity scale and nothing else: per-case median S0 spans
+# ~36x across the UChicago cohort (7.8 to 278.7), so no fixed absolute value
+# means "near-void" in every case, and referencing the voxel's own peak signal
+# would leak post-contrast (future) information into a precontrast decision.
+# Not to be tuned against pCR performance -- it is an acquisition-validity
+# threshold, not a model hyperparameter.
+DEFAULT_VALID_FRAC = 0.05
+
+_MODE_OFF = "off"
+_MODE_MASK = "mask"
+_MODE_IMPUTE = "impute"
+REPAIR_MODES = (_MODE_OFF, _MODE_MASK, _MODE_IMPUTE)
+
+
+@dataclass(frozen=True)
+class BaselineRepair:
+    """Outcome of validity marking + imputation for one graph.
+
+    ``observed_valid`` is the measurement record and is what gates the readout.
+    ``has_baseline`` additionally includes successfully imputed nodes and is
+    what decides whether a node gets usable features at all.
+    """
+
+    s0_filled: np.ndarray
+    observed_valid: np.ndarray
+    has_baseline: np.ndarray
+    imputation_round: np.ndarray
+    threshold: float
+
+    @property
+    def n_nodes(self) -> int:
+        """Total nodes considered."""
+        return int(self.observed_valid.size)
+
+    @property
+    def n_invalid(self) -> int:
+        """Nodes whose own baseline was not observed."""
+        return int((~self.observed_valid).sum())
+
+    @property
+    def n_imputed(self) -> int:
+        """Invalid nodes that received a neighbour-derived baseline."""
+        return int((self.has_baseline & ~self.observed_valid).sum())
+
+    @property
+    def n_unrepaired(self) -> int:
+        """Invalid nodes left with no usable baseline."""
+        return int((~self.has_baseline).sum())
+
+    @property
+    def max_round(self) -> int:
+        """Deepest imputation round used (0 when nothing was imputed)."""
+        return int(self.imputation_round.max()) if self.imputation_round.size else 0
+
+
+def observed_valid_mask(
+    s0: np.ndarray, *, valid_frac: float = DEFAULT_VALID_FRAC
+) -> tuple[np.ndarray, float]:
+    """Mark nodes with a finite baseline above the case's validity threshold.
+
+    Returns the mask and the absolute threshold it used, so the threshold can be
+    recorded per case in QC rather than inferred later.
+    """
+    if not 0.0 <= valid_frac < 1.0:
+        raise ValueError(f"valid_frac must be in [0, 1); got {valid_frac}")
+    s0 = np.asarray(s0, dtype=float)
+    finite = np.isfinite(s0)
+    if not finite.any():
+        raise ValueError("no finite node baselines; the DCE series is unusable")
+    # Median over finite baselines only -- including NaNs would drag the case's
+    # own reference scale toward the very voxels being screened out.
+    threshold = float(valid_frac * np.median(s0[finite]))
+    return finite & (s0 > threshold), threshold
+
+
+def repair_baselines(
+    graph: nx.Graph,
+    nodes: list,
+    s0: np.ndarray,
+    *,
+    mode: str,
+    valid_frac: float = DEFAULT_VALID_FRAC,
+) -> BaselineRepair:
+    """Mark baseline validity for one graph, and under ``"impute"`` also fill it.
+
+    ``mode`` is ``"mask"`` (record validity, leave baselines untouched) or
+    ``"impute"`` (additionally fill invalid baselines from valid neighbours).
+    ``"off"`` is handled by the caller, which skips this module entirely.
+    """
+    if mode not in (_MODE_MASK, _MODE_IMPUTE):
+        raise ValueError(
+            f"mode must be {_MODE_MASK!r} or {_MODE_IMPUTE!r}; got {mode!r}"
+        )
+    observed_valid, threshold = observed_valid_mask(s0, valid_frac=valid_frac)
+    if mode == _MODE_MASK:
+        s0 = np.asarray(s0, dtype=float)
+        return BaselineRepair(
+            s0_filled=np.where(observed_valid, s0, np.nan),
+            observed_valid=observed_valid,
+            has_baseline=observed_valid.copy(),
+            imputation_round=np.zeros(s0.size, dtype=np.int64),
+            threshold=threshold,
+        )
+    return _impute_baselines(
+        graph,
+        nodes,
+        s0,
+        observed_valid,
+        threshold=threshold,
+    )
+
+
+def _impute_baselines(
+    graph: nx.Graph,
+    nodes: list,
+    s0: np.ndarray,
+    observed_valid: np.ndarray,
+    *,
+    threshold: float,
+) -> BaselineRepair:
+    """Fill invalid baselines from valid graph neighbours, one hop per round.
+
+    Each round collects every eligible node with at least one neighbour that
+    already has a baseline, computes all their medians from the state at the
+    START of the round, then applies them together -- so a value travels at most
+    one neighbourhood step per round and the fill order cannot depend on node
+    iteration order. Repeats until no node can be filled.
+
+    ``nodes`` must be the node ordering ``s0`` and the masks are indexed by.
+
+    Eligibility depends only on the precontrast baseline and graph adjacency.
+    Postcontrast frames are deliberately not inspected: using future signal to
+    decide whether a baseline is valid would leak the forecasting target into
+    preprocessing.
+    """
+    s0 = np.asarray(s0, dtype=float)
+    observed_valid = np.asarray(observed_valid, dtype=bool)
+    if not (len(nodes) == s0.size == observed_valid.size):
+        raise ValueError("nodes, s0, and observed_valid must align")
+
+    index_of = {node: i for i, node in enumerate(nodes)}
+    s0_filled = np.where(observed_valid, s0, np.nan)
+    has_baseline = observed_valid.copy()
+    imputation_round = np.zeros(s0.size, dtype=np.int64)
+
+    round_number = 0
+    while True:
+        round_number += 1
+        pending: dict[int, float] = {}
+        for i, node in enumerate(nodes):
+            if has_baseline[i]:
+                continue
+            usable = [
+                s0_filled[index_of[nbr]]
+                for nbr in graph.neighbors(node)
+                if nbr in index_of and has_baseline[index_of[nbr]]
+            ]
+            if not usable:
+                continue
+            candidate = float(np.median(usable))
+            pending[i] = candidate
+        if not pending:
+            break
+        for i, value in pending.items():
+            s0_filled[i] = value
+            has_baseline[i] = True
+            imputation_round[i] = round_number
+
+    return BaselineRepair(
+        s0_filled=s0_filled,
+        observed_valid=observed_valid,
+        has_baseline=has_baseline,
+        imputation_round=imputation_round,
+        threshold=threshold,
+    )

--- a/gnn/build_dataset.py
+++ b/gnn/build_dataset.py
@@ -54,6 +54,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--id-column", type=str, default="case_id")
     parser.add_argument("--label-column", type=str, default="pcr")
     parser.add_argument(
+        "--kinetic-baseline-floor-frac",
+        type=float,
+        default=0.0,
+        help="Floor the relative-enhancement denominator at this fraction of "
+        "each voxel's own peak |signal|, so a near-void baseline can't inflate "
+        "(S-S0)/S0 into a divide-by-noise artifact. 0.0 (default) preserves the "
+        "historical behavior (exact-zero guard only); e.g. 0.05 caps peak "
+        "relative enhancement at ~20x. Voxel mode only. See gnn/kinetics.py.",
+    )
+    parser.add_argument(
         "--node-mode",
         type=str,
         default="voxel",
@@ -265,6 +275,7 @@ def main() -> None:
         id_column=args.id_column,
         label_column=args.label_column,
         max_missing_label_frac=args.max_missing_label_frac,
+        kinetic_baseline_floor_frac=args.kinetic_baseline_floor_frac,
         profile=not args.no_profile,
         num_workers=args.num_workers,
         allow_manifest_mismatch=args.allow_manifest_mismatch,

--- a/gnn/build_uchicago_temporal_cache.py
+++ b/gnn/build_uchicago_temporal_cache.py
@@ -30,6 +30,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Validate and reuse existing per-exam .pt files in the cache directory.",
     )
+    parser.add_argument("--shard-index", type=int)
+    parser.add_argument("--num-shards", type=int)
     parser.add_argument(
         "--defer-manifest",
         action="store_true",
@@ -55,6 +57,8 @@ def main(argv: list[str] | None = None) -> None:
             if args.cases
             else None
         ),
+        shard_index=args.shard_index,
+        num_shards=args.num_shards,
         resume=args.resume,
         write_manifest=not args.defer_manifest,
     )

--- a/gnn/build_uchicago_temporal_cache.py
+++ b/gnn/build_uchicago_temporal_cache.py
@@ -1,0 +1,65 @@
+"""CLI for building labeled or unlabeled UChicago temporal graph caches."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from gnn.uchicago_temporal_data import build_temporal_cache
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse manifest and output paths for one temporal cache build."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--centerline-root", type=Path, required=True)
+    parser.add_argument("--dce-root", type=Path, required=True)
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument(
+        "--exclude-labeled-manifest",
+        type=Path,
+        help="Remove every patient_key in this labeled manifest before building.",
+    )
+    parser.add_argument(
+        "--cases",
+        help="Optional comma-separated exam_id whitelist for a Slurm smoke build.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Validate and reuse existing per-exam .pt files in the cache directory.",
+    )
+    parser.add_argument(
+        "--defer-manifest",
+        action="store_true",
+        help="Build graph files without writing the shared final cache manifest.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Build the requested UChicago temporal cache."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    args = parse_args(argv)
+    records = build_temporal_cache(
+        manifest_path=args.manifest,
+        centerline_root=args.centerline_root,
+        dce_root=args.dce_root,
+        cache_dir=args.cache_dir,
+        exclude_labeled_manifest=args.exclude_labeled_manifest,
+        cases=(
+            [case.strip() for case in args.cases.split(",") if case.strip()]
+            if args.cases
+            else None
+        ),
+        resume=args.resume,
+        write_manifest=not args.defer_manifest,
+    )
+    logging.info("Built %d UChicago temporal exam graphs", len(records))
+
+
+if __name__ == "__main__":
+    main()

--- a/gnn/data_loader.py
+++ b/gnn/data_loader.py
@@ -347,6 +347,8 @@ def _attach_node_features(
     relative_enhancement: bool,
     label: int | None,
     node_features: tuple[str, ...],
+    *,
+    baseline_floor_frac: float = 0.0,
 ) -> None:
     """Set ``radius`` and the DCE-derived kinetic features on every node.
 
@@ -379,6 +381,7 @@ def _attach_node_features(
             time_axis,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         )
         tte_idx = kinetic["tte_idx"]
 
@@ -528,6 +531,7 @@ def _build_case(
     node_mode: str,
     edge_features: tuple[str, ...] = (),
     attach_node_series: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> tuple[Data, dict[str, list[float]]]:
     """Build one labeled :class:`Data` graph for ``case_id`` in ``node_mode``.
 
@@ -551,6 +555,17 @@ def _build_case(
     ``_finalize_data``. ``edge_features`` is non-empty only for junction mode.
     """
     stage_samples: dict[str, list[float]] = {}
+    # The baseline floor is currently threaded only through the voxel kinetic
+    # path (_attach_node_features). Segment/junction builds and the forecasting
+    # node-series path still call baseline_relative_curve with the default
+    # (unfloored) denominator, so refuse rather than silently half-apply it.
+    if baseline_floor_frac > 0.0 and (node_mode != _VOXEL_MODE or attach_node_series):
+        raise NotImplementedError(
+            "baseline_floor_frac > 0 is only wired into voxel-mode kinetic "
+            f"features (got node_mode={node_mode!r}, attach_node_series="
+            f"{attach_node_series}). Thread it through the segment/junction/"
+            "node-series paths before using it there."
+        )
     study_dir = mask_path.parent
 
     with _stage_timer(stage_samples, "mask_load"):
@@ -636,6 +651,7 @@ def _build_case(
                     relative_enhancement,
                     label,
                     node_features,
+                    baseline_floor_frac=baseline_floor_frac,
                 )
             graph = voxel_graph
 
@@ -863,6 +879,7 @@ class VanguardCenterlineDataset(InMemoryDataset):
         id_column: str = "case_id",
         label_column: str = "pcr",
         max_missing_label_frac: float = 0.1,
+        kinetic_baseline_floor_frac: float = 0.0,
         profile: bool = False,
         num_workers: int = 1,
         allow_manifest_mismatch: bool = False,
@@ -995,6 +1012,9 @@ class VanguardCenterlineDataset(InMemoryDataset):
         self._id_column = id_column
         self._label_column = label_column
         self._max_missing_label_frac = max_missing_label_frac
+        if kinetic_baseline_floor_frac < 0.0:
+            raise ValueError("kinetic_baseline_floor_frac must be >= 0")
+        self._kinetic_baseline_floor_frac = float(kinetic_baseline_floor_frac)
         self._profile = profile
         self._num_workers = num_workers
         self._allow_manifest_mismatch = allow_manifest_mismatch
@@ -1140,6 +1160,12 @@ class VanguardCenterlineDataset(InMemoryDataset):
             "node_features": list(self._node_features),
             "feature_source": _FEATURE_SOURCE,
         }
+        # Kinetic baseline floor: recorded only when active so pre-floor caches
+        # (which have no such key) stay schema-compatible. _check_cache_manifest
+        # normalizes a missing cached value to 0.0, so a floored cache never
+        # silently serves an unfloored request or vice versa.
+        if self._kinetic_baseline_floor_frac > 0.0:
+            settings["kinetic_baseline_floor_frac"] = self._kinetic_baseline_floor_frac
         # Only junction mode has edge features. Recording the key only when it's
         # non-empty keeps voxel/segment manifests (and the caches already built
         # under them) schema-compatible -- a pre-edge_features cache has no such
@@ -1217,6 +1243,18 @@ class VanguardCenterlineDataset(InMemoryDataset):
                     mismatched[key] = {"cached": cached_value, "requested": value}
             elif cached_value != value:
                 mismatched[key] = {"cached": cached_value, "requested": value}
+        # Kinetic baseline floor is recorded only when active, so it may be
+        # absent from either side; compare it explicitly with absent==0.0 so a
+        # floored cache can't serve an unfloored request (or vice versa) even
+        # though the key is missing from the requested settings.
+        floor_key = "kinetic_baseline_floor_frac"
+        cached_floor = manifest.get(floor_key) or 0.0
+        requested_floor = requested.get(floor_key) or 0.0
+        if cached_floor != requested_floor:
+            mismatched[floor_key] = {
+                "cached": cached_floor,
+                "requested": requested_floor,
+            }
         if mismatched and not self._allow_manifest_mismatch:
             raise RuntimeError(
                 f"Cache at {self.processed_dir} was built with different "
@@ -1656,6 +1694,7 @@ class VanguardCenterlineDataset(InMemoryDataset):
                     node_features=self._node_features,
                     node_mode=self._node_mode,
                     edge_features=self._edge_features,
+                    baseline_floor_frac=self._kinetic_baseline_floor_frac,
                 )
                 self._timings.merge(stage_samples)
                 logging.info("GNN build: built %s (%d/%d)", case_id, done, total)
@@ -1681,6 +1720,7 @@ class VanguardCenterlineDataset(InMemoryDataset):
                         node_features=self._node_features,
                         node_mode=self._node_mode,
                         edge_features=self._edge_features,
+                        baseline_floor_frac=self._kinetic_baseline_floor_frac,
                     )
                     for case_id, mask_path, label in batch
                 ]

--- a/gnn/data_loader.py
+++ b/gnn/data_loader.py
@@ -531,6 +531,7 @@ def _build_case(
     node_mode: str,
     edge_features: tuple[str, ...] = (),
     attach_node_series: bool = False,
+    attach_temporal_contract: bool = False,
     baseline_floor_frac: float = 0.0,
 ) -> tuple[Data, dict[str, list[float]]]:
     """Build one labeled :class:`Data` graph for ``case_id`` in ``node_mode``.
@@ -559,7 +560,12 @@ def _build_case(
     # kinetic paths. The forecasting node-series path (attach_node_series) still
     # calls baseline_relative_curve with the default (unfloored) denominator, so
     # refuse rather than silently half-apply it there.
-    if baseline_floor_frac > 0.0 and attach_node_series:
+    if attach_temporal_contract and node_mode != _VOXEL_MODE:
+        raise ValueError(
+            "attach_temporal_contract=True requires node_mode='voxel'; the "
+            "UChicago weight-transfer experiment does not sweep graph modes."
+        )
+    if baseline_floor_frac > 0.0 and (attach_node_series or attach_temporal_contract):
         raise NotImplementedError(
             "baseline_floor_frac > 0 is not yet wired into the forecasting "
             "node-series path (attach_node_series=True). Thread it through "
@@ -690,14 +696,55 @@ def _build_case(
     #     ``ordered_nodes``). First-pass target = raw junction-voxel curve
     #     (design doc §4.3; flow/derivative alternative deferred).
     # Default off -> the classification build path is byte-for-byte unchanged.
-    if attach_node_series:
+    if attach_node_series or attach_temporal_contract:
         from gnn.pretrain.node_series import (
             junction_node_series,
             segment_node_series,
             voxel_node_series,
         )
 
-        if node_mode == _VOXEL_MODE:
+        if attach_temporal_contract:
+            from gnn.baseline_validity import repair_baselines
+
+            ordered_nodes = list(voxel_graph.nodes())
+            raw_signal = np.stack(
+                [dce_4d[:, z, y, x] for x, y, z in ordered_nodes], axis=0
+            )
+            s0 = raw_signal[:, :baseline_frame_count].mean(axis=1)
+            repair = repair_baselines(
+                voxel_graph,
+                ordered_nodes,
+                s0,
+                mode="impute",
+            )
+            if not repair.observed_valid.any():
+                raise ValueError(
+                    f"case={case_id}: no voxel has an observed valid baseline; "
+                    "forecast loss and downstream pooling would be undefined"
+                )
+            node_series = voxel_node_series(
+                dce_4d,
+                ordered_nodes,
+                baseline_frame_count=baseline_frame_count,
+                # The temporal-transfer path has one preprocessing contract:
+                # relative enhancement against the locally repaired S0. It is
+                # deliberately independent of the static-feature policy above.
+                relative_enhancement=True,
+                baseline_override=repair.s0_filled,
+            )
+            # A component with no valid baseline seed cannot be repaired. Keep
+            # its nodes in the graph so topology is unchanged, but give them a
+            # neutral curve; node_valid masks them from every loss/readout.
+            node_series[~repair.has_baseline] = 0.0
+            node_valid = repair.observed_valid
+            data.baseline_imputed = torch.tensor(
+                repair.has_baseline & ~repair.observed_valid, dtype=torch.bool
+            )
+            data.baseline_imputation_round = torch.tensor(
+                repair.imputation_round, dtype=torch.long
+            )
+            data.baseline_validity_threshold = float(repair.threshold)
+        elif node_mode == _VOXEL_MODE:
             node_series = voxel_node_series(
                 dce_4d,
                 list(voxel_graph.nodes()),
@@ -722,11 +769,24 @@ def _build_case(
             raise ValueError(
                 f"attach_node_series=True: unknown node_mode {node_mode!r}."
             )
-        data.node_series = torch.tensor(node_series, dtype=torch.float)
+        if attach_temporal_contract:
+            data.node_series = torch.tensor(node_series, dtype=torch.float).unsqueeze(
+                -1
+            )
+            data.node_valid = torch.tensor(node_valid, dtype=torch.bool)
+        else:
+            # Historical Duke smoke contract. Kept separate so the production
+            # UChicago contract does not silently change a cohort-specific
+            # placeholder harness.
+            data.node_series = torch.tensor(node_series, dtype=torch.float)
         # Physical acquisition seconds for the forecasting time axis (issue 3a):
         # the same ``time_axis`` the kinetic path uses, so forecasting sees the
         # real (irregular) UFAST cadence rather than frame indices.
         data.node_times = torch.tensor(time_axis, dtype=torch.float)
+        if attach_temporal_contract:
+            data.times_seconds = data.node_times
+            postbaseline = np.arange(num_timepoints) >= baseline_frame_count
+            data.is_postbaseline = torch.tensor(postbaseline, dtype=torch.bool)
         # Protocol baseline length, so the forecasting tiler can drop precontrast
         # baseline frames from its windows (issue 3b) while still using them for S0.
         data.baseline_frame_count = int(baseline_frame_count)

--- a/gnn/data_loader.py
+++ b/gnn/data_loader.py
@@ -555,16 +555,15 @@ def _build_case(
     ``_finalize_data``. ``edge_features`` is non-empty only for junction mode.
     """
     stage_samples: dict[str, list[float]] = {}
-    # The baseline floor is currently threaded only through the voxel kinetic
-    # path (_attach_node_features). Segment/junction builds and the forecasting
-    # node-series path still call baseline_relative_curve with the default
-    # (unfloored) denominator, so refuse rather than silently half-apply it.
-    if baseline_floor_frac > 0.0 and (node_mode != _VOXEL_MODE or attach_node_series):
+    # The baseline floor is threaded through the voxel, segment, and junction
+    # kinetic paths. The forecasting node-series path (attach_node_series) still
+    # calls baseline_relative_curve with the default (unfloored) denominator, so
+    # refuse rather than silently half-apply it there.
+    if baseline_floor_frac > 0.0 and attach_node_series:
         raise NotImplementedError(
-            "baseline_floor_frac > 0 is only wired into voxel-mode kinetic "
-            f"features (got node_mode={node_mode!r}, attach_node_series="
-            f"{attach_node_series}). Thread it through the segment/junction/"
-            "node-series paths before using it there."
+            "baseline_floor_frac > 0 is not yet wired into the forecasting "
+            "node-series path (attach_node_series=True). Thread it through "
+            "gnn/pretrain/node_series.py before using it there."
         )
     study_dir = mask_path.parent
 
@@ -627,6 +626,7 @@ def _build_case(
                 time_axis,
                 baseline_frame_count=baseline_frame_count,
                 relative_enhancement=relative_enhancement,
+                baseline_floor_frac=baseline_floor_frac,
             )
         num_connected_components = int(data.num_connected_components)
     else:
@@ -639,6 +639,7 @@ def _build_case(
                     time_axis,
                     baseline_frame_count=baseline_frame_count,
                     relative_enhancement=relative_enhancement,
+                    baseline_floor_frac=baseline_floor_frac,
                 )
         else:
             with _stage_timer(stage_samples, "peak_time"):

--- a/gnn/junction_graph.py
+++ b/gnn/junction_graph.py
@@ -116,6 +116,7 @@ def _junction_node_features(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> dict[str, float]:
     """Per-voxel features for one junction/endpoint voxel, plus its degree.
 
@@ -142,6 +143,7 @@ def _junction_node_features(
         time_axis,
         baseline_frame_count=baseline_frame_count,
         relative_enhancement=relative_enhancement,
+        baseline_floor_frac=baseline_floor_frac,
     )
     tte_idx = kinetic["tte_idx"]
     features = {
@@ -173,6 +175,7 @@ def build_junction_graph(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> Data:
     """Build the segment-as-edge (junction) graph from a voxel skeleton graph.
 
@@ -231,6 +234,7 @@ def build_junction_graph(
             bifurcation_summary.get(node),
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         )
         for name in JUNCTION_NODE_FEATURE_ATTR:
             node_columns[name].append(features[name])
@@ -251,6 +255,7 @@ def build_junction_graph(
             voxel_graph,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         )
         directed = [(u, v)] if u == v else [(u, v), (v, u)]
         for a, b in directed:

--- a/gnn/kinetics.py
+++ b/gnn/kinetics.py
@@ -52,6 +52,7 @@ def baseline_relative_curve(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> np.ndarray:
     """Baseline-reference a DCE curve (or stack of curves) along the time axis.
 
@@ -77,17 +78,32 @@ def baseline_relative_curve(
     n_timepoints = arr.shape[-1]
     if not 1 <= baseline_frame_count < n_timepoints:
         raise ValueError("baseline_frame_count must be in [1, n_timepoints)")
+    if baseline_floor_frac < 0.0:
+        raise ValueError("baseline_floor_frac must be >= 0")
     baseline = arr[..., :baseline_frame_count].mean(axis=-1, keepdims=True)
     difference = arr - baseline
     if not relative_enhancement:
         return difference
-    # Divide only where the baseline is usable; rows with a non-finite or
-    # <= float32-eps baseline stay zero (matches the kinetic path). Using
+    # Denominator for the relative transform. By default it is the raw baseline
+    # (historical behavior, only the exact-zero guard below). When
+    # ``baseline_floor_frac > 0`` the denominator is floored at that fraction of
+    # each row's OWN signal scale (max |S| over time), so a near-void baseline
+    # can't turn ``(S - S0)/S0`` into a divide-by-noise artifact: a voxel whose
+    # baseline is a tiny fraction of its own peak signal would otherwise report
+    # relative enhancement in the thousands-to-millions (physiological is ~0-5).
+    # The floor caps peak relative enhancement at ~1/baseline_floor_frac and
+    # leaves normal voxels (baseline >> floor) untouched. See AUDITING_RESULTS.md.
+    denom = baseline
+    if baseline_floor_frac > 0.0:
+        signal_scale = np.max(np.abs(arr), axis=-1, keepdims=True)
+        denom = np.maximum(baseline, baseline_floor_frac * signal_scale)
+    # Divide only where the denominator is usable; rows with a non-finite or
+    # <= float32-eps denominator stay zero (matches the kinetic path). Using
     # ``np.divide(where=...)`` skips the invalid division entirely rather than
     # computing it and masking afterwards, so no divide-by-zero warning fires.
-    usable = np.isfinite(baseline) & (baseline > np.finfo(np.float32).eps)
+    usable = np.isfinite(denom) & (denom > np.finfo(np.float32).eps)
     enhancement = np.zeros_like(difference)
-    np.divide(difference, baseline, out=enhancement, where=usable)
+    np.divide(difference, denom, out=enhancement, where=usable)
     return enhancement
 
 
@@ -97,6 +113,7 @@ def node_kinetic_features(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> dict[str, object]:
     """Derive kinetic features from one voxel's unscaled DCE signal curve.
 
@@ -118,6 +135,7 @@ def node_kinetic_features(
             signal,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         ),
         dtype=float,
     )

--- a/gnn/kinetics.py
+++ b/gnn/kinetics.py
@@ -53,6 +53,7 @@ def baseline_relative_curve(
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
     baseline_floor_frac: float = 0.0,
+    baseline_override: np.ndarray | float | None = None,
 ) -> np.ndarray:
     """Baseline-reference a DCE curve (or stack of curves) along the time axis.
 
@@ -80,7 +81,17 @@ def baseline_relative_curve(
         raise ValueError("baseline_frame_count must be in [1, n_timepoints)")
     if baseline_floor_frac < 0.0:
         raise ValueError("baseline_floor_frac must be >= 0")
-    baseline = arr[..., :baseline_frame_count].mean(axis=-1, keepdims=True)
+    if baseline_override is None:
+        baseline = arr[..., :baseline_frame_count].mean(axis=-1, keepdims=True)
+    else:
+        # A repaired baseline supplied by the caller (gnn.baseline_validity):
+        # this voxel's own precontrast frames were not usable, so its enhancement
+        # is referenced against a locally imputed S0 instead.
+        baseline = np.asarray(baseline_override, dtype=float)
+        baseline = np.broadcast_to(
+            baseline.reshape(baseline.shape + (1,) * (arr.ndim - baseline.ndim)),
+            arr.shape[:-1] + (1,),
+        )
     difference = arr - baseline
     if not relative_enhancement:
         return difference
@@ -114,6 +125,7 @@ def node_kinetic_features(
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
     baseline_floor_frac: float = 0.0,
+    baseline_override: float | None = None,
 ) -> dict[str, object]:
     """Derive kinetic features from one voxel's unscaled DCE signal curve.
 
@@ -129,13 +141,18 @@ def node_kinetic_features(
     if not 1 <= baseline_frame_count < signal.size:
         raise ValueError("baseline_frame_count must be in [1, n_timepoints)")
 
-    baseline = float(np.mean(signal[:baseline_frame_count]))
+    baseline = (
+        float(np.mean(signal[:baseline_frame_count]))
+        if baseline_override is None
+        else float(baseline_override)
+    )
     enhancement = np.asarray(
         baseline_relative_curve(
             signal,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
             baseline_floor_frac=baseline_floor_frac,
+            baseline_override=baseline_override,
         ),
         dtype=float,
     )

--- a/gnn/model.py
+++ b/gnn/model.py
@@ -45,19 +45,62 @@ POOLING_WIDTHS: dict[str, int] = {"mean": 1, "mean_max": 2, "mean_max_sum": 3}
 
 
 def _graph_readout(
-    h: torch.Tensor, batch_index: torch.Tensor, pooling: str
+    h: torch.Tensor,
+    batch_index: torch.Tensor,
+    pooling: str,
+    node_mask: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Concatenate the pooled node embeddings selected by ``pooling``.
 
     ``"mean"`` reproduces the original single ``global_mean_pool`` readout;
     ``"mean_max"``/``"mean_max_sum"`` append global max (and add) pools so the
     graph embedding keeps extreme/aggregate node signal, not just the average.
+
+    ``node_mask`` (shape ``(num_nodes,)``, True = keep) restricts every pool to
+    the marked nodes. Nodes it excludes still took part in message passing --
+    they shaped their neighbours' embeddings in the conv stack -- but contribute
+    nothing to the graph vector, so they cannot reach the graph-level loss. This
+    is the whole-graph analogue of masking a per-node loss: pooling is the last
+    point at which nodes are individually addressable.
+
+    The pools are computed by weighting rather than by dropping rows, so every
+    graph in the batch keeps its slot in the output even when some of its nodes
+    are masked out. A graph with no kept nodes has no defined readout and raises
+    rather than emitting NaN.
     """
-    parts = [global_mean_pool(h, batch_index)]
+    if node_mask is None:
+        parts = [global_mean_pool(h, batch_index)]
+        if pooling in ("mean_max", "mean_max_sum"):
+            parts.append(global_max_pool(h, batch_index))
+        if pooling == "mean_max_sum":
+            parts.append(global_add_pool(h, batch_index))
+        return torch.cat(parts, dim=1)
+
+    if node_mask.shape != batch_index.shape:
+        raise ValueError(
+            f"node_mask shape {tuple(node_mask.shape)} does not match "
+            f"batch_index {tuple(batch_index.shape)}"
+        )
+    keep = node_mask.to(dtype=torch.bool)
+    weights = keep.to(h.dtype).unsqueeze(-1)
+    kept_per_graph = global_add_pool(weights, batch_index)
+    if bool((kept_per_graph == 0).any()):
+        empty = int((kept_per_graph == 0).sum())
+        raise ValueError(
+            f"{empty} graph(s) in this batch have no unmasked nodes, so their "
+            "readout is undefined. Every graph must retain at least one node "
+            "with an observed baseline."
+        )
+    masked_sum = global_add_pool(h * weights, batch_index)
+    parts = [masked_sum / kept_per_graph]
     if pooling in ("mean_max", "mean_max_sum"):
-        parts.append(global_max_pool(h, batch_index))
+        # Excluded rows must lose the max outright, so push them to the dtype's
+        # floor rather than to 0 -- a genuine all-negative embedding would
+        # otherwise be beaten by a masked node.
+        floored = h.masked_fill(~keep.unsqueeze(-1), torch.finfo(h.dtype).min)
+        parts.append(global_max_pool(floored, batch_index))
     if pooling == "mean_max_sum":
-        parts.append(global_add_pool(h, batch_index))
+        parts.append(masked_sum)
     return torch.cat(parts, dim=1)
 
 
@@ -106,18 +149,21 @@ class GCNClassifier(nn.Module):
         edge_index: torch.Tensor,
         batch_index: torch.Tensor,
         graph_features: torch.Tensor | None = None,
+        node_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Return one raw logit per graph in the batch (shape ``(batch_size,)``).
 
         ``graph_features`` (shape ``(batch_size, graph_dim)``) is required
-        when ``graph_dim > 0`` and ignored otherwise.
+        when ``graph_dim > 0`` and ignored otherwise. ``node_mask`` restricts the
+        readout to the marked nodes without removing them from message passing
+        (see ``_graph_readout``).
         """
         h = x
         for conv in self.convs:
             h = conv(h, edge_index)
             h = torch.relu(h)
             h = self.dropout(h)
-        pooled = _graph_readout(h, batch_index, self.pooling)
+        pooled = _graph_readout(h, batch_index, self.pooling, node_mask)
         if self.graph_dim > 0:
             if graph_features is None:
                 raise ValueError("graph_features is required when graph_dim > 0")

--- a/gnn/pretrain/__init__.py
+++ b/gnn/pretrain/__init__.py
@@ -1,4 +1,4 @@
-"""Self-supervised contrast-forecasting pretraining for the vessel-graph GNN.
+"""Self-supervised contrast forecasting for UChicago vessel graphs.
 
 Implements the voxel-as-node pilot from ``docs/design/contrast_pretraining.md``:
 pretrain an encoder to forecast each node's *future* contrast enhancement from
@@ -6,20 +6,18 @@ its own and its neighbours' earlier frames, so the encoder learns how the bolus
 propagates across vascular edges (the perfusion structure we hope transfers to
 downstream pCR prediction).
 
-The design decisions this package commits to (see the design doc §8a):
+The production contract is implemented by :mod:`gnn.pretrain.uchicago`:
 
-- **Target** = baseline-subtracted enhancement (frame-0 baseline, no FFT), the
-  same convention voxel-mode kinetics already use (``gnn.kinetics``,
-  ``gnn.data_loader._attach_node_features``).
+- **Target** = relative enhancement against a graph-neighbour-repaired baseline,
+  with original baseline validity retained as a separate channel and loss mask.
 - **Temporal encoder** = per-frame GNN encoder + a per-node recurrent temporal
   head (alternative (b) in the doc): reuses the existing ``GCNConv`` machinery
   and keeps "how the graph mixes" separate from "how time is modelled".
 - **Graph ablation** = a message-passing-free per-node forecaster with the same
   temporal head, to run the doc's §7.ii "does the graph matter" check.
 
-Scope: this is the first-pass pilot. It is validated on synthetic graphs; the
-UChicago data pipeline is not ready, and any run against placeholder (e.g. Duke)
-data is a plumbing smoke test only, not a result.
+``gnn.pretrain.duke_forecast`` remains a historical placeholder-data smoke; it
+is not the UChicago production entrypoint.
 """
 
 from __future__ import annotations
@@ -27,7 +25,12 @@ from __future__ import annotations
 from gnn.pretrain.baselines import last_frame_forecast, temporal_mean_forecast
 from gnn.pretrain.forecast import ForecastHorizon, split_forecast_window
 from gnn.pretrain.loss import masked_mae
-from gnn.pretrain.model import ContrastForecastGNN, PerNodeForecaster
+from gnn.pretrain.model import (
+    ContrastForecastGNN,
+    PerNodeForecaster,
+    PerNodeTemporalEncoder,
+    TemporalGraphEncoder,
+)
 from gnn.pretrain.node_series import (
     junction_node_series,
     segment_node_series,
@@ -38,6 +41,8 @@ __all__ = [
     "ContrastForecastGNN",
     "ForecastHorizon",
     "PerNodeForecaster",
+    "PerNodeTemporalEncoder",
+    "TemporalGraphEncoder",
     "junction_node_series",
     "last_frame_forecast",
     "masked_mae",

--- a/gnn/pretrain/checkpoint.py
+++ b/gnn/pretrain/checkpoint.py
@@ -1,0 +1,84 @@
+"""Strict encoder-only checkpoints for temporal weight transfer."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+
+def _git_commit() -> str:
+    result = subprocess.run(  # noqa: S603
+        ["git", "rev-parse", "HEAD"],  # noqa: S607
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def save_encoder_checkpoint(
+    path: str | Path,
+    *,
+    model: nn.Module,
+    preprocessing_contract: dict[str, Any],
+    data_manifest: str | Path,
+    epoch: int,
+    validation_mae: float,
+) -> None:
+    """Save only the reusable encoder and its complete construction contract."""
+    encoder = getattr(model, "encoder", None)
+    if encoder is None or not hasattr(encoder, "config"):
+        raise TypeError("model must expose an encoder with a config() method")
+    required_contract = {
+        "baseline_frame_count_source",
+        "enhancement",
+        "baseline_imputation",
+        "validity_mask_policy",
+        "time_anchor",
+    }
+    missing = required_contract - set(preprocessing_contract)
+    if missing:
+        raise ValueError(
+            f"preprocessing_contract is missing required fields: {sorted(missing)}"
+        )
+    payload = {
+        "encoder_state_dict": encoder.state_dict(),
+        "encoder_config": encoder.config(),
+        "preprocessing_contract": dict(preprocessing_contract),
+        "git_commit": _git_commit(),
+        "data_manifest": str(data_manifest),
+        "epoch": int(epoch),
+        "validation_mae": float(validation_mae),
+    }
+    torch.save(payload, Path(path))
+
+
+def load_checkpoint(path: str | Path) -> dict[str, Any]:
+    """Load a checkpoint and fail if any weight-transfer field is absent."""
+    checkpoint = torch.load(Path(path), map_location="cpu")
+    required = {
+        "encoder_state_dict",
+        "encoder_config",
+        "preprocessing_contract",
+        "git_commit",
+        "data_manifest",
+        "epoch",
+        "validation_mae",
+    }
+    missing = required - set(checkpoint)
+    if missing:
+        raise ValueError(f"encoder checkpoint is missing fields: {sorted(missing)}")
+    return checkpoint
+
+
+DEFAULT_PREPROCESSING_CONTRACT = {
+    "baseline_frame_count_source": "run_summary.kinetic_feature_policy",
+    "enhancement": "(S-S0_imputed)/S0_imputed",
+    "baseline_imputation": "simultaneous_iterative_neighbor_median",
+    "validity_mask_policy": "finite_S0_and_S0_gt_0.05_case_median_S0",
+    "time_anchor": "minutes_since_last_baseline_acquisition",
+}

--- a/gnn/pretrain/forecast.py
+++ b/gnn/pretrain/forecast.py
@@ -147,3 +147,52 @@ def tile_forecast_windows(
             )
         )
     return tiles
+
+
+def all_forecast_windows(
+    series: torch.Tensor,
+    times_seconds: torch.Tensor,
+    horizon: ForecastHorizon,
+    *,
+    baseline_frame_count: int,
+) -> list[tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Return every eligible fixed-length window for one exam.
+
+    Starts span ``B - 1`` through the last complete 3+2 window, matching the
+    temporal-transfer plan. Acquisition times are expressed in minutes relative
+    to the exam's last baseline frame, not to an inferred injection time.
+    """
+    if series.ndim != _NDIM_2D:
+        raise ValueError(f"series must be 2D (N, T); got shape {tuple(series.shape)}")
+    num_timepoints = series.shape[1]
+    if times_seconds.ndim != 1 or times_seconds.shape[0] != num_timepoints:
+        raise ValueError(
+            f"times_seconds must be 1D of length T={num_timepoints}; "
+            f"got {tuple(times_seconds.shape)}"
+        )
+    if not 1 <= baseline_frame_count < num_timepoints:
+        raise ValueError(
+            f"baseline_frame_count must be in [1, T={num_timepoints}); "
+            f"got {baseline_frame_count}"
+        )
+    first = baseline_frame_count - 1
+    last = num_timepoints - horizon.window
+    if first > last:
+        raise ValueError(
+            f"exam has no eligible window: B={baseline_frame_count}, "
+            f"T={num_timepoints}, window={horizon.window}"
+        )
+    times_minutes = (times_seconds - times_seconds[baseline_frame_count - 1]) / 60.0
+    windows = []
+    for start in range(first, last + 1):
+        cut = start + horizon.input_len
+        end = start + horizon.window
+        windows.append(
+            (
+                series[:, start:cut],
+                series[:, cut:end],
+                times_minutes[start:cut],
+                times_minutes[cut:end],
+            )
+        )
+    return windows

--- a/gnn/pretrain/model.py
+++ b/gnn/pretrain/model.py
@@ -1,134 +1,24 @@
-"""Contrast-forecasting models: encoder (b) and the graph-free ablation.
+"""Forecasting heads around the shared temporal encoders.
 
-Both predict, for every node, the contrast enhancement at a set of future query
-times from an input horizon of ``(N, input_len, in_channels)`` per-frame node
-features plus the acquisition times of those frames. They share a temporal head
-(a per-node GRU + a time-conditioned decoder) and differ only in how each
-*frame* is spatially encoded -- which is exactly the comparison the design doc's
-§7.ii "does the graph matter" ablation needs:
-
-- ``ContrastForecastGNN`` (design doc alternative (b)): each frame is encoded by
-  a shared ``GCNConv`` stack, so a node's per-frame embedding depends on its
-  neighbours' contemporaneous contrast -- the mechanism by which the model can
-  learn bolus propagation across vascular edges. Reuses ``GCNConv`` exactly as
-  ``gnn.model.GCNClassifier`` does.
-- ``PerNodeForecaster``: each frame is encoded by a per-node MLP with **no
-  message passing**. Same temporal head, same capacity knobs; the only thing
-  removed is the graph. If this matches the GNN on held-out forecasting loss,
-  the "graph-ey" defense (design doc §5) is not what is being learned.
-
-**Physical time (design review issue 3a).** UFAST cadence is irregular and
-varies several-fold between exams, so frame *index* is not frame *time*. Both
-models therefore (1) append each input frame's elapsed acquisition seconds as an
-extra encoder channel (the "delta-t channel", decision 1a), and (2) condition
-the decoder on the elapsed seconds of each frame it is asked to predict
-(decision 1b), so it forecasts "enhancement at +tau seconds" rather than "at
-output slot k". Times are elapsed seconds from the window's first input frame,
-shared across nodes (anatomy is static within a scan; only contrast varies).
-
-The temporal encoder is deliberately kept separate from the spatial one
-(alternative (b), not the DCGRU fusion of alternative (a)): it is the cheapest
-path to a falsifying pilot and keeps the two design choices independent.
+Only the decoder is forecasting-specific.  The encoder objects are also used by
+the downstream pCR classifiers in :mod:`gnn.temporal_model`, making checkpoint
+transfer exact and strict.
 """
 
 from __future__ import annotations
 
 import torch
 from torch import nn
-from torch_geometric.nn import GCNConv
 
-_NDIM_3D = 3  # (num_nodes, input_len, in_channels)
-_TIME_CHANNELS = 1  # elapsed acquisition seconds, appended per frame / per query
-
-
-def _augment_with_time(x_seq: torch.Tensor, input_times: torch.Tensor) -> torch.Tensor:
-    """Append each input frame's elapsed time as an extra channel.
-
-    ``x_seq`` ``(N, input_len, C)`` + ``input_times`` ``(input_len,)`` ->
-    ``(N, input_len, C + 1)``. The time axis is shared across nodes, so it is
-    broadcast over the node dimension.
-    """
-    if x_seq.ndim != _NDIM_3D:
-        raise ValueError(
-            f"x_seq must be 3D (N, input_len, C); got {tuple(x_seq.shape)}"
-        )
-    num_nodes, input_len, _ = x_seq.shape
-    if input_times.ndim != 1 or input_times.shape[0] != input_len:
-        raise ValueError(
-            f"input_times must be 1D of length input_len={input_len}; "
-            f"got shape {tuple(input_times.shape)}"
-        )
-    times = (
-        input_times.to(x_seq.dtype)
-        .view(1, input_len, _TIME_CHANNELS)
-        .expand(num_nodes, input_len, _TIME_CHANNELS)
-    )
-    return torch.cat([x_seq, times], dim=-1)
-
-
-class _TemporalForecastHead(nn.Module):
-    """Per-node GRU over frame embeddings -> time-conditioned query decoder.
-
-    Consumes a ``(N, input_len, hidden)`` sequence of per-frame node embeddings
-    (nodes are the batch dimension, frames the sequence), runs a GRU, and takes
-    the final hidden state as a per-node summary of the input horizon. The
-    decoder is **time-conditioned** (design review decision 1b): for each target
-    time ``tau`` (elapsed seconds from the window start) it predicts that node's
-    enhancement from an MLP on ``[hidden_state, tau]``. It thus predicts
-    "enhancement at +tau seconds", not "enhancement at output slot k", so one
-    model handles the irregular / exam-varying target spacing that
-    non-overlapping tiling produces -- and any number of target frames. Shared by
-    both encoders so the only difference between them is spatial, never temporal.
-    """
-
-    def __init__(self, hidden_dim: int, num_gru_layers: int) -> None:
-        super().__init__()
-        self.gru = nn.GRU(
-            input_size=hidden_dim,
-            hidden_size=hidden_dim,
-            num_layers=num_gru_layers,
-            batch_first=True,
-        )
-        self.decoder = nn.Sequential(
-            nn.Linear(hidden_dim + _TIME_CHANNELS, hidden_dim),
-            nn.ReLU(),
-            nn.Linear(hidden_dim, 1),
-        )
-
-    def forward(
-        self, frame_embeddings: torch.Tensor, target_times: torch.Tensor
-    ) -> torch.Tensor:
-        """``(N, input_len, hidden)`` + ``(target_len,)`` -> ``(N, target_len)``."""
-        if target_times.ndim != 1:
-            raise ValueError(
-                f"target_times must be 1D (target_len,); got {tuple(target_times.shape)}"
-            )
-        output, _ = self.gru(frame_embeddings)
-        last = output[:, -1, :]  # (N, hidden)
-        num_nodes, hidden_dim = last.shape
-        num_targets = target_times.shape[0]
-        hidden_expanded = last.unsqueeze(1).expand(num_nodes, num_targets, hidden_dim)
-        tau = (
-            target_times.to(last.dtype)
-            .view(1, num_targets, _TIME_CHANNELS)
-            .expand(num_nodes, num_targets, _TIME_CHANNELS)
-        )
-        decoder_input = torch.cat([hidden_expanded, tau], dim=-1)
-        return self.decoder(decoder_input).squeeze(-1)
-
-
-def _check_common_args(in_channels: int, hidden_dim: int, num_layers: int) -> None:
-    """Shared positivity checks (fail-fast, mirroring ``gnn.model``)."""
-    if in_channels <= 0:
-        raise ValueError(f"in_channels must be positive, got {in_channels}")
-    if hidden_dim <= 0:
-        raise ValueError(f"hidden_dim must be positive, got {hidden_dim}")
-    if num_layers < 1:
-        raise ValueError(f"num_layers must be >= 1, got {num_layers}")
+from gnn.temporal_model import (
+    PerNodeTemporalEncoder,
+    TemporalGraphEncoder,
+    TimeConditionedForecastDecoder,
+)
 
 
 class ContrastForecastGNN(nn.Module):
-    """Per-frame ``GCNConv`` encoder + per-node temporal head (design doc (b))."""
+    """TemporalGraphEncoder followed by a time-conditioned forecast decoder."""
 
     def __init__(
         self,
@@ -138,64 +28,43 @@ class ContrastForecastGNN(nn.Module):
         num_layers: int = 2,
         num_gru_layers: int = 1,
         dropout: float = 0.2,
+        encoder: TemporalGraphEncoder | None = None,
     ) -> None:
         super().__init__()
-        _check_common_args(in_channels, hidden_dim, num_layers)
-        self.convs = nn.ModuleList()
-        in_dim = in_channels + _TIME_CHANNELS  # raw enhancement + elapsed time
-        for _ in range(num_layers):
-            self.convs.append(GCNConv(in_dim, hidden_dim))
-            in_dim = hidden_dim
-        self.dropout = nn.Dropout(p=dropout)
-        self.temporal = _TemporalForecastHead(hidden_dim, num_gru_layers)
-
-    def _encode_frame(self, x: torch.Tensor, edge_index: torch.Tensor) -> torch.Tensor:
-        """One frame's node features ``(N, C+1)`` -> embedding ``(N, hidden)``."""
-        h = x
-        for conv in self.convs:
-            h = conv(h, edge_index)
-            h = torch.relu(h)
-            h = self.dropout(h)
-        return h
+        self.encoder = encoder or TemporalGraphEncoder(
+            signal_channels=in_channels,
+            hidden_dim=hidden_dim,
+            num_gcn_layers=num_layers,
+            num_gru_layers=num_gru_layers,
+            dropout=dropout,
+        )
+        self.decoder = TimeConditionedForecastDecoder(self.encoder.hidden_dim)
 
     def forward(
         self,
-        x_seq: torch.Tensor,
+        node_series: torch.Tensor,
         edge_index: torch.Tensor,
-        input_times: torch.Tensor,
-        target_times: torch.Tensor,
+        acquisition_times: torch.Tensor,
+        baseline_observed: torch.Tensor,
+        target_times: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Forecast ``(N, target_len)`` from a timed input horizon.
-
-        ``x_seq`` is ``(N, input_len, in_channels)``; ``input_times`` /
-        ``target_times`` are elapsed seconds ``(input_len,)`` / ``(target_len,)``
-        from the window start. Each frame (with its elapsed-time channel appended)
-        is passed through the shared ``GCNConv`` stack over the *same*
-        ``edge_index`` (anatomy is static within a scan; only contrast varies),
-        producing a per-frame node embedding; the GRU integrates them over time
-        and the time-conditioned decoder reads them out at ``target_times``.
-        ``edge_index`` is the (batched) vascular adjacency -- the message-passing
-        path whose contribution the ``PerNodeForecaster`` ablation removes.
-        """
-        x_aug = _augment_with_time(x_seq, input_times)
-        frame_embeddings = torch.stack(
-            [
-                self._encode_frame(x_aug[:, t, :], edge_index)
-                for t in range(x_aug.shape[1])
-            ],
-            dim=1,
+        # Compatibility for the historical Duke smoke call
+        # model(x, edge, input_times, target_times). Production UChicago code
+        # passes both validity and target times explicitly.
+        if target_times is None:
+            target_times = baseline_observed
+            baseline_observed = torch.ones(
+                node_series.shape[0], dtype=torch.bool, device=node_series.device
+            )
+        embedding = self.encoder(
+            node_series, edge_index, acquisition_times, baseline_observed
         )
-        return self.temporal(frame_embeddings, target_times)
+        target_horizon = target_times - acquisition_times[-1]
+        return self.decoder(embedding, target_horizon)
 
 
 class PerNodeForecaster(nn.Module):
-    """Graph-free counterpart of ``ContrastForecastGNN`` (design doc §7.ii ablation).
-
-    Identical temporal head; each frame is encoded by a per-node MLP instead of a
-    ``GCNConv`` stack, so no information ever crosses an edge. ``forward`` takes
-    no ``edge_index`` -- the absence of the graph is structural, not a runtime
-    flag, so the ablation cannot accidentally leak message passing.
-    """
+    """Graph-free matched encoder followed by the same forecast decoder."""
 
     def __init__(
         self,
@@ -205,28 +74,39 @@ class PerNodeForecaster(nn.Module):
         num_layers: int = 2,
         num_gru_layers: int = 1,
         dropout: float = 0.2,
+        encoder: PerNodeTemporalEncoder | None = None,
     ) -> None:
         super().__init__()
-        _check_common_args(in_channels, hidden_dim, num_layers)
-        layers: list[nn.Module] = []
-        in_dim = in_channels + _TIME_CHANNELS  # raw enhancement + elapsed time
-        for _ in range(num_layers):
-            layers.append(nn.Linear(in_dim, hidden_dim))
-            layers.append(nn.ReLU())
-            layers.append(nn.Dropout(p=dropout))
-            in_dim = hidden_dim
-        self.frame_encoder = nn.Sequential(*layers)
-        self.temporal = _TemporalForecastHead(hidden_dim, num_gru_layers)
+        self.encoder = encoder or PerNodeTemporalEncoder(
+            signal_channels=in_channels,
+            hidden_dim=hidden_dim,
+            num_gcn_layers=num_layers,
+            num_gru_layers=num_gru_layers,
+            dropout=dropout,
+        )
+        self.decoder = TimeConditionedForecastDecoder(self.encoder.hidden_dim)
 
     def forward(
         self,
-        x_seq: torch.Tensor,
-        input_times: torch.Tensor,
-        target_times: torch.Tensor,
+        node_series: torch.Tensor,
+        acquisition_times: torch.Tensor,
+        baseline_observed: torch.Tensor,
+        target_times: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Forecast ``(N, target_len)`` from a timed input horizon, no edges."""
-        x_aug = _augment_with_time(x_seq, input_times)
-        num_nodes, input_len, channels = x_aug.shape
-        flat = x_aug.reshape(num_nodes * input_len, channels)
-        embedded = self.frame_encoder(flat).reshape(num_nodes, input_len, -1)
-        return self.temporal(embedded, target_times)
+        if target_times is None:
+            target_times = baseline_observed
+            baseline_observed = torch.ones(
+                node_series.shape[0], dtype=torch.bool, device=node_series.device
+            )
+        embedding = self.encoder(node_series, acquisition_times, baseline_observed)
+        target_horizon = target_times - acquisition_times[-1]
+        return self.decoder(embedding, target_horizon)
+
+
+__all__ = [
+    "ContrastForecastGNN",
+    "PerNodeForecaster",
+    "PerNodeTemporalEncoder",
+    "TemporalGraphEncoder",
+    "TimeConditionedForecastDecoder",
+]

--- a/gnn/pretrain/node_series.py
+++ b/gnn/pretrain/node_series.py
@@ -45,6 +45,7 @@ def voxel_node_series(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_override: np.ndarray | None = None,
 ) -> np.ndarray:
     """Stack each voxel node's baseline-referenced DCE curve into ``(num_nodes, T)``.
 
@@ -75,6 +76,7 @@ def voxel_node_series(
         series,
         baseline_frame_count=baseline_frame_count,
         relative_enhancement=relative_enhancement,
+        baseline_override=baseline_override,
     )
     return enhancement.astype(np.float32)
 

--- a/gnn/pretrain/train.py
+++ b/gnn/pretrain/train.py
@@ -50,8 +50,25 @@ class ForecastGraph:
     x_seq: torch.Tensor  # (N, input_len, C)
     target: torch.Tensor  # (N, target_len)
     edge_index: torch.Tensor  # (2, E)
-    input_times: torch.Tensor  # (input_len,) elapsed seconds from window start
-    target_times: torch.Tensor  # (target_len,) elapsed seconds from window start
+    input_times: torch.Tensor  # (input_len,) acquisition times
+    target_times: torch.Tensor  # (target_len,) minutes from last baseline
+    target_mask: torch.Tensor | None = None  # (N, target_len)
+    baseline_observed: torch.Tensor | None = None  # (N,) original validity
+    exam_id: str = ""
+
+    def __post_init__(self) -> None:
+        """Fill compatibility defaults for legacy all-valid smoke fixtures."""
+        if self.target_mask is None:
+            self.target_mask = torch.isfinite(self.target)
+        if self.baseline_observed is None:
+            self.baseline_observed = torch.ones(
+                self.x_seq.shape[0], dtype=torch.bool, device=self.x_seq.device
+            )
+
+    @property
+    def acquisition_times(self) -> torch.Tensor:
+        """Explicit name used by the shared temporal encoder."""
+        return self.input_times
 
 
 def build_synthetic_forecast_graphs(
@@ -100,47 +117,90 @@ def build_synthetic_forecast_graphs(
                 edge_index=edge_index,
                 input_times=input_times,
                 target_times=target_times,
+                target_mask=torch.ones_like(target, dtype=torch.bool),
+                baseline_observed=torch.ones(num_nodes, dtype=torch.bool),
             )
         )
     return graphs
 
 
-def _mean_graph_mae(
-    per_graph_errors: list[torch.Tensor], node_counts: list[int]
+def _exam_groups(
+    graphs: list[ForecastGraph] | list[list[ForecastGraph]],
+) -> list[list[ForecastGraph]]:
+    """Normalize the legacy one-window-per-exam form to grouped exam windows."""
+    if not graphs:
+        raise ValueError("at least one forecast exam is required")
+    if isinstance(graphs[0], ForecastGraph):
+        return [[graph] for graph in graphs]  # type: ignore[list-item]
+    groups = graphs  # type: ignore[assignment]
+    if any(not group for group in groups):
+        raise ValueError("every exam must contain at least one eligible window")
+    return groups
+
+
+def _mean_exam_mae(per_exam_window_errors: list[list[torch.Tensor]]) -> float:
+    """Average windows within an exam, then exams equally."""
+    exam_means = [
+        torch.stack(errors).mean().item() for errors in per_exam_window_errors
+    ]
+    return float(sum(exam_means) / len(exam_means))
+
+
+@torch.no_grad()
+def evaluate_gnn(
+    model: ContrastForecastGNN,
+    graphs: list[ForecastGraph] | list[list[ForecastGraph]],
 ) -> float:
-    """Node-weighted mean MAE across graphs (a node is a node, regardless of graph)."""
-    total = sum(
-        err.item() * n for err, n in zip(per_graph_errors, node_counts, strict=True)
-    )
-    return total / sum(node_counts)
+    """Held-out MAE averaged within exam and then across exams."""
+    model.eval()
+    errors = [
+        [
+            masked_mae(
+                model(
+                    g.x_seq,
+                    g.edge_index,
+                    g.acquisition_times,
+                    g.baseline_observed,
+                    g.target_times,
+                ),
+                g.target,
+                g.target_mask,
+            )
+            for g in exam
+        ]
+        for exam in _exam_groups(graphs)
+    ]
+    return _mean_exam_mae(errors)
 
 
 @torch.no_grad()
-def evaluate_gnn(model: ContrastForecastGNN, graphs: list[ForecastGraph]) -> float:
-    """Node-weighted held-out MAE of the GNN forecaster over ``graphs``."""
+def evaluate_per_node(
+    model: PerNodeForecaster,
+    graphs: list[ForecastGraph] | list[list[ForecastGraph]],
+) -> float:
+    """Held-out graph-free MAE averaged within exam and then across exams."""
     model.eval()
-    errs = [
-        masked_mae(
-            model(g.x_seq, g.edge_index, g.input_times, g.target_times), g.target
-        )
-        for g in graphs
+    errors = [
+        [
+            masked_mae(
+                model(
+                    g.x_seq,
+                    g.acquisition_times,
+                    g.baseline_observed,
+                    g.target_times,
+                ),
+                g.target,
+                g.target_mask,
+            )
+            for g in exam
+        ]
+        for exam in _exam_groups(graphs)
     ]
-    return _mean_graph_mae(errs, [g.x_seq.shape[0] for g in graphs])
-
-
-@torch.no_grad()
-def evaluate_per_node(model: PerNodeForecaster, graphs: list[ForecastGraph]) -> float:
-    """Node-weighted held-out MAE of the graph-free forecaster over ``graphs``."""
-    model.eval()
-    errs = [
-        masked_mae(model(g.x_seq, g.input_times, g.target_times), g.target)
-        for g in graphs
-    ]
-    return _mean_graph_mae(errs, [g.x_seq.shape[0] for g in graphs])
+    return _mean_exam_mae(errors)
 
 
 def _baseline_mae(
-    graphs: list[ForecastGraph],
+    graphs: list[ForecastGraph] | list[list[ForecastGraph]],
     forecast_fn: Callable[[torch.Tensor, int], torch.Tensor],
     target_len: int,
 ) -> float:
@@ -150,20 +210,26 @@ def _baseline_mae(
     contrast enhancement being forecast -- the target signal), consistent with
     the models forecasting that same channel.
     """
-    errs = []
-    for g in graphs:
-        inputs = g.x_seq[:, :, 0]  # (N, input_len) -- the enhancement channel
-        errs.append(masked_mae(forecast_fn(inputs, target_len), g.target))
-    return _mean_graph_mae(errs, [g.x_seq.shape[0] for g in graphs])
+    errors = []
+    for exam in _exam_groups(graphs):
+        exam_errors = []
+        for g in exam:
+            inputs = g.x_seq[:, :, 0]
+            exam_errors.append(
+                masked_mae(forecast_fn(inputs, target_len), g.target, g.target_mask)
+            )
+        errors.append(exam_errors)
+    return _mean_exam_mae(errors)
 
 
 def train_forecaster(
     model: torch.nn.Module,
-    train_graphs: list[ForecastGraph],
+    train_graphs: list[ForecastGraph] | list[list[ForecastGraph]],
     *,
     epochs: int,
     lr: float,
     uses_graph: bool,
+    seed: int = 0,
 ) -> list[float]:
     """Train ``model`` (batch-of-one per graph); return per-epoch mean train MAE.
 
@@ -171,30 +237,45 @@ def train_forecaster(
     the graph-free ablation does not. One optimiser step per graph per epoch.
     """
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    exams = _exam_groups(train_graphs)
+    generator = torch.Generator().manual_seed(seed)
     history: list[float] = []
     for _ in range(epochs):
         model.train()
-        epoch_errs: list[torch.Tensor] = []
-        for g in train_graphs:
+        epoch_errs: list[list[torch.Tensor]] = []
+        order = torch.randperm(len(exams), generator=generator).tolist()
+        for exam_index in order:
+            exam = exams[exam_index]
+            window_index = int(torch.randint(len(exam), (1,), generator=generator))
+            g = exam[window_index]
             optimizer.zero_grad()
             pred = (
-                model(g.x_seq, g.edge_index, g.input_times, g.target_times)
+                model(
+                    g.x_seq,
+                    g.edge_index,
+                    g.acquisition_times,
+                    g.baseline_observed,
+                    g.target_times,
+                )
                 if uses_graph
-                else model(g.x_seq, g.input_times, g.target_times)
+                else model(
+                    g.x_seq,
+                    g.acquisition_times,
+                    g.baseline_observed,
+                    g.target_times,
+                )
             )
-            loss = masked_mae(pred, g.target)
+            loss = masked_mae(pred, g.target, g.target_mask)
             loss.backward()
             optimizer.step()
-            epoch_errs.append(loss.detach())
-        history.append(
-            _mean_graph_mae(epoch_errs, [g.x_seq.shape[0] for g in train_graphs])
-        )
+            epoch_errs.append([loss.detach()])
+        history.append(_mean_exam_mae(epoch_errs))
     return history
 
 
 def run_pretrain_gates(
-    train_graphs: list[ForecastGraph],
-    val_graphs: list[ForecastGraph],
+    train_graphs: list[ForecastGraph] | list[list[ForecastGraph]],
+    val_graphs: list[ForecastGraph] | list[list[ForecastGraph]],
     horizon: ForecastHorizon,
     *,
     in_channels: int = 1,
@@ -220,7 +301,9 @@ def run_pretrain_gates(
         num_layers=num_layers,
         dropout=dropout,
     )
-    train_forecaster(gnn, train_graphs, epochs=epochs, lr=lr, uses_graph=True)
+    train_forecaster(
+        gnn, train_graphs, epochs=epochs, lr=lr, uses_graph=True, seed=seed
+    )
 
     torch.manual_seed(seed)
     per_node = PerNodeForecaster(
@@ -229,7 +312,14 @@ def run_pretrain_gates(
         num_layers=num_layers,
         dropout=dropout,
     )
-    train_forecaster(per_node, train_graphs, epochs=epochs, lr=lr, uses_graph=False)
+    train_forecaster(
+        per_node,
+        train_graphs,
+        epochs=epochs,
+        lr=lr,
+        uses_graph=False,
+        seed=seed,
+    )
 
     gnn_mae = evaluate_gnn(gnn, val_graphs)
     per_node_mae = evaluate_per_node(per_node, val_graphs)

--- a/gnn/pretrain/uchicago.py
+++ b/gnn/pretrain/uchicago.py
@@ -104,9 +104,7 @@ def write_pretraining_readme(
             f"- `{checkpoint_path.name}` SHA-256 `{_sha256(checkpoint_path)}`"
         )
     results_path = args.outdir / "pretraining_results.json"
-    artifacts.append(
-        f"- `{results_path.name}` SHA-256 `{_sha256(results_path)}`"
-    )
+    artifacts.append(f"- `{results_path.name}` SHA-256 `{_sha256(results_path)}`")
     status_text = status if status else "clean"
     readme = f"""# UChicago temporal pretraining result
 
@@ -460,8 +458,7 @@ def main(argv: list[str] | None = None) -> None:
         }
     if args.arm == "both":
         results["graph_helps_forecasting"] = (
-            results["gnn"]["validation_mae"]
-            < results["graph_free"]["validation_mae"]
+            results["gnn"]["validation_mae"] < results["graph_free"]["validation_mae"]
         )
     results["train_patient_count"] = len(
         {str(record["patient_key"]) for record in train_records}

--- a/gnn/pretrain/uchicago.py
+++ b/gnn/pretrain/uchicago.py
@@ -1,0 +1,479 @@
+"""Production UChicago temporal pretraining on manifest-grouped exams.
+
+Unlike :mod:`gnn.pretrain.duke_forecast`, this entrypoint is longitudinal and
+manifest-driven. It loads one exam at a time, samples one eligible 3+2 window
+per exam per epoch, and averages validation windows within exam before averaging
+exams so graph size and series length cannot reweight the metric.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from collections import defaultdict
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+
+from gnn.pretrain.baselines import last_frame_forecast
+from gnn.pretrain.checkpoint import (
+    DEFAULT_PREPROCESSING_CONTRACT,
+    save_encoder_checkpoint,
+)
+from gnn.pretrain.forecast import ForecastHorizon
+from gnn.pretrain.loss import masked_mae
+from gnn.pretrain.model import ContrastForecastGNN, PerNodeForecaster
+from gnn.pretrain.train import ForecastGraph
+from gnn.uchicago_temporal_data import load_temporal_cache_manifest
+
+HORIZON = ForecastHorizon(input_len=3, target_len=2)
+_MIN_SPLIT_PATIENTS = 2
+_NDIM_TEMPORAL = 3
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _git_provenance() -> tuple[str, str]:
+    commit = subprocess.run(  # noqa: S603
+        ["git", "rev-parse", "HEAD"],  # noqa: S607
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    status = subprocess.run(  # noqa: S603
+        ["git", "status", "--short"],  # noqa: S607
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.rstrip()
+    return commit, status
+
+
+def _reproduction_command(args: argparse.Namespace) -> str:
+    values = (
+        ("cache-dir", args.cache_dir),
+        ("outdir", args.outdir),
+        ("epochs", args.epochs),
+        ("hidden-dim", args.hidden_dim),
+        ("num-gcn-layers", args.num_gcn_layers),
+        ("num-gru-layers", args.num_gru_layers),
+        ("dropout", args.dropout),
+        ("learning-rate", args.learning_rate),
+        ("val-fraction", args.val_fraction),
+        ("seed", args.seed),
+        ("arm", args.arm),
+        ("device", args.device),
+    )
+    flags = " ".join(f"--{name} {value}" for name, value in values)
+    return f"python -u -m gnn.pretrain.uchicago {flags}"
+
+
+def write_pretraining_readme(
+    *,
+    args: argparse.Namespace,
+    results: dict[str, object],
+    manifest: dict[str, object],
+) -> Path:
+    """Write the mandatory self-contained provenance note for one result directory."""
+    commit, status = _git_provenance()
+    manifest_path = Path(args.cache_dir) / "temporal_cache_manifest.json"
+    arm_names = [name for name in ("gnn", "graph_free") if name in results]
+    rows = []
+    artifacts = []
+    for arm in arm_names:
+        arm_result = results[arm]
+        rows.append(
+            f"| {arm} | {int(arm_result['best_epoch'])} | "
+            f"{float(arm_result['validation_mae']):.10f} | "
+            f"{float(arm_result['persistence_mae']):.10f} | "
+            f"{bool(arm_result['beats_persistence'])} |"
+        )
+        checkpoint_path = args.outdir / f"{arm}_encoder.pt"
+        artifacts.append(
+            f"- `{checkpoint_path.name}` SHA-256 `{_sha256(checkpoint_path)}`"
+        )
+    results_path = args.outdir / "pretraining_results.json"
+    artifacts.append(
+        f"- `{results_path.name}` SHA-256 `{_sha256(results_path)}`"
+    )
+    status_text = status if status else "clean"
+    readme = f"""# UChicago temporal pretraining result
+
+## Status and question
+
+Complete. Requested arm: `{args.arm}`. This run tests future-frame DCE forecasting;
+it is not a downstream pCR result.
+
+## Results
+
+Lower MAE is better. Validation averages eligible windows within exam and then exams.
+
+| Arm | Best epoch | Validation MAE | Persistence MAE | Beats persistence |
+|---|---:|---:|---:|---|
+{chr(10).join(rows)}
+
+## Data and split
+
+- Cache: `{args.cache_dir}`
+- Cache manifest SHA-256: `{_sha256(manifest_path)}`
+- Source manifest: `{manifest.get('source_manifest')}`
+- Excluded labeled manifest: `{manifest.get('excluded_labeled_manifest')}`
+- Records: {len(manifest['records'])}
+- Train patients: {results['train_patient_count']}
+- Validation patients: {results['val_patient_count']}
+- Split: patient-level, validation fraction {args.val_fraction}, seed {args.seed}
+
+## Configuration
+
+- Epochs: {args.epochs}
+- Hidden dimension: {args.hidden_dim}
+- Per-frame layers: {args.num_gcn_layers}
+- GRU layers: {args.num_gru_layers}
+- Dropout: {args.dropout}
+- Learning rate: {args.learning_rate}
+- Device: {args.device}
+- Forecast window: 3 input frames -> 2 target frames
+- Time anchor: minutes since last baseline acquisition
+
+## Scheduler and artifacts
+
+- Slurm job ID: `{os.environ.get('SLURM_JOB_ID', 'not available')}`
+{chr(10).join(artifacts)}
+
+## Reproduce
+
+```bash
+{_reproduction_command(args)}
+```
+
+## Code provenance
+
+- Git commit: `{commit}`
+- Dirty-worktree status at README creation:
+
+```text
+{status_text}
+```
+
+## Interpretation limit
+
+This single split/seed forecasting result does not establish downstream pCR benefit or
+that graph connectivity is universally useful or useless. Compare matched downstream
+random/pretrained arms with patient-level OOF metrics and uncertainty intervals.
+"""
+    path = args.outdir / "README.md"
+    path.write_text(readme)
+    return path
+
+
+def _record_groups(
+    records: list[dict[str, object]],
+) -> dict[str, list[dict[str, object]]]:
+    grouped: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        grouped[str(record["patient_key"])].append(record)
+    return dict(grouped)
+
+
+def split_records_by_patient(
+    records: list[dict[str, object]], *, val_fraction: float, seed: int
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """Randomly split unique patients, keeping all their exams together."""
+    if not 0.0 < val_fraction < 1.0:
+        raise ValueError("val_fraction must be between 0 and 1")
+    grouped = _record_groups(records)
+    patients = sorted(grouped)
+    if len(patients) < _MIN_SPLIT_PATIENTS:
+        raise ValueError("patient-level pretraining split requires at least 2 patients")
+    generator = torch.Generator().manual_seed(seed)
+    order = torch.randperm(len(patients), generator=generator).tolist()
+    n_val = max(1, round(len(patients) * val_fraction))
+    val_patients = {patients[i] for i in order[:n_val]}
+    train = [r for r in records if str(r["patient_key"]) not in val_patients]
+    val = [r for r in records if str(r["patient_key"]) in val_patients]
+    if {str(r["patient_key"]) for r in train} & val_patients:
+        raise RuntimeError("patient leakage in pretraining split")
+    return train, val
+
+
+def eligible_starts(data: object, horizon: ForecastHorizon = HORIZON) -> list[int]:
+    """Enumerate starts from B-1 through the last complete window."""
+    baseline_count = int(data.baseline_frame_count)
+    total_frames = int(data.node_series.shape[1])
+    starts = list(range(baseline_count - 1, total_frames - horizon.window + 1))
+    if not starts:
+        raise ValueError(
+            f"exam {getattr(data, 'exam_id', '')} has no eligible window: "
+            f"B={baseline_count}, T={total_frames}, window={horizon.window}"
+        )
+    return starts
+
+
+def make_window(
+    data: object, start: int, horizon: ForecastHorizon = HORIZON
+) -> ForecastGraph:
+    """Materialize one masked window using minutes from the last baseline."""
+    if data.node_series.ndim != _NDIM_TEMPORAL or data.node_series.shape[-1] != 1:
+        raise ValueError("node_series must be (num_nodes, T, 1)")
+    if start not in eligible_starts(data, horizon):
+        raise ValueError(f"start={start} is not eligible for this exam")
+    baseline_count = int(data.baseline_frame_count)
+    times = (data.times_seconds - data.times_seconds[baseline_count - 1]) / 60.0
+    cut = start + horizon.input_len
+    end = start + horizon.window
+    inputs = data.node_series[:, start:cut, :]
+    target = data.node_series[:, cut:end, 0]
+    target_mask = data.node_valid[:, None].bool() & torch.isfinite(target)
+    return ForecastGraph(
+        x_seq=torch.nan_to_num(inputs),
+        target=torch.nan_to_num(target),
+        edge_index=data.edge_index,
+        input_times=times[start:cut],
+        target_times=times[cut:end],
+        target_mask=target_mask,
+        baseline_observed=data.node_valid.bool(),
+        exam_id=str(data.exam_id),
+    )
+
+
+def _load_graph(record: dict[str, object], device: torch.device) -> object:
+    data = torch.load(Path(str(record["graph_path"])), map_location="cpu")
+    return data.to(device)
+
+
+def _forward(
+    model: torch.nn.Module, window: ForecastGraph, uses_graph: bool
+) -> torch.Tensor:
+    if uses_graph:
+        return model(
+            window.x_seq,
+            window.edge_index,
+            window.acquisition_times,
+            window.baseline_observed,
+            window.target_times,
+        )
+    return model(
+        window.x_seq,
+        window.acquisition_times,
+        window.baseline_observed,
+        window.target_times,
+    )
+
+
+@torch.no_grad()
+def evaluate_records(
+    model: torch.nn.Module,
+    records: list[dict[str, object]],
+    *,
+    uses_graph: bool,
+    device: torch.device,
+) -> tuple[float, float]:
+    """Return learned-model and persistence MAE, equally weighted by exam."""
+    model.eval()
+    exam_maes = []
+    persistence_maes = []
+    for record in records:
+        data = _load_graph(record, device)
+        learned_windows = []
+        persistence_windows = []
+        for start in eligible_starts(data):
+            window = make_window(data, start)
+            learned_windows.append(
+                masked_mae(
+                    _forward(model, window, uses_graph),
+                    window.target,
+                    window.target_mask,
+                )
+            )
+            persistence_windows.append(
+                masked_mae(
+                    last_frame_forecast(window.x_seq[:, :, 0], HORIZON.target_len),
+                    window.target,
+                    window.target_mask,
+                )
+            )
+        exam_maes.append(torch.stack(learned_windows).mean().item())
+        persistence_maes.append(torch.stack(persistence_windows).mean().item())
+    return (
+        float(sum(exam_maes) / len(exam_maes)),
+        float(sum(persistence_maes) / len(persistence_maes)),
+    )
+
+
+def train_one_encoder(
+    model: torch.nn.Module,
+    train_records: list[dict[str, object]],
+    val_records: list[dict[str, object]],
+    *,
+    uses_graph: bool,
+    epochs: int,
+    learning_rate: float,
+    seed: int,
+    device: torch.device,
+) -> tuple[torch.nn.Module, list[dict[str, float]], float, int, float]:
+    """Train with one random exam window per epoch and inner validation only."""
+    model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    generator = torch.Generator().manual_seed(seed)
+    best_state = None
+    best_val = float("inf")
+    best_epoch = 0
+    best_persistence = float("nan")
+    history = []
+    for epoch in range(1, epochs + 1):
+        model.train()
+        order = torch.randperm(len(train_records), generator=generator).tolist()
+        losses = []
+        for index in order:
+            data = _load_graph(train_records[index], device)
+            starts = eligible_starts(data)
+            choice = int(torch.randint(len(starts), (1,), generator=generator))
+            window = make_window(data, starts[choice])
+            optimizer.zero_grad()
+            loss = masked_mae(
+                _forward(model, window, uses_graph),
+                window.target,
+                window.target_mask,
+            )
+            loss.backward()
+            optimizer.step()
+            losses.append(loss.detach().item())
+        val_mae, persistence_mae = evaluate_records(
+            model, val_records, uses_graph=uses_graph, device=device
+        )
+        train_mae = float(sum(losses) / len(losses))
+        history.append(
+            {"epoch": float(epoch), "train_mae": train_mae, "val_mae": val_mae}
+        )
+        logging.info(
+            "epoch=%d train_mae=%.6f val_mae=%.6f persistence=%.6f",
+            epoch,
+            train_mae,
+            val_mae,
+            persistence_mae,
+        )
+        if val_mae < best_val:
+            best_val = val_mae
+            best_epoch = epoch
+            best_persistence = persistence_mae
+            best_state = deepcopy(model.state_dict())
+    if best_state is None:
+        raise RuntimeError("pretraining produced no checkpoint")
+    model.load_state_dict(best_state)
+    return model, history, best_val, best_epoch, best_persistence
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse production UChicago pretraining settings."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--hidden-dim", type=int, default=32)
+    parser.add_argument("--num-gcn-layers", type=int, default=2)
+    parser.add_argument("--num-gru-layers", type=int, default=1)
+    parser.add_argument("--dropout", type=float, default=0.2)
+    parser.add_argument("--learning-rate", type=float, default=1e-3)
+    parser.add_argument("--val-fraction", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument(
+        "--arm",
+        choices=("both", "gnn", "graph_free"),
+        default="both",
+        help="Train both matched arms sequentially or one arm in an isolated job.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Pretrain matched graph and graph-free encoders and save checkpoints."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    args = parse_args(argv)
+    manifest = load_temporal_cache_manifest(args.cache_dir)
+    if manifest.get("excluded_labeled_manifest") is None:
+        raise ValueError(
+            "pretraining cache does not record exclusion of the labeled cohort; "
+            "rebuild with --exclude-labeled-manifest"
+        )
+    records = list(manifest["records"])
+    train_records, val_records = split_records_by_patient(
+        records, val_fraction=args.val_fraction, seed=args.seed
+    )
+    device = torch.device(args.device)
+    common = {
+        "in_channels": 1,
+        "hidden_dim": args.hidden_dim,
+        "num_layers": args.num_gcn_layers,
+        "num_gru_layers": args.num_gru_layers,
+        "dropout": args.dropout,
+    }
+    arm_specs = {
+        "gnn": (ContrastForecastGNN, True),
+        "graph_free": (PerNodeForecaster, False),
+    }
+    arms = arm_specs if args.arm == "both" else {args.arm: arm_specs[args.arm]}
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    results = {"requested_arm": args.arm}
+    for arm, (model_class, uses_graph) in arms.items():
+        torch.manual_seed(args.seed)
+        model = model_class(**common)
+        model, history, val_mae, epoch, persistence = train_one_encoder(
+            model,
+            train_records,
+            val_records,
+            uses_graph=uses_graph,
+            epochs=args.epochs,
+            learning_rate=args.learning_rate,
+            seed=args.seed,
+            device=device,
+        )
+        checkpoint_path = args.outdir / f"{arm}_encoder.pt"
+        save_encoder_checkpoint(
+            checkpoint_path,
+            model=model,
+            preprocessing_contract=DEFAULT_PREPROCESSING_CONTRACT,
+            data_manifest=Path(args.cache_dir) / "temporal_cache_manifest.json",
+            epoch=epoch,
+            validation_mae=val_mae,
+        )
+        results[arm] = {
+            "validation_mae": val_mae,
+            "persistence_mae": persistence,
+            "beats_persistence": val_mae < persistence,
+            "best_epoch": epoch,
+            "history": history,
+            "checkpoint": str(checkpoint_path),
+        }
+    if args.arm == "both":
+        results["graph_helps_forecasting"] = (
+            results["gnn"]["validation_mae"]
+            < results["graph_free"]["validation_mae"]
+        )
+    results["train_patient_count"] = len(
+        {str(record["patient_key"]) for record in train_records}
+    )
+    results["val_patient_count"] = len(
+        {str(record["patient_key"]) for record in val_records}
+    )
+    (args.outdir / "pretraining_results.json").write_text(
+        json.dumps(results, indent=2) + "\n"
+    )
+    write_pretraining_readme(args=args, results=results, manifest=manifest)
+
+
+if __name__ == "__main__":
+    main()

--- a/gnn/relational_features.py
+++ b/gnn/relational_features.py
@@ -1,0 +1,278 @@
+"""Graph-*relational* per-case features: how kinetics vary ACROSS the vessel tree.
+
+Every node feature the GNN currently trains on is node-intrinsic -- a property of
+one voxel computed in isolation (``gnn.kinetics``). Nothing is a difference between
+connected nodes. That is why graph structure has not paid off: if the target
+depends only on the distribution of a node function, pooling that function is
+sufficient and the adjacency is irrelevant. Topology earns its keep only when the
+target depends on *how* a node function varies across edges.
+
+This module computes that missing quantity. The physiological target is contrast
+bolus propagation: contrast enters at the inlet and travels distally, so arrival
+time is a function on the tree that increases with distance from the root. Its
+rate is transit velocity, its scatter is how orderly propagation is, and its
+asymmetry between sibling branches is differential perfusion. Tumor-associated
+angiogenesis is expected to perturb exactly these.
+
+Two properties make these features worth the trouble at N=179:
+
+- **Not computable from per-case means.** Each one is a joint property of
+  (kinetics, tree position), so a tabular model on these scalars is a direct test
+  of whether the graph carries signal -- with a model too simple to be accused of
+  winning on capacity.
+- **Protocol-invariant.** They are expressed in differences of physical seconds
+  over physical millimetres. The per-case duration normalization that makes
+  ``peak_time``/``time_to_enhancement`` track acquisition protocol
+  (``experiments/uchicago_protocol_confound``) cancels out.
+
+Everything is read from an already-built voxel-mode cache: ``pos`` (voxel
+coordinates), ``edge_index`` (skeleton adjacency),
+``time_to_enhancement_seconds`` / ``peak_time_seconds`` (physical seconds, set by
+``gnn.data_loader._attach_node_features``), and ``radius``. No DCE reload and no
+rebuild. UChicago v5 volumes are 1x1x1 mm isotropic, so voxel-coordinate distance
+*is* millimetres.
+
+**Root definition.** Each connected component is rooted at its largest-radius
+node: proximal vessels are thickest, and unlike "earliest arrival" this is a
+geometry-only rule, so it does not make the arrival-based features circular.
+
+**Documented data handling** (see ``AUDITING_RESULTS.md``):
+
+- ``time_to_enhancement_seconds`` is NaN for a voxel with no detected arrival
+  (non-enhancing tissue -- a real case, not a bug). Such nodes are excluded from
+  the arrival-based fits rather than imputed, and the retained fraction is
+  reported as ``frac_nodes_with_arrival`` so the exclusion stays audited.
+- Components smaller than ``MIN_COMPONENT_NODES`` are skipped: a handful of voxels
+  has no meaningful transit geometry, and these graphs carry 11-24 components of
+  which most are small fragments. The number kept is reported as
+  ``n_components_used``.
+- Slopes are estimated **within component then pooled** (component-demeaned, i.e.
+  a fixed-effects fit), so a component whose root happens to enhance late cannot
+  masquerade as a shallow transit slope.
+
+A case that yields no usable component at all raises rather than returning zeros.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+import numpy as np
+from torch_geometric.data import Data
+
+# Per-case relational feature vocabulary, in the order ``case_relational_features``
+# emits them.
+RELATIONAL_FEATURE_COLUMNS: tuple[str, ...] = (
+    "transit_slope_s_per_mm",
+    "transit_r2",
+    "peak_transit_slope_s_per_mm",
+    "peak_transit_r2",
+    "arrival_monotonic_frac",
+    "sibling_arrival_asymmetry_s",
+    "radius_taper_per_mm",
+)
+# Bookkeeping emitted alongside the features so every exclusion above is visible
+# in the output CSV rather than implicit.
+RELATIONAL_QC_COLUMNS: tuple[str, ...] = (
+    "arrival_tie_frac",
+    "frac_peak_censored",
+    "n_components_used",
+    "n_nodes_used",
+    "frac_nodes_with_arrival",
+    "n_bifurcations_used",
+)
+
+# A component with fewer nodes than this has no meaningful transit geometry.
+MIN_COMPONENT_NODES = 20
+# A slope needs at least this many points, and a sibling comparison at least this
+# many downstream branches, to be defined at all.
+_MIN_FIT_POINTS = 10
+_MIN_SIBLINGS = 2
+# Degree at which a node is treated as a branch point.
+_BIFURCATION_DEGREE = 3
+
+
+def _skeleton_graph(data: Data) -> nx.Graph:
+    """Undirected skeleton graph with Euclidean (millimetre) edge weights.
+
+    ``edge_index`` stores each undirected skeleton edge in both directions;
+    ``nx.Graph`` collapses the duplicates. Edge weight is the physical distance
+    between the two voxels (1, sqrt(2) or sqrt(3) mm under 26-connectivity), so
+    geodesic distance along a vessel is a real path length rather than a hop count.
+    """
+    pos = data.pos.numpy().astype(float)
+    edge_index = data.edge_index.numpy()
+    graph = nx.Graph()
+    graph.add_nodes_from(range(int(data.num_nodes)))
+    for source, target in zip(edge_index[0], edge_index[1], strict=True):
+        if source == target:
+            continue
+        graph.add_edge(
+            int(source),
+            int(target),
+            weight=float(np.linalg.norm(pos[source] - pos[target])),
+        )
+    return graph
+
+
+def _demeaned_slope(
+    x: np.ndarray, y: np.ndarray, groups: list[np.ndarray]
+) -> tuple[float, float]:
+    """Within-group slope of ``y`` on ``x``, pooled across groups, plus its R^2.
+
+    Each group (connected component) is centered on its own means before pooling,
+    which removes between-component offsets in both variables -- the fixed-effects
+    estimator. Returns ``(nan, nan)`` when fewer than ``_MIN_FIT_POINTS`` usable
+    points survive, so a case with no estimable slope is visibly missing rather
+    than silently zero.
+    """
+    xs, ys = [], []
+    for index in groups:
+        if index.size < _MIN_FIT_POINTS:
+            continue
+        xi, yi = x[index], y[index]
+        keep = np.isfinite(xi) & np.isfinite(yi)
+        if keep.sum() < _MIN_FIT_POINTS:
+            continue
+        xi, yi = xi[keep], yi[keep]
+        xs.append(xi - xi.mean())
+        ys.append(yi - yi.mean())
+    if not xs:
+        return float("nan"), float("nan")
+    x_all = np.concatenate(xs)
+    y_all = np.concatenate(ys)
+    denominator = float(np.sum(x_all**2))
+    if x_all.size < _MIN_FIT_POINTS or denominator <= 0.0:
+        return float("nan"), float("nan")
+    slope = float(np.sum(x_all * y_all) / denominator)
+    total = float(np.sum(y_all**2))
+    if total <= 0.0:
+        return slope, float("nan")
+    residual = float(np.sum((y_all - slope * x_all) ** 2))
+    return slope, float(1.0 - residual / total)
+
+
+def case_relational_features(data: Data) -> dict[str, float]:
+    """All relational features + QC bookkeeping for one built voxel-mode graph.
+
+    Raises if ``data`` is not a voxel-mode graph carrying the physical-seconds
+    kinetic attributes, or if no component is large enough to measure -- both are
+    build/config errors rather than expected data conditions.
+    """
+    for attribute in (
+        "pos",
+        "time_to_enhancement_seconds",
+        "peak_time_seconds",
+        "radius",
+    ):
+        if not hasattr(data, attribute):
+            raise AttributeError(
+                f"Graph is missing {attribute!r}. Relational features need a "
+                "voxel-mode cache built with the physical-seconds kinetic "
+                "attributes (gnn.data_loader._attach_node_features)."
+            )
+    arrival = data.time_to_enhancement_seconds.numpy().astype(float)
+    peak = data.peak_time_seconds.numpy().astype(float)
+    radius = data.radius.numpy().astype(float)
+
+    graph = _skeleton_graph(data)
+    components = [
+        np.asarray(sorted(component), dtype=int)
+        for component in nx.connected_components(graph)
+        if len(component) >= MIN_COMPONENT_NODES
+    ]
+    if not components:
+        raise ValueError(
+            f"case={getattr(data, 'case_id', '?')}: no connected component with "
+            f">= {MIN_COMPONENT_NODES} nodes; cannot measure transit geometry."
+        )
+
+    # Distance from each component's own root (its thickest node).
+    distance = np.full(int(data.num_nodes), np.nan, dtype=float)
+    for component in components:
+        root = int(component[int(np.argmax(radius[component]))])
+        lengths = nx.single_source_dijkstra_path_length(graph, root, weight="weight")
+        for node, length in lengths.items():
+            distance[node] = float(length)
+
+    transit_slope, transit_r2 = _demeaned_slope(distance, arrival, components)
+    peak_slope, peak_r2 = _demeaned_slope(distance, peak, components)
+    taper_slope, _ = _demeaned_slope(distance, radius, components)
+
+    used = np.concatenate(components)
+    in_use = np.zeros(int(data.num_nodes), dtype=bool)
+    in_use[used] = True
+
+    # Arrival monotonicity: along each skeleton edge, does the node farther from
+    # the root enhance later? Only edges whose endpoints are both in a usable
+    # component, both have a detected arrival, and sit at different distances can
+    # answer that.
+    #
+    # Adjacent voxels very often land in the SAME frame, because the DCE series is
+    # sampled every ~3-7 s while bolus transit across a vessel is far faster. Those
+    # ties carry no ordering information, so they are excluded from the fraction
+    # and reported separately as ``arrival_tie_frac`` -- which is itself the honest
+    # measure of how much arrival ordering this acquisition can resolve at all.
+    agree = 0
+    comparable = 0
+    tied = 0
+    for source, target in graph.edges():
+        if not (in_use[source] and in_use[target]):
+            continue
+        d_distance = distance[target] - distance[source]
+        d_arrival = arrival[target] - arrival[source]
+        if not np.isfinite(d_arrival) or d_distance == 0.0:
+            continue
+        if d_arrival == 0.0:
+            tied += 1
+            continue
+        comparable += 1
+        agree += int(np.sign(d_distance) == np.sign(d_arrival))
+    monotonic_frac = float(agree / comparable) if comparable else float("nan")
+    total_edges = comparable + tied
+    tie_frac = float(tied / total_edges) if total_edges else float("nan")
+
+    # Right-censoring check. A voxel whose enhancement is still rising when
+    # acquisition stops reports its peak at the final frame, so peak_time (and the
+    # washout slope measured from it) describe when the scan ended rather than the
+    # physiology. Reported per case because the affected fraction is large and
+    # varies with protocol.
+    peak_index = data.peak_time.numpy().astype(int)
+    frac_peak_censored = float(
+        np.mean(peak_index[used] == int(data.num_timepoints) - 1)
+    )
+
+    # Sibling asymmetry: at a branch point, how differently do its downstream
+    # branches enhance? Measured on the immediate downstream neighbours, so this is
+    # a local (one-voxel) estimate; a segment-level version is the natural
+    # refinement once this feature set proves useful.
+    spreads = []
+    for node in used:
+        if graph.degree(int(node)) < _BIFURCATION_DEGREE:
+            continue
+        downstream = [
+            arrival[neighbor]
+            for neighbor in graph.neighbors(int(node))
+            if in_use[neighbor]
+            and distance[neighbor] > distance[node]
+            and np.isfinite(arrival[neighbor])
+        ]
+        if len(downstream) < _MIN_SIBLINGS:
+            continue
+        spreads.append(float(max(downstream) - min(downstream)))
+    sibling_asymmetry = float(np.mean(spreads)) if spreads else float("nan")
+
+    return {
+        "transit_slope_s_per_mm": transit_slope,
+        "transit_r2": transit_r2,
+        "peak_transit_slope_s_per_mm": peak_slope,
+        "peak_transit_r2": peak_r2,
+        "arrival_monotonic_frac": monotonic_frac,
+        "sibling_arrival_asymmetry_s": sibling_asymmetry,
+        "radius_taper_per_mm": taper_slope,
+        "arrival_tie_frac": tie_frac,
+        "frac_peak_censored": frac_peak_censored,
+        "n_components_used": float(len(components)),
+        "n_nodes_used": float(used.size),
+        "frac_nodes_with_arrival": float(np.isfinite(arrival[used]).mean()),
+        "n_bifurcations_used": float(len(spreads)),
+    }

--- a/gnn/segment_graph.py
+++ b/gnn/segment_graph.py
@@ -115,6 +115,7 @@ def _segment_kinetic_summary(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> dict[str, float]:
     """Mean/std of the per-voxel kinetic scalars along one segment's voxels.
 
@@ -138,6 +139,7 @@ def _segment_kinetic_summary(
             time_axis,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         )
         samples["peak_time"].append(
             float(kinetic["peak_time_seconds"]) / duration_seconds
@@ -172,6 +174,7 @@ def segment_summary_features(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> dict[str, float]:
     """All segment-level features for one segment polyline, as a flat dict.
 
@@ -198,6 +201,7 @@ def segment_summary_features(
             time_axis,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         )
     )
     attrs["seg_num_voxels"] = float(len(path))
@@ -216,6 +220,7 @@ def build_segment_line_graph(
     *,
     baseline_frame_count: int = 1,
     relative_enhancement: bool = False,
+    baseline_floor_frac: float = 0.0,
 ) -> nx.Graph:
     """Build the segment line graph (Option B) from a voxel skeleton graph.
 
@@ -258,6 +263,7 @@ def build_segment_line_graph(
             voxel_graph,
             baseline_frame_count=baseline_frame_count,
             relative_enhancement=relative_enhancement,
+            baseline_floor_frac=baseline_floor_frac,
         )
         midpoint = np.mean(np.asarray(path, dtype=float), axis=0)
         line.add_node(seg_id, pos=midpoint, **attrs)

--- a/gnn/slurm/submit_all_models_gate_uchicago.slurm
+++ b/gnn/slurm/submit_all_models_gate_uchicago.slurm
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=all-models-gate-uchicago
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8G
+#SBATCH --time=00:20:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# All-models summary forest plot (tabular + every GNN arm) on pooled OOF AUC +
+# bootstrap 95% CI. Run after the 2-feat training array finishes.
+#   sbatch --dependency=afterok:<2feat_array> gnn/slurm/submit_all_models_gate_uchicago.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+GPFS=/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments
+python -m analysis.gnn_all_models_gate \
+  --tier-sweep-root "${GPFS}/gnn_uchicago_tier_sweep_floored" \
+  --graph-mode-root "${GPFS}/gnn_uchicago_graph_mode_floored" \
+  --twofeat-root "${GPFS}/gnn_uchicago_2feat_floored" \
+  --graph-qc /ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+  --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+  --out-dir experiments/uchicago_all_models

--- a/gnn/slurm/submit_arrival_field_structure.slurm
+++ b/gnn/slurm/submit_arrival_field_structure.slurm
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=arrival-field-structure
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Does the arrival-time field have ANY spatial structure on the vessel tree?
+#
+# Separates "my root definition is wrong" from "the arrival field is spatially
+# unstructured" -- the two readings of the Stage 2 relational features coming out at
+# chance with arrival_monotonic_frac == 0.490. Measures edge-wise agreement of
+# arrival times against a within-case shuffled null and against radius as a positive
+# control (calibre must be smooth along a centreline, so if radius shows structure
+# and arrival does not, the graph reconstruction is sound).
+#
+# On Slurm rather than the login node because it loads all 179 cached graphs
+# (~283 MB) and runs Dijkstra per component. No DCE reload, no cache rebuild.
+#
+# See docs/design/gnn_graph_representation_plan.md Stage 2.
+#
+# Usage:
+#   sbatch gnn/slurm/submit_arrival_field_structure.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+python -u -m analysis.arrival_field_structure \
+  --cache-dir /ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored \
+  --out-dir experiments/uchicago_arrival_field

--- a/gnn/slurm/submit_floor_activation_check.slurm
+++ b/gnn/slurm/submit_floor_activation_check.slurm
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 #SBATCH --job-name=floor-activation-check
 #SBATCH --partition=tier1q
-#SBATCH --cpus-per-task=2
-#SBATCH --mem=24G
-#SBATCH --time=00:30:00
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=48G
+#SBATCH --time=12:00:00
 #SBATCH --output=logs/%x-%j.out
 #SBATCH --error=logs/%x-%j.err
 
-# Verification: render where the kinetic baseline floor activates, on the top-down
-# center axial slice, for one representative UChicago case per sub-family. Loads
-# raw 4D DCE, so it runs on Slurm, not the head node.
+# Verification: render where the kinetic baseline floor activates, per case, for
+# the whole UChicago cohort. Loads raw 4D DCE, so it runs on Slurm, not the head
+# node. Writes one directory of figures per case under OUT_DIR.
 #
 # Usage:
 #   sbatch gnn/slurm/submit_floor_activation_check.slurm
 #   CASES="id1 id2" sbatch gnn/slurm/submit_floor_activation_check.slurm
+#   OUT_DIR=/path/to/dir sbatch gnn/slurm/submit_floor_activation_check.slurm
 
 set -euo pipefail
 
@@ -32,14 +33,17 @@ set -u
 export PYTHONUNBUFFERED=1
 
 UROOT=/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5
-CASES="${CASES:-her2_naclike_1_3_1044741369180520970681559947209255863618251733856 simbiosys_1_3_1004851971177365454526032714777574610025402498462 uch_nac_1_3_1004294011319227272751368633606051346978841464528}"
+OUT_DIR="${OUT_DIR:-/gpfs/data/karczmar-lab/workspaces/spencervenancio/precontrast_floor_experiment}"
 
-for CASE in ${CASES}; do
-  echo "=================== ${CASE} ==================="
-  python -m analysis.floor_activation_map \
-    --case-id "${CASE}" \
-    --centerline-root "${UROOT}/centerlines" \
-    --dce-root "${UROOT}/dce" \
-    --floor-frac 0.05 \
-    --out-dir experiments/floor_activation_check
-done
+# Omitting --case-id renders every case under the centerline root.
+CASE_ARGS=()
+if [[ -n "${CASES:-}" ]]; then
+  CASE_ARGS=(--case-id ${CASES})
+fi
+
+python -m analysis.floor_activation_map \
+  "${CASE_ARGS[@]}" \
+  --centerline-root "${UROOT}/centerlines" \
+  --dce-root "${UROOT}/dce" \
+  --floor-frac 0.05 \
+  --out-dir "${OUT_DIR}"

--- a/gnn/slurm/submit_floor_activation_check.slurm
+++ b/gnn/slurm/submit_floor_activation_check.slurm
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=floor-activation-check
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=24G
+#SBATCH --time=00:30:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Verification: render where the kinetic baseline floor activates, on the top-down
+# center axial slice, for one representative UChicago case per sub-family. Loads
+# raw 4D DCE, so it runs on Slurm, not the head node.
+#
+# Usage:
+#   sbatch gnn/slurm/submit_floor_activation_check.slurm
+#   CASES="id1 id2" sbatch gnn/slurm/submit_floor_activation_check.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+UROOT=/ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5
+CASES="${CASES:-her2_naclike_1_3_1044741369180520970681559947209255863618251733856 simbiosys_1_3_1004851971177365454526032714777574610025402498462 uch_nac_1_3_1004294011319227272751368633606051346978841464528}"
+
+for CASE in ${CASES}; do
+  echo "=================== ${CASE} ==================="
+  python -m analysis.floor_activation_map \
+    --case-id "${CASE}" \
+    --centerline-root "${UROOT}/centerlines" \
+    --dce-root "${UROOT}/dce" \
+    --floor-frac 0.05 \
+    --out-dir experiments/floor_activation_check
+done

--- a/gnn/slurm/submit_gnn_build.slurm
+++ b/gnn/slurm/submit_gnn_build.slurm
@@ -55,7 +55,7 @@ NODE_FEATURES="${NODE_FEATURES:-peak_time,radius}"
 # Floor the relative-enhancement denominator at this fraction of each voxel's
 # own peak signal (gnn/kinetics.py). 0 = historical behavior; e.g. 0.05 caps
 # peak relative enhancement at ~20x to kill divide-by-near-zero-baseline
-# artifacts. Voxel mode only.
+# artifacts. Applies to voxel, segment, and junction modes.
 KINETIC_BASELINE_FLOOR_FRAC="${KINETIC_BASELINE_FLOOR_FRAC:-0}"
 # Only used by --node-mode junction (segment-as-edge): the segment summary rides
 # on the edges there. Empty for voxel/segment mode.

--- a/gnn/slurm/submit_gnn_build.slurm
+++ b/gnn/slurm/submit_gnn_build.slurm
@@ -52,6 +52,11 @@ LABEL_COLUMN="${LABEL_COLUMN:-pcr}"
 # build fall back to the mode's own default feature set.
 NODE_MODE="${NODE_MODE:-voxel}"
 NODE_FEATURES="${NODE_FEATURES:-peak_time,radius}"
+# Floor the relative-enhancement denominator at this fraction of each voxel's
+# own peak signal (gnn/kinetics.py). 0 = historical behavior; e.g. 0.05 caps
+# peak relative enhancement at ~20x to kill divide-by-near-zero-baseline
+# artifacts. Voxel mode only.
+KINETIC_BASELINE_FLOOR_FRAC="${KINETIC_BASELINE_FLOOR_FRAC:-0}"
 # Only used by --node-mode junction (segment-as-edge): the segment summary rides
 # on the edges there. Empty for voxel/segment mode.
 EDGE_FEATURES="${EDGE_FEATURES:-}"
@@ -75,6 +80,7 @@ ARGS=(
   --id-column "${ID_COLUMN}"
   --label-column "${LABEL_COLUMN}"
   --node-mode "${NODE_MODE}"
+  --kinetic-baseline-floor-frac "${KINETIC_BASELINE_FLOOR_FRAC}"
   --max-missing-label-frac "${MAX_MISSING_LABEL_FRAC}"
   --max-missing-clinical-frac "${MAX_MISSING_CLINICAL_FRAC}"
   --num-workers "${NUM_WORKERS}"

--- a/gnn/slurm/submit_gnn_uchicago_2feat_floored.slurm
+++ b/gnn/slurm/submit_gnn_uchicago_2feat_floored.slurm
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-uch-2feat-floored
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+#SBATCH --time=02:00:00
+#SBATCH --array=0-4
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# 2-feature ([peak_time, radius]) floored voxel GNN, 5 seeds, for the all-models
+# comparison. Subsets the existing 7-feature floored voxel cache (no rebuild).
+# Predictions land in voxel2feat_seed{n} so the gate can pool them.
+#
+#   sbatch gnn/slurm/submit_gnn_uchicago_2feat_floored.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_uchicago_2feat_floored"
+SEED="${SLURM_ARRAY_TASK_ID}"
+
+python -u -m gnn.train \
+    --config configs/uchicago_gnn_2feat_floored.yaml \
+    --random-state "${SEED}" \
+    --outdir "${OUT_ROOT}/voxel2feat_seed${SEED}"

--- a/gnn/slurm/submit_gnn_uchicago_edge_ablation.slurm
+++ b/gnn/slurm/submit_gnn_uchicago_edge_ablation.slurm
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-uchicago-edge-ablation
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=02:00:00
+#SBATCH --array=0-14
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# Does the voxel GNN use the vessel topology at all?
+#
+# 15 tasks = 3 arms x 5 seeds:
+#   none   -- the real skeleton adjacency (reference)
+#   rewire -- degree-preserving random rewiring; same node features, node count,
+#             edge count and degree sequence, only *which* nodes are adjacent changes
+#   drop   -- edge_index emptied; GCNConv's self-loops reduce the model to a
+#             per-node map plus a permutation-invariant readout
+#
+# All three arms read the SAME floored 7-feature voxel cache
+# (gnn_cache_voxel_richfeat_floored) and the SAME frozen predefined folds, and the
+# ablation is applied at TRAIN time to the cloned per-fold graphs
+# (gnn/train.py::_apply_edge_ablation), so no cache rebuild is needed and a paired
+# dAUC by (seed x fold) isolates the ablation and nothing else.
+#
+# Motivation: at num_layers=2 on skeleton graphs whose diameter is 290-618 hops,
+# each node sees only its immediate neighbourhood before global_mean_pool averages
+# everything -- so the graph may be contributing nothing but a short moving average.
+# If all three arms score the same, topology is provably unused, and every
+# graph-mode null to date is explained by the operator rather than by the
+# vasculature. See docs/design/gnn_graph_representation_plan.md Stage 0.1.
+#
+# As with the tier sweep, folds are split_mode=predefined, so --random-state varies
+# torch init + inner-val split only, NOT fold membership.
+#
+# Usage (cache already built -- no build dependency needed):
+#   sbatch gnn/slurm/submit_gnn_uchicago_edge_ablation.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/ess/scratch/scratch1/t-9svena/uchicago/experiments/gnn_edge_ablation"
+
+# Index 0-4 none, 5-9 rewire, 10-14 drop; seeds 0..4 within each arm.
+CONFIGS=(
+  configs/uchicago_gnn_edge_none.yaml configs/uchicago_gnn_edge_none.yaml \
+  configs/uchicago_gnn_edge_none.yaml configs/uchicago_gnn_edge_none.yaml \
+  configs/uchicago_gnn_edge_none.yaml \
+  configs/uchicago_gnn_edge_rewire.yaml configs/uchicago_gnn_edge_rewire.yaml \
+  configs/uchicago_gnn_edge_rewire.yaml configs/uchicago_gnn_edge_rewire.yaml \
+  configs/uchicago_gnn_edge_rewire.yaml \
+  configs/uchicago_gnn_edge_drop.yaml configs/uchicago_gnn_edge_drop.yaml \
+  configs/uchicago_gnn_edge_drop.yaml configs/uchicago_gnn_edge_drop.yaml \
+  configs/uchicago_gnn_edge_drop.yaml
+)
+SEEDS=(0 1 2 3 4 0 1 2 3 4 0 1 2 3 4)
+TAGS=(
+  none_seed0 none_seed1 none_seed2 none_seed3 none_seed4 \
+  rewire_seed0 rewire_seed1 rewire_seed2 rewire_seed3 rewire_seed4 \
+  drop_seed0 drop_seed1 drop_seed2 drop_seed3 drop_seed4
+)
+
+i="${SLURM_ARRAY_TASK_ID}"
+CONFIG="${CONFIGS[$i]}"
+SEED="${SEEDS[$i]}"
+TAG="${TAGS[$i]}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+
+echo "task ${i}: config=${CONFIG} seed=${SEED} outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config "${CONFIG}" \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/slurm/submit_gnn_uchicago_graph_mode_floored.slurm
+++ b/gnn/slurm/submit_gnn_uchicago_graph_mode_floored.slurm
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-uch-graph-mode-floored
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+#SBATCH --time=04:00:00
+#SBATCH --array=0-9
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# Phase 2.2: floored voxel/segment/junction graph-mode comparison on UChicago.
+# 10 tasks = 2 modes x 5 seeds. Both arms read their own floored cache (segment /
+# junction, built with KINETIC_BASELINE_FLOOR_FRAC=0.05) under the SAME frozen
+# predefined folds and the SAME baseline (D0.6) training knobs as the voxel
+# baseline arm -- so the only thing that varies across voxel/segment/junction is
+# the graph representation. Voxel is already run (gnn_uchicago_tier_sweep_floored
+# baseline_seed*); this adds the other two modes. Predictions land in the same
+# {mode}_seed{n} layout so analysis/gnn_graph_mode_gate.py can pool them.
+#
+# Usage (build the two caches first; a dependency handles ordering):
+#   sbatch --dependency=afterok:<seg_build>:<junc_build> \
+#       gnn/slurm/submit_gnn_uchicago_graph_mode_floored.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_uchicago_graph_mode_floored"
+
+# Index 0-4 segment, 5-9 junction; seeds 0..4 within each mode.
+CONFIGS=(
+  configs/uchicago_gnn_segment_floored.yaml configs/uchicago_gnn_segment_floored.yaml \
+  configs/uchicago_gnn_segment_floored.yaml configs/uchicago_gnn_segment_floored.yaml \
+  configs/uchicago_gnn_segment_floored.yaml \
+  configs/uchicago_gnn_junction_floored.yaml configs/uchicago_gnn_junction_floored.yaml \
+  configs/uchicago_gnn_junction_floored.yaml configs/uchicago_gnn_junction_floored.yaml \
+  configs/uchicago_gnn_junction_floored.yaml
+)
+SEEDS=(0 1 2 3 4 0 1 2 3 4)
+TAGS=(
+  segment_seed0 segment_seed1 segment_seed2 segment_seed3 segment_seed4 \
+  junction_seed0 junction_seed1 junction_seed2 junction_seed3 junction_seed4
+)
+
+i="${SLURM_ARRAY_TASK_ID}"
+CONFIG="${CONFIGS[$i]}"
+SEED="${SEEDS[$i]}"
+TAG="${TAGS[$i]}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+
+echo "task ${i}: config=${CONFIG} seed=${SEED} outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config "${CONFIG}" \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/slurm/submit_gnn_uchicago_tier_sweep.slurm
+++ b/gnn/slurm/submit_gnn_uchicago_tier_sweep.slurm
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-uchicago-tier-sweep
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=1-00:00:00
+#SBATCH --array=0-14
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# UChicago replication of the PLAN_advanced_modeling.md tier ladder, Tiers 0-1.
+# 15 tasks = 3 arms x 5 seeds:
+#   baseline (frozen hygiene) | tier0 (hygiene stack) | tier1 (tier0 + mean_max readout)
+# All three arms read the SAME v5 voxel cache (gnn_cache_voxel_richfeat, 7-feature
+# set) and the SAME frozen predefined folds, so a paired dAUC by (seed x fold)
+# isolates each tier's change (Gate G0: tier0 vs baseline; Gate G1: tier1 vs tier0).
+#
+# NOTE (vs. the Duke tier0 sweep): folds are split_mode=predefined here (UChicago
+# ships patient-grouped folds, no patient column to reshuffle safely), so
+# --random-state varies torch init + inner-val split only, NOT fold membership.
+# The paired test is therefore less powerful than Duke's random-CV draws; this is
+# the deliberate leak-safe trade (LAB_NOTEBOOK 2026-07-26).
+#
+# Usage (cache already built -- no build dependency needed):
+#   sbatch gnn/slurm/submit_gnn_uchicago_tier_sweep.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/ess/scratch/scratch1/t-9svena/uchicago/experiments/gnn_tier_sweep"
+
+# Index 0-4 baseline, 5-9 tier0, 10-14 tier1; seeds 0..4 within each arm.
+CONFIGS=(
+  configs/uchicago_gnn_tier_baseline.yaml configs/uchicago_gnn_tier_baseline.yaml \
+  configs/uchicago_gnn_tier_baseline.yaml configs/uchicago_gnn_tier_baseline.yaml \
+  configs/uchicago_gnn_tier_baseline.yaml \
+  configs/uchicago_gnn_tier0.yaml configs/uchicago_gnn_tier0.yaml \
+  configs/uchicago_gnn_tier0.yaml configs/uchicago_gnn_tier0.yaml \
+  configs/uchicago_gnn_tier0.yaml \
+  configs/uchicago_gnn_tier1.yaml configs/uchicago_gnn_tier1.yaml \
+  configs/uchicago_gnn_tier1.yaml configs/uchicago_gnn_tier1.yaml \
+  configs/uchicago_gnn_tier1.yaml
+)
+SEEDS=(0 1 2 3 4 0 1 2 3 4 0 1 2 3 4)
+TAGS=(
+  baseline_seed0 baseline_seed1 baseline_seed2 baseline_seed3 baseline_seed4 \
+  tier0_seed0 tier0_seed1 tier0_seed2 tier0_seed3 tier0_seed4 \
+  tier1_seed0 tier1_seed1 tier1_seed2 tier1_seed3 tier1_seed4
+)
+
+i="${SLURM_ARRAY_TASK_ID}"
+CONFIG="${CONFIGS[$i]}"
+SEED="${SEEDS[$i]}"
+TAG="${TAGS[$i]}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+
+echo "task ${i}: config=${CONFIG} seed=${SEED} outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config "${CONFIG}" \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/slurm/submit_gnn_uchicago_tier_sweep_floored.slurm
+++ b/gnn/slurm/submit_gnn_uchicago_tier_sweep_floored.slurm
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=gnn-uchicago-tier-sweep-floored
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=1-00:00:00
+#SBATCH --array=0-14
+#SBATCH --output=logs/%x-%A_%a.out
+#SBATCH --error=logs/%x-%A_%a.err
+
+# UChicago replication of the PLAN_advanced_modeling.md tier ladder, Tiers 0-1.
+# 15 tasks = 3 arms x 5 seeds:
+#   baseline (frozen hygiene) | tier0 (hygiene stack) | tier1 (tier0 + mean_max readout)
+# All three arms read the SAME v5 voxel cache (gnn_cache_voxel_richfeat, 7-feature
+# set) and the SAME frozen predefined folds, so a paired dAUC by (seed x fold)
+# isolates each tier's change (Gate G0: tier0 vs baseline; Gate G1: tier1 vs tier0).
+#
+# NOTE (vs. the Duke tier0 sweep): folds are split_mode=predefined here (UChicago
+# ships patient-grouped folds, no patient column to reshuffle safely), so
+# --random-state varies torch init + inner-val split only, NOT fold membership.
+# The paired test is therefore less powerful than Duke's random-CV draws; this is
+# the deliberate leak-safe trade (LAB_NOTEBOOK 2026-07-26).
+#
+# Usage (cache already built -- no build dependency needed):
+#   sbatch gnn/slurm/submit_gnn_uchicago_tier_sweep.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+OUT_ROOT="/ess/scratch/scratch1/t-9svena/uchicago/experiments/gnn_tier_sweep_floored"
+
+# Index 0-4 baseline, 5-9 tier0, 10-14 tier1; seeds 0..4 within each arm.
+CONFIGS=(
+  configs/uchicago_gnn_tier_baseline_floored.yaml configs/uchicago_gnn_tier_baseline_floored.yaml \
+  configs/uchicago_gnn_tier_baseline_floored.yaml configs/uchicago_gnn_tier_baseline_floored.yaml \
+  configs/uchicago_gnn_tier_baseline_floored.yaml \
+  configs/uchicago_gnn_tier0_floored.yaml configs/uchicago_gnn_tier0_floored.yaml \
+  configs/uchicago_gnn_tier0_floored.yaml configs/uchicago_gnn_tier0_floored.yaml \
+  configs/uchicago_gnn_tier0_floored.yaml \
+  configs/uchicago_gnn_tier1_floored.yaml configs/uchicago_gnn_tier1_floored.yaml \
+  configs/uchicago_gnn_tier1_floored.yaml configs/uchicago_gnn_tier1_floored.yaml \
+  configs/uchicago_gnn_tier1_floored.yaml
+)
+SEEDS=(0 1 2 3 4 0 1 2 3 4 0 1 2 3 4)
+TAGS=(
+  baseline_seed0 baseline_seed1 baseline_seed2 baseline_seed3 baseline_seed4 \
+  tier0_seed0 tier0_seed1 tier0_seed2 tier0_seed3 tier0_seed4 \
+  tier1_seed0 tier1_seed1 tier1_seed2 tier1_seed3 tier1_seed4
+)
+
+i="${SLURM_ARRAY_TASK_ID}"
+CONFIG="${CONFIGS[$i]}"
+SEED="${SEEDS[$i]}"
+TAG="${TAGS[$i]}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+
+echo "task ${i}: config=${CONFIG} seed=${SEED} outdir=${OUTDIR}"
+
+python -u -m gnn.train \
+    --config "${CONFIG}" \
+    --random-state "${SEED}" \
+    --outdir "${OUTDIR}"

--- a/gnn/slurm/submit_graph_mode_gate_uchicago.slurm
+++ b/gnn/slurm/submit_graph_mode_gate_uchicago.slurm
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=graph-mode-gate-uchicago
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8G
+#SBATCH --time=00:20:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Phase 2.2 gate: voxel vs segment vs junction (floored UChicago) on pooled OOF
+# AUC + bootstrap 95% CIs, plus paired dAUC of each structural mode vs. voxel.
+# Reads small prediction CSVs + refits the tiny 7-means tabular bar + bootstraps;
+# kept off the head node like the other gate jobs.
+#
+# Usage (after the graph-mode training array finishes):
+#   sbatch gnn/slurm/submit_graph_mode_gate_uchicago.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+python -m analysis.gnn_graph_mode_gate \
+  --voxel-root /gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_uchicago_tier_sweep_floored \
+  --voxel-arm baseline \
+  --graph-mode-root /gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_uchicago_graph_mode_floored \
+  --graph-qc /ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+  --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+  --out-dir experiments/uchicago_graph_mode_floored

--- a/gnn/slurm/submit_graph_relational_gate.slurm
+++ b/gnn/slurm/submit_graph_relational_gate.slurm
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=graph-relational-gate
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Stage 2 gate: does the vessel GRAPH carry pCR signal the per-node means discard?
+#
+# Computes per-case RELATIONAL features (gnn/relational_features.py -- transit
+# slope, arrival monotonicity, sibling asymmetry, radius tapering) from the already
+# built floored voxel cache, then scores a plain logistic regression on them
+# against the published 7-means bar, the protocol-residualized bar, and a
+# protocol-only floor, with bootstrap CIs and paired deltas.
+#
+# On Slurm rather than the login node because it loads all 179 cached graphs
+# (~283 MB) and runs Dijkstra per component; the analysis itself is single-core and
+# takes a couple of minutes. No DCE reload and no cache rebuild.
+#
+# See docs/design/gnn_graph_representation_plan.md Stage 2.
+#
+# Usage:
+#   sbatch gnn/slurm/submit_graph_relational_gate.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+python -u -m analysis.graph_relational_gate \
+  --cache-dir /ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored \
+  --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+  --dce-root /ess/scratch/scratch1/t-9svena/uchicago/preprocessing_out_v5/dce \
+  --out-dir experiments/uchicago_graph_relational

--- a/gnn/slurm/submit_tabular_bar_uchicago_floored.slurm
+++ b/gnn/slurm/submit_tabular_bar_uchicago_floored.slurm
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=tabular-bar-uchicago-floored
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+#SBATCH --time=00:30:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Phase 1.1 tabular bar: the number the UChicago vessel-GNN must beat.
+# Fits logistic-regression + XGBoost on per-case vessel-summary features
+# (mean/std/q10/q50/q90 of the 7 node kinetics + tte-no-arrival fraction +
+# node/edge counts) read read-only from the floored voxel cache, under the
+# frozen predefined folds. Reports POOLED OOF AUC over all 179 cases with a
+# bootstrap 95% CI (the plan's headline metric, comparable to the GNN ~0.61).
+#
+# Usage (cache already built -- no build dependency):
+#   sbatch gnn/slurm/submit_tabular_bar_uchicago_floored.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+python -m tabular.gnn_feature_baseline \
+  --config configs/uchicago_gnn_tier_baseline_floored.yaml \
+  --out-dir experiments/uchicago_tabular_bar_floored

--- a/gnn/slurm/submit_tabular_gate_uchicago.slurm
+++ b/gnn/slurm/submit_tabular_gate_uchicago.slurm
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=tabular-gate-uchicago
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8G
+#SBATCH --time=00:20:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Phase 1 gate: GNN (baseline/tier1) vs the vessel-only tabular bar, all on
+# pooled OOF AUC over the 179 UChicago cases with bootstrap 95% CIs, plus a
+# paired dAUC test (GNN - best tabular). Reads only small CSVs; refits the
+# tiny tabular models + runs 2000 bootstraps -- fast, but kept off the head
+# node so the login node stays for coordination only.
+#
+# Usage:
+#   sbatch gnn/slurm/submit_tabular_gate_uchicago.slurm
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate vanguard
+fi
+set -u
+
+export PYTHONUNBUFFERED=1
+
+python -m analysis.gnn_tabular_gate \
+  --gnn-sweep-root /gpfs/data/karczmar-lab/workspaces/spencervenancio/experiments/gnn_uchicago_tier_sweep_floored \
+  --graph-qc /ess/scratch/scratch1/t-9svena/uchicago/gnn_cache_voxel_richfeat_floored/processed/graph_qc.csv \
+  --tabular-features experiments/uchicago_tabular_bar_floored/tabular_baseline_features.csv \
+  --out-dir experiments/uchicago_tabular_bar_floored

--- a/gnn/slurm/submit_uchicago_temporal_cache.slurm
+++ b/gnn/slurm/submit_uchicago_temporal_cache.slurm
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uch-temporal-cache
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=24:00:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+# Build either the unlabeled SSL cache or labeled longitudinal cache. Required
+# paths are explicit because the uc-uf-pretrain preprocessing location is not a
+# checked-in repository fact.
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+: "${MANIFEST:?Set MANIFEST to the UChicago exam manifest CSV}"
+: "${CENTERLINE_ROOT:?Set CENTERLINE_ROOT to aligned UChicago centerlines}"
+: "${DCE_ROOT:?Set DCE_ROOT to aligned UChicago DCE phases/timestamps}"
+: "${CACHE_DIR:?Set CACHE_DIR to a new temporal-cache output directory}"
+
+ARGS=(
+  python -u -m gnn.build_uchicago_temporal_cache
+  --manifest "${MANIFEST}"
+  --centerline-root "${CENTERLINE_ROOT}"
+  --dce-root "${DCE_ROOT}"
+  --cache-dir "${CACHE_DIR}"
+)
+if [[ -n "${EXCLUDE_LABELED_MANIFEST:-}" ]]; then
+  ARGS+=(--exclude-labeled-manifest "${EXCLUDE_LABELED_MANIFEST}")
+fi
+if [[ -n "${CASES:-}" ]]; then
+  ARGS+=(--cases "${CASES}")
+fi
+if [[ "${RESUME:-0}" == "1" ]]; then
+  ARGS+=(--resume)
+fi
+if [[ "${DEFER_MANIFEST:-0}" == "1" ]]; then
+  ARGS+=(--defer-manifest)
+fi
+"${ARGS[@]}"

--- a/gnn/slurm/submit_uchicago_temporal_cache.slurm
+++ b/gnn/slurm/submit_uchicago_temporal_cache.slurm
@@ -41,6 +41,11 @@ fi
 if [[ -n "${CASES:-}" ]]; then
   ARGS+=(--cases "${CASES}")
 fi
+if [[ -n "${SHARD_INDEX:-}" || -n "${NUM_SHARDS:-}" ]]; then
+  : "${SHARD_INDEX:?Set both SHARD_INDEX and NUM_SHARDS}"
+  : "${NUM_SHARDS:?Set both SHARD_INDEX and NUM_SHARDS}"
+  ARGS+=(--shard-index "${SHARD_INDEX}" --num-shards "${NUM_SHARDS}")
+fi
 if [[ "${RESUME:-0}" == "1" ]]; then
   ARGS+=(--resume)
 fi

--- a/gnn/slurm/submit_uchicago_temporal_finetune.slurm
+++ b/gnn/slurm/submit_uchicago_temporal_finetune.slurm
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uch-pcr-arm
+#SBATCH --partition=gpuq
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --gres=gpu:1
+#SBATCH --time=12:00:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+: "${CACHE_DIR:?Set CACHE_DIR to the labeled UChicago temporal cache}"
+: "${COHORT_MANIFEST:?Set COHORT_MANIFEST to the Anna-confirmed larger cohort}"
+: "${GNN_CHECKPOINT:?Set GNN_CHECKPOINT to the pretrained graph encoder}"
+: "${GRAPH_FREE_CHECKPOINT:?Set GRAPH_FREE_CHECKPOINT to the pretrained graph-free encoder}"
+: "${ARM:?Set ARM to one of the four downstream arm names}"
+: "${OUTDIR:?Set OUTDIR to the selected arm result directory}"
+
+python -u -m gnn.temporal_finetune \
+  --cache-dir "${CACHE_DIR}" \
+  --cohort-manifest "${COHORT_MANIFEST}" \
+  --gnn-checkpoint "${GNN_CHECKPOINT}" \
+  --graph-free-checkpoint "${GRAPH_FREE_CHECKPOINT}" \
+  --outdir "${OUTDIR}" \
+  --tabular-reference "${TABULAR_REFERENCE:-experiments/uchicago_tabular_bar_floored/gate_auc_ci.csv}" \
+  --epochs "${EPOCHS:-50}" \
+  --learning-rate "${LEARNING_RATE:-0.0003}" \
+  --inner-val-fraction "${INNER_VAL_FRACTION:-0.2}" \
+  --seed "${SEED:-0}" \
+  --arm "${ARM}" \
+  --device cuda

--- a/gnn/slurm/submit_uchicago_temporal_finetune_aggregate.slurm
+++ b/gnn/slurm/submit_uchicago_temporal_finetune_aggregate.slurm
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uch-pcr-aggregate
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=8G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+: "${CACHE_DIR:?Set CACHE_DIR to the labeled UChicago temporal cache}"
+: "${COHORT_MANIFEST:?Set COHORT_MANIFEST to the Anna-confirmed larger cohort}"
+: "${GNN_CHECKPOINT:?Set GNN_CHECKPOINT to the pretrained graph encoder}"
+: "${GRAPH_FREE_CHECKPOINT:?Set GRAPH_FREE_CHECKPOINT to the pretrained graph-free encoder}"
+: "${OUTDIR:?Set OUTDIR to the parent 2x2 downstream result directory}"
+: "${ARM_JOB_IDS:?Set ARM_JOB_IDS to the four dependency job IDs}"
+
+python -u -m gnn.temporal_finetune \
+  --cache-dir "${CACHE_DIR}" \
+  --cohort-manifest "${COHORT_MANIFEST}" \
+  --gnn-checkpoint "${GNN_CHECKPOINT}" \
+  --graph-free-checkpoint "${GRAPH_FREE_CHECKPOINT}" \
+  --outdir "${OUTDIR}" \
+  --tabular-reference "${TABULAR_REFERENCE:-experiments/uchicago_tabular_bar_floored/gate_auc_ci.csv}" \
+  --epochs "${EPOCHS:-50}" \
+  --learning-rate "${LEARNING_RATE:-0.0003}" \
+  --inner-val-fraction "${INNER_VAL_FRACTION:-0.2}" \
+  --seed "${SEED:-0}" \
+  --arm all \
+  --aggregate-only \
+  --device cpu

--- a/gnn/slurm/submit_uchicago_temporal_pretrain.slurm
+++ b/gnn/slurm/submit_uchicago_temporal_pretrain.slurm
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uch-temporal-ssl
+#SBATCH --partition=gpuq
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --gres=gpu:1
+#SBATCH --time=12:00:00
+#SBATCH --output=logs/%x-%j.out
+#SBATCH --error=logs/%x-%j.err
+
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+mkdir -p "${REPO_ROOT}/logs"
+cd "${REPO_ROOT}"
+
+set +u
+source "${HOME}/.bashrc" || true
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+: "${CACHE_DIR:?Set CACHE_DIR to the unlabeled UChicago temporal cache}"
+: "${OUTDIR:?Set OUTDIR to a new pretraining result directory}"
+
+python -u -m gnn.pretrain.uchicago \
+  --cache-dir "${CACHE_DIR}" \
+  --outdir "${OUTDIR}" \
+  --epochs "${EPOCHS:-100}" \
+  --hidden-dim "${HIDDEN_DIM:-32}" \
+  --num-gcn-layers "${NUM_GCN_LAYERS:-2}" \
+  --num-gru-layers "${NUM_GRU_LAYERS:-1}" \
+  --dropout "${DROPOUT:-0.2}" \
+  --learning-rate "${LEARNING_RATE:-0.001}" \
+  --val-fraction "${VAL_FRACTION:-0.2}" \
+  --seed "${SEED:-0}" \
+  --arm "${ARM:-both}" \
+  --device cuda

--- a/gnn/temporal_finetune.py
+++ b/gnn/temporal_finetune.py
@@ -1,0 +1,828 @@
+"""Patient-level UChicago temporal fine-tuning and the required 2x2 comparison."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from collections import defaultdict
+from copy import deepcopy
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+from gnn.pretrain.checkpoint import load_checkpoint
+from gnn.pretrain.uchicago import _git_provenance, _sha256
+from gnn.temporal_model import (
+    PerNodeTemporalEncoder,
+    TemporalGraphClassifier,
+    TemporalGraphEncoder,
+    TemporalPerNodeClassifier,
+    build_encoder_from_config,
+    load_encoder_strict,
+)
+from gnn.uchicago_temporal_data import load_temporal_cache_manifest
+
+_BINARY_CLASS_COUNT = 2
+_DEFAULT_TABULAR_REFERENCE = Path(
+    "experiments/uchicago_tabular_bar_floored/gate_auc_ci.csv"
+)
+_ARM_SPECS = {
+    "graph_free_random": ("graph_free", False),
+    "graph_free_pretrained": ("graph_free", True),
+    "gnn_random": ("gnn", False),
+    "gnn_pretrained": ("gnn", True),
+}
+_COMPARISONS = {
+    "pretraining_without_graph": ("graph_free_pretrained", "graph_free_random"),
+    "connectivity_without_pretraining": ("gnn_random", "graph_free_random"),
+    "graph_pretraining": ("gnn_pretrained", "gnn_random"),
+    "pretrained_graph_beyond_dynamics": (
+        "gnn_pretrained",
+        "graph_free_pretrained",
+    ),
+}
+
+
+def _group_by_patient(
+    records: list[dict[str, object]],
+) -> dict[str, list[dict[str, object]]]:
+    groups: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for record in records:
+        if record.get("pcr") is None or record.get("fold") is None:
+            raise ValueError("downstream records require both pcr and fold")
+        groups[str(record["patient_key"])].append(record)
+    for patient, exams in groups.items():
+        labels = {int(exam["pcr"]) for exam in exams}
+        folds = {int(exam["fold"]) for exam in exams}
+        if len(labels) != 1:
+            raise ValueError(f"patient {patient} has inconsistent pCR labels: {labels}")
+        if len(folds) != 1:
+            raise ValueError(f"patient {patient} crosses outer folds: {folds}")
+    return dict(groups)
+
+
+def validate_cache_against_cohort(
+    records: list[dict[str, object]], cohort_manifest: Path
+) -> None:
+    """Require every cached exam to retain the labeled cohort identity and split."""
+    cohort = pd.read_csv(cohort_manifest)
+    required = {"exam_id", "patient_key", "fold", "pcr"}
+    missing = required - set(cohort.columns)
+    if missing:
+        raise ValueError(f"downstream cohort is missing columns: {sorted(missing)}")
+    if cohort["exam_id"].duplicated().any():
+        raise ValueError("downstream cohort contains duplicate exam_id values")
+    expected = cohort.set_index("exam_id")
+    for record in records:
+        exam_id = str(record["exam_id"])
+        if exam_id not in expected.index:
+            raise ValueError(f"cached exam {exam_id} is absent from downstream cohort")
+        row = expected.loc[exam_id]
+        identity = (
+            str(record["patient_key"]),
+            int(record["fold"]),
+            int(record["pcr"]),
+        )
+        expected_identity = (
+            str(row["patient_key"]),
+            int(row["fold"]),
+            int(row["pcr"]),
+        )
+        if identity != expected_identity:
+            raise ValueError(
+                f"cached exam {exam_id} identity/split mismatch: "
+                f"{identity} != {expected_identity}"
+            )
+
+
+def _full_exam_inputs(data: object) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    baseline_count = int(data.baseline_frame_count)
+    times = (data.times_seconds - data.times_seconds[baseline_count - 1]) / 60.0
+    return torch.nan_to_num(data.node_series), times, data.node_valid.bool()
+
+
+def _build_classifier(
+    checkpoint: dict[str, object], *, pretrained: bool
+) -> tuple[torch.nn.Module, bool]:
+    encoder = build_encoder_from_config(checkpoint["encoder_config"])
+    if pretrained:
+        load_encoder_strict(encoder, checkpoint)
+    if isinstance(encoder, TemporalGraphEncoder):
+        return TemporalGraphClassifier(encoder), True
+    if isinstance(encoder, PerNodeTemporalEncoder):
+        return TemporalPerNodeClassifier(encoder), False
+    raise TypeError(f"unsupported temporal encoder {type(encoder)}")
+
+
+def _forward_exam(
+    model: torch.nn.Module, data: object, uses_graph: bool
+) -> torch.Tensor:
+    series, times, observed = _full_exam_inputs(data)
+    if uses_graph:
+        return model(series, data.edge_index, times, observed)
+    return model(series, times, observed)
+
+
+def _load_record(record: dict[str, object], device: torch.device) -> object:
+    return torch.load(Path(str(record["graph_path"])), map_location="cpu").to(device)
+
+
+def _inner_patient_split(
+    patient_groups: dict[str, list[dict[str, object]]],
+    *,
+    val_fraction: float,
+    seed: int,
+) -> tuple[list[str], list[str]]:
+    patients = sorted(patient_groups)
+    labels = [int(patient_groups[patient][0]["pcr"]) for patient in patients]
+    train, val = train_test_split(
+        patients,
+        test_size=val_fraction,
+        random_state=seed,
+        stratify=labels,
+    )
+    return list(train), list(val)
+
+
+@torch.no_grad()
+def predict_patients(
+    model: torch.nn.Module,
+    patient_groups: dict[str, list[dict[str, object]]],
+    patients: list[str],
+    *,
+    uses_graph: bool,
+    device: torch.device,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Predict every exam, then average probabilities within patient."""
+    model.eval()
+    labels = []
+    probabilities = []
+    for patient in patients:
+        exam_probabilities = []
+        exams = patient_groups[patient]
+        for record in exams:
+            data = _load_record(record, device)
+            exam_probabilities.append(
+                torch.sigmoid(_forward_exam(model, data, uses_graph)).item()
+            )
+        labels.append(int(exams[0]["pcr"]))
+        probabilities.append(float(np.mean(exam_probabilities)))
+    return np.asarray(labels, dtype=int), np.asarray(probabilities, dtype=float)
+
+
+def _patient_loss(
+    model: torch.nn.Module,
+    patient_groups: dict[str, list[dict[str, object]]],
+    patients: list[str],
+    *,
+    uses_graph: bool,
+    device: torch.device,
+) -> float:
+    losses = []
+    model.eval()
+    with torch.no_grad():
+        for patient in patients:
+            exam_logits = []
+            exams = patient_groups[patient]
+            for record in exams:
+                exam_logits.append(
+                    _forward_exam(model, _load_record(record, device), uses_graph)
+                )
+            patient_probability = torch.sigmoid(torch.stack(exam_logits)).mean()
+            label = torch.tensor(float(exams[0]["pcr"]), device=device)
+            losses.append(
+                torch.nn.functional.binary_cross_entropy(
+                    patient_probability, label
+                ).item()
+            )
+    return float(np.mean(losses))
+
+
+def validate_matched_encoder_configs(
+    graph_checkpoint: dict[str, object], free_checkpoint: dict[str, object]
+) -> None:
+    """Require the two pretrained arms to differ only by connectivity."""
+    graph_config = dict(graph_checkpoint["encoder_config"])
+    free_config = dict(free_checkpoint["encoder_config"])
+    if graph_config.pop("encoder_type", None) != "graph":
+        raise ValueError("--gnn-checkpoint must contain a graph encoder")
+    if free_config.pop("encoder_type", None) != "graph_free":
+        raise ValueError("--graph-free-checkpoint must contain a graph-free encoder")
+    if graph_config != free_config:
+        raise ValueError(
+            "graph and graph-free checkpoints must have matched encoder "
+            "configurations apart from encoder_type"
+        )
+
+
+def protocol_only_oof(
+    patient_groups: dict[str, list[dict[str, object]]],
+) -> pd.DataFrame:
+    """Audit label prediction from acquisition timing without imaging content."""
+    rows = []
+    feature_names = ("n_frames", "duration_seconds", "median_dt_seconds")
+    for patient, exams in sorted(patient_groups.items()):
+        try:
+            features = np.asarray(
+                [[float(exam[name]) for name in feature_names] for exam in exams]
+            ).mean(axis=0)
+        except KeyError as error:
+            raise ValueError(
+                "temporal cache lacks protocol descriptors; rebuild it with the "
+                "current UChicago cache builder"
+            ) from error
+        rows.append(
+            {
+                "patient_key": patient,
+                "fold": int(exams[0]["fold"]),
+                "y_true": int(exams[0]["pcr"]),
+                **dict(zip(feature_names, features, strict=True)),
+            }
+        )
+    frame = pd.DataFrame(rows)
+    frame["y_prob"] = np.nan
+    for fold in sorted(frame["fold"].unique()):
+        train = frame["fold"] != fold
+        test = ~train
+        model = make_pipeline(
+            StandardScaler(), LogisticRegression(max_iter=2000, random_state=0)
+        )
+        model.fit(frame.loc[train, list(feature_names)], frame.loc[train, "y_true"])
+        frame.loc[test, "y_prob"] = model.predict_proba(
+            frame.loc[test, list(feature_names)]
+        )[:, 1]
+    if frame["y_prob"].isna().any():
+        raise RuntimeError("protocol-only audit did not produce every OOF prediction")
+    return frame[["patient_key", "fold", "y_true", "y_prob"]]
+
+
+def load_tabular_reference(path: Path) -> dict[str, object]:
+    """Load the strongest existing UChicago vessel-tabular OOF result."""
+    frame = pd.read_csv(path)
+    required = {"model", "pooled_oof_auc", "ci_lo", "ci_hi"}
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"tabular reference is missing columns: {sorted(missing)}")
+    candidates = frame.loc[frame["model"].astype(str).str.startswith("tabular_")]
+    if candidates.empty:
+        raise ValueError("tabular reference contains no model starting with 'tabular_'")
+    best = candidates.loc[candidates["pooled_oof_auc"].idxmax()]
+    return {
+        "model": str(best["model"]),
+        "auc": float(best["pooled_oof_auc"]),
+        "ci_low": float(best["ci_lo"]),
+        "ci_high": float(best["ci_hi"]),
+        "source": str(path),
+        "role": "existing_exam_level_reference_not_paired_with_patient_level_arms",
+    }
+
+
+def fit_fold(
+    model: torch.nn.Module,
+    train_groups: dict[str, list[dict[str, object]]],
+    *,
+    uses_graph: bool,
+    epochs: int,
+    learning_rate: float,
+    inner_val_fraction: float,
+    seed: int,
+    device: torch.device,
+) -> tuple[torch.nn.Module, list[dict[str, float]]]:
+    """Fine-tune the entire encoder and head from epoch one."""
+    fit_patients, inner_patients = _inner_patient_split(
+        train_groups, val_fraction=inner_val_fraction, seed=seed
+    )
+    model.to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    criterion = torch.nn.BCEWithLogitsLoss()
+    generator = torch.Generator().manual_seed(seed)
+    best_state = None
+    best_loss = float("inf")
+    history = []
+    for epoch in range(1, epochs + 1):
+        model.train()
+        order = torch.randperm(len(fit_patients), generator=generator).tolist()
+        epoch_losses = []
+        for patient_index in order:
+            patient = fit_patients[patient_index]
+            exams = train_groups[patient]
+            exam_index = int(torch.randint(len(exams), (1,), generator=generator))
+            record = exams[exam_index]
+            data = _load_record(record, device)
+            optimizer.zero_grad()
+            logit = _forward_exam(model, data, uses_graph).squeeze()
+            label = torch.tensor(float(record["pcr"]), device=device)
+            loss = criterion(logit, label)
+            loss.backward()
+            optimizer.step()
+            epoch_losses.append(loss.item())
+        inner_loss = _patient_loss(
+            model,
+            train_groups,
+            inner_patients,
+            uses_graph=uses_graph,
+            device=device,
+        )
+        history.append(
+            {
+                "epoch": float(epoch),
+                "train_loss": float(np.mean(epoch_losses)),
+                "inner_val_loss": inner_loss,
+            }
+        )
+        if inner_loss < best_loss:
+            best_loss = inner_loss
+            best_state = deepcopy(model.state_dict())
+    if best_state is None:
+        raise RuntimeError("fine-tuning produced no selected checkpoint")
+    model.load_state_dict(best_state)
+    return model, history
+
+
+def _bootstrap_auc(
+    y: np.ndarray, probability: np.ndarray, *, seed: int, n_bootstrap: int = 2000
+) -> tuple[float, float, float]:
+    auc = float(roc_auc_score(y, probability))
+    rng = np.random.default_rng(seed)
+    values = []
+    for _ in range(n_bootstrap):
+        index = rng.integers(0, len(y), len(y))
+        if np.unique(y[index]).size == _BINARY_CLASS_COUNT:
+            values.append(roc_auc_score(y[index], probability[index]))
+    if not values:
+        raise ValueError("no valid patient-level bootstrap samples")
+    low, high = np.quantile(values, [0.025, 0.975])
+    return auc, float(low), float(high)
+
+
+def _paired_auc_delta(
+    predictions: pd.DataFrame,
+    arm_a: str,
+    arm_b: str,
+    *,
+    seed: int,
+    n_bootstrap: int = 2000,
+) -> dict[str, float]:
+    """Patient-resampled paired OOF AUC difference ``arm_a - arm_b``."""
+    left = predictions.loc[
+        predictions["arm"] == arm_a, ["patient_key", "y_true", "y_prob"]
+    ].rename(columns={"y_prob": "prob_a"})
+    right = predictions.loc[
+        predictions["arm"] == arm_b, ["patient_key", "y_true", "y_prob"]
+    ].rename(columns={"y_prob": "prob_b"})
+    paired = left.merge(
+        right,
+        on=["patient_key", "y_true"],
+        how="inner",
+        validate="one_to_one",
+    )
+    expected = predictions.loc[predictions["arm"] == arm_a, "patient_key"].nunique()
+    if len(paired) != expected:
+        raise ValueError(f"arms {arm_a} and {arm_b} do not have identical patients")
+    y = paired["y_true"].to_numpy()
+    prob_a = paired["prob_a"].to_numpy()
+    prob_b = paired["prob_b"].to_numpy()
+    point = float(roc_auc_score(y, prob_a) - roc_auc_score(y, prob_b))
+    rng = np.random.default_rng(seed)
+    values = []
+    for _ in range(n_bootstrap):
+        index = rng.integers(0, len(y), len(y))
+        if np.unique(y[index]).size == _BINARY_CLASS_COUNT:
+            values.append(
+                roc_auc_score(y[index], prob_a[index])
+                - roc_auc_score(y[index], prob_b[index])
+            )
+    low, high = np.quantile(values, [0.025, 0.975])
+    return {"delta_auc": point, "ci_low": float(low), "ci_high": float(high)}
+
+
+def _arm_metrics(predictions: pd.DataFrame, *, seed: int) -> dict[str, object]:
+    metrics: dict[str, object] = {}
+    for arm_name, arm_frame in predictions.groupby("arm"):
+        auc, low, high = _bootstrap_auc(
+            arm_frame["y_true"].to_numpy(),
+            arm_frame["y_prob"].to_numpy(),
+            seed=seed,
+        )
+        metrics[str(arm_name)] = {"auc": auc, "ci_low": low, "ci_high": high}
+    return metrics
+
+
+def load_parallel_arm_predictions(outdir: Path) -> pd.DataFrame:
+    """Load one complete patient-level prediction table from every 2x2 arm."""
+    frames = []
+    expected_patients = None
+    for arm in _ARM_SPECS:
+        path = outdir / arm / "patient_predictions.csv"
+        if not path.is_file():
+            raise FileNotFoundError(f"missing completed arm predictions: {path}")
+        frame = pd.read_csv(path)
+        required = {"arm", "fold", "patient_key", "y_true", "y_prob", "n_exams"}
+        missing = required - set(frame.columns)
+        if missing:
+            raise ValueError(f"{path} is missing columns: {sorted(missing)}")
+        if set(frame["arm"].astype(str)) != {arm}:
+            raise ValueError(f"{path} contains predictions for the wrong arm")
+        patients = set(frame["patient_key"].astype(str))
+        if expected_patients is None:
+            expected_patients = patients
+        elif patients != expected_patients:
+            raise ValueError("parallel arms do not contain identical patient sets")
+        if frame["patient_key"].duplicated().any():
+            raise ValueError(f"{path} contains duplicate patient predictions")
+        frames.append(frame)
+    return pd.concat(frames, ignore_index=True)
+
+
+def _reproduction_command(args: argparse.Namespace) -> str:
+    values = (
+        ("cache-dir", args.cache_dir),
+        ("cohort-manifest", args.cohort_manifest),
+        ("gnn-checkpoint", args.gnn_checkpoint),
+        ("graph-free-checkpoint", args.graph_free_checkpoint),
+        ("outdir", args.outdir),
+        ("tabular-reference", args.tabular_reference),
+        ("epochs", args.epochs),
+        ("learning-rate", args.learning_rate),
+        ("inner-val-fraction", args.inner_val_fraction),
+        ("seed", args.seed),
+        ("arm", args.arm),
+        ("device", args.device),
+    )
+    flags = " ".join(f"--{name} {value}" for name, value in values)
+    if args.aggregate_only:
+        flags += " --aggregate-only"
+    return f"python -u -m gnn.temporal_finetune {flags}"
+
+
+def _result_artifacts(outdir: Path, *, aggregate: bool) -> list[Path]:
+    paths = [outdir / "patient_predictions.csv", outdir / "metrics.json"]
+    if aggregate:
+        paths.append(outdir / "protocol_only_patient_predictions.csv")
+        for arm in _ARM_SPECS:
+            paths.extend(
+                [
+                    outdir / arm / "patient_predictions.csv",
+                    outdir / arm / "metrics.json",
+                    outdir / arm / "history.json",
+                    outdir / arm / "README.md",
+                ]
+            )
+    else:
+        paths.append(outdir / "history.json")
+    return paths
+
+
+def write_finetune_readme(
+    *,
+    args: argparse.Namespace,
+    manifest: dict[str, object],
+    metrics: dict[str, object],
+    predictions: pd.DataFrame,
+    aggregate: bool,
+) -> Path:
+    """Write the mandatory self-contained provenance note for a downstream result."""
+    commit, status = _git_provenance()
+    cache_manifest = args.cache_dir / "temporal_cache_manifest.json"
+    source_manifest = Path(str(manifest["source_manifest"]))
+    cohort_exam_count = pd.read_csv(
+        args.cohort_manifest, usecols=["exam_id"]
+    )["exam_id"].nunique()
+    fold_counts = (
+        predictions.drop_duplicates("patient_key")["fold"]
+        .value_counts()
+        .sort_index()
+        .to_dict()
+    )
+    artifacts = [
+        f"- `{path.relative_to(args.outdir)}` SHA-256 `{_sha256(path)}`"
+        for path in _result_artifacts(args.outdir, aggregate=aggregate)
+        if path.is_file()
+    ]
+    if aggregate:
+        result_rows = [
+            f"| {arm} | {float(metrics[arm]['auc']):.6f} | "
+            f"{float(metrics[arm]['ci_low']):.6f} | "
+            f"{float(metrics[arm]['ci_high']):.6f} |"
+            for arm in _ARM_SPECS
+        ]
+        delta_rows = [
+            f"| {name} | {arm_a} - {arm_b} | "
+            f"{float(metrics['paired_oof_auc_differences'][name]['delta_auc']):+.6f} | "
+            f"{float(metrics['paired_oof_auc_differences'][name]['ci_low']):+.6f} | "
+            f"{float(metrics['paired_oof_auc_differences'][name]['ci_high']):+.6f} |"
+            for name, (arm_a, arm_b) in _COMPARISONS.items()
+        ]
+        title = "UChicago temporal-transfer downstream 2x2"
+        status_line = "Complete: all four matched arms and paired OOF comparisons."
+        results_text = f"""| Arm | Patient-level pooled OOF AUC | 95% CI low | 95% CI high |
+|---|---:|---:|---:|---:|
+{chr(10).join(result_rows)}
+
+| Question | Contrast | Delta AUC | 95% CI low | 95% CI high |
+|---|---|---:|---:|---:|
+{chr(10).join(delta_rows)}"""
+        interpretation = (
+            "The paired contrasts, rather than any arm in isolation, decide whether "
+            "pretraining or connectivity helps. A confidence interval spanning zero "
+            "does not support a resolved improvement on this cohort."
+        )
+    else:
+        arm = str(predictions["arm"].iloc[0])
+        arm_metric = metrics[arm]
+        title = f"UChicago temporal-transfer arm: {arm}"
+        status_line = "Complete as one arm; scientific interpretation awaits aggregation."
+        results_text = (
+            "| Arm | Patient-level pooled OOF AUC | 95% CI low | 95% CI high |\n"
+            "|---|---:|---:|---:|---:|\n"
+            f"| {arm} | {float(arm_metric['auc']):.6f} | "
+            f"{float(arm_metric['ci_low']):.6f} | "
+            f"{float(arm_metric['ci_high']):.6f} |"
+        )
+        interpretation = (
+            "Do not interpret this arm alone. The decision requires paired predictions "
+            "from all four matched connectivity-by-initialization arms."
+        )
+    status_text = status if status else "clean"
+    readme = f"""# {title}
+
+## Status and question
+
+{status_line} The experiment tests whether future-frame pretraining and/or vascular
+message passing improves patient-level pCR discrimination.
+
+## Results
+
+{results_text}
+
+## Data and split
+
+- Anna-confirmed larger downstream cohort: `{args.cohort_manifest}`
+- Downstream cohort SHA-256: `{_sha256(args.cohort_manifest)}`
+- Audited temporal cache: `{args.cache_dir}`
+- Cache manifest SHA-256: `{_sha256(cache_manifest)}`
+- Cache source manifest: `{source_manifest}`
+- Cache source manifest SHA-256: `{_sha256(source_manifest)}`
+- GNN pretraining checkpoint: `{args.gnn_checkpoint}`
+- GNN checkpoint SHA-256: `{_sha256(args.gnn_checkpoint)}`
+- Graph-free pretraining checkpoint: `{args.graph_free_checkpoint}`
+- Graph-free checkpoint SHA-256: `{_sha256(args.graph_free_checkpoint)}`
+- Cached usable exams: {len(manifest['records'])} of {cohort_exam_count} cohort exams
+- Patients: {predictions['patient_key'].nunique()}
+- Outer split: predefined patient-grouped five-fold OOF; patient counts {fold_counts}
+- Inner selection split: pCR-stratified patient split, fraction {args.inner_val_fraction},
+  seed `seed + outer_fold`; outer labels are used only for final prediction.
+
+## Matched configuration
+
+- Epochs: {args.epochs}
+- Learning rate: {args.learning_rate}
+- Seed: {args.seed}
+- Encoder: hidden dimension 32, two frame layers, one GRU layer, dropout 0.2
+- Fine-tuning: full encoder and linear classification head from epoch one
+- Patient prediction: mean of exam probabilities
+- Primary metric: pooled patient-level OOF AUC
+- Uncertainty: 2,000 paired patient-resampling bootstrap replicates
+
+## Scheduler and artifacts
+
+- Slurm job ID: `{os.environ.get('SLURM_JOB_ID', 'not available')}`
+- Parallel arm job IDs: `{os.environ.get('ARM_JOB_IDS', 'not available')}`
+{chr(10).join(artifacts)}
+
+## Reproduce
+
+```bash
+{_reproduction_command(args)}
+```
+
+## Code provenance
+
+- Git commit: `{commit}`
+- Dirty-worktree status at README creation:
+
+```text
+{status_text}
+```
+
+## Interpretation and limits
+
+{interpretation} This is one fixed cohort and one training seed. The existing tabular
+reference is exam-level and is therefore contextual, not a paired patient-level control.
+"""
+    path = args.outdir / "README.md"
+    path.write_text(readme)
+    return path
+
+
+def write_aggregate_provenance(outdir: Path) -> None:
+    """Record scheduler evidence and checksums after all downstream arms complete."""
+    provenance = outdir / "provenance"
+    provenance.mkdir(parents=True, exist_ok=True)
+    snapshot = provenance / "source_snapshot.tar.gz"
+    snapshot_line = (
+        f"- `source_snapshot.tar.gz` SHA-256 `{_sha256(snapshot)}`"
+        if snapshot.is_file()
+        else "- Source snapshot was not present when aggregation ran."
+    )
+    (provenance / "README.md").write_text(
+        "# Downstream 2x2 provenance\n\n"
+        f"- Parallel arm job IDs: `{os.environ.get('ARM_JOB_IDS', 'not available')}`\n"
+        f"- Aggregation job ID: `{os.environ.get('SLURM_JOB_ID', 'not available')}`\n"
+        "- Slurm stdout/stderr files in this directory are named by job and ID.\n"
+        f"{snapshot_line}\n"
+        "- `artifact_checksums.sha256` verifies completed result artifacts.\n"
+    )
+
+
+def write_aggregate_checksums(outdir: Path) -> Path:
+    """Write checksums for the finalized downstream outputs and source snapshot."""
+    candidates = _result_artifacts(outdir, aggregate=True) + [
+        outdir / "README.md",
+        outdir / "provenance" / "README.md",
+        outdir / "provenance" / "source_snapshot.tar.gz",
+    ]
+    lines = [
+        f"{_sha256(path)}  {path.relative_to(outdir)}"
+        for path in candidates
+        if path.is_file()
+    ]
+    checksum_path = outdir / "provenance" / "artifact_checksums.sha256"
+    checksum_path.write_text("\n".join(lines) + "\n")
+    return checksum_path
+
+
+def aggregate_parallel_results(
+    *,
+    args: argparse.Namespace,
+    manifest: dict[str, object],
+    patient_groups: dict[str, list[dict[str, object]]],
+) -> dict[str, object]:
+    """Combine parallel arm outputs and compute the predeclared paired readouts."""
+    predictions = load_parallel_arm_predictions(args.outdir)
+    metrics = _arm_metrics(predictions, seed=args.seed)
+    metrics["paired_oof_auc_differences"] = {
+        name: _paired_auc_delta(predictions, arm_a, arm_b, seed=args.seed)
+        for name, (arm_a, arm_b) in _COMPARISONS.items()
+    }
+    protocol_predictions = protocol_only_oof(patient_groups)
+    protocol_auc, protocol_low, protocol_high = _bootstrap_auc(
+        protocol_predictions["y_true"].to_numpy(),
+        protocol_predictions["y_prob"].to_numpy(),
+        seed=args.seed,
+    )
+    metrics["protocol_only_audit"] = {
+        "auc": protocol_auc,
+        "ci_low": protocol_low,
+        "ci_high": protocol_high,
+        "features": ["n_frames", "duration_seconds", "median_dt_seconds"],
+        "primary_model_residualized": False,
+    }
+    metrics["existing_tabular_reference"] = load_tabular_reference(
+        args.tabular_reference
+    )
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    predictions.to_csv(args.outdir / "patient_predictions.csv", index=False)
+    protocol_predictions.to_csv(
+        args.outdir / "protocol_only_patient_predictions.csv", index=False
+    )
+    (args.outdir / "metrics.json").write_text(json.dumps(metrics, indent=2) + "\n")
+    write_aggregate_provenance(args.outdir)
+    write_finetune_readme(
+        args=args,
+        manifest=manifest,
+        metrics=metrics,
+        predictions=predictions,
+        aggregate=True,
+    )
+    write_aggregate_checksums(args.outdir)
+    return metrics
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse labeled-cache, checkpoint, and fine-tuning settings."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cache-dir", type=Path, required=True)
+    parser.add_argument("--cohort-manifest", type=Path, required=True)
+    parser.add_argument("--gnn-checkpoint", type=Path, required=True)
+    parser.add_argument("--graph-free-checkpoint", type=Path, required=True)
+    parser.add_argument("--outdir", type=Path, required=True)
+    parser.add_argument(
+        "--tabular-reference", type=Path, default=_DEFAULT_TABULAR_REFERENCE
+    )
+    parser.add_argument("--epochs", type=int, default=50)
+    parser.add_argument("--learning-rate", type=float, default=3e-4)
+    parser.add_argument("--inner-val-fraction", type=float, default=0.2)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--arm", choices=("all", *_ARM_SPECS), required=True)
+    parser.add_argument("--aggregate-only", action="store_true")
+    parser.add_argument("--device", default="cuda")
+    args = parser.parse_args(argv)
+    if args.aggregate_only and args.arm != "all":
+        parser.error("--aggregate-only requires --arm all")
+    if not args.aggregate_only and args.arm == "all":
+        parser.error("--arm all is reserved for --aggregate-only")
+    return args
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run one temporal arm or aggregate all four arms on fixed outer folds."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    args = parse_args(argv)
+    manifest = load_temporal_cache_manifest(args.cache_dir)
+    records = list(manifest["records"])
+    validate_cache_against_cohort(records, args.cohort_manifest)
+    patient_groups = _group_by_patient(records)
+    graph_checkpoint = load_checkpoint(args.gnn_checkpoint)
+    free_checkpoint = load_checkpoint(args.graph_free_checkpoint)
+    validate_matched_encoder_configs(graph_checkpoint, free_checkpoint)
+    if args.aggregate_only:
+        aggregate_parallel_results(
+            args=args, manifest=manifest, patient_groups=patient_groups
+        )
+        return
+
+    checkpoint_by_kind = {"gnn": graph_checkpoint, "graph_free": free_checkpoint}
+    kind, pretrained = _ARM_SPECS[args.arm]
+    outer_folds = sorted({int(record["fold"]) for record in records})
+    rows = []
+    history_rows = []
+    device = torch.device(args.device)
+    for fold in outer_folds:
+        outer_patients = sorted(
+            patient
+            for patient, exams in patient_groups.items()
+            if int(exams[0]["fold"]) == fold
+        )
+        outer_patient_set = set(outer_patients)
+        train_groups = {
+            patient: exams
+            for patient, exams in patient_groups.items()
+            if patient not in outer_patient_set
+        }
+        torch.manual_seed(args.seed + fold)
+        model, uses_graph = _build_classifier(
+            checkpoint_by_kind[kind], pretrained=pretrained
+        )
+        model, history = fit_fold(
+            model,
+            train_groups,
+            uses_graph=uses_graph,
+            epochs=args.epochs,
+            learning_rate=args.learning_rate,
+            inner_val_fraction=args.inner_val_fraction,
+            seed=args.seed + fold,
+            device=device,
+        )
+        y, probability = predict_patients(
+            model,
+            patient_groups,
+            outer_patients,
+            uses_graph=uses_graph,
+            device=device,
+        )
+        rows.extend(
+            {
+                "arm": args.arm,
+                "fold": fold,
+                "patient_key": patient,
+                "y_true": int(label),
+                "y_prob": float(prob),
+                "n_exams": len(patient_groups[patient]),
+            }
+            for patient, label, prob in zip(
+                outer_patients, y, probability, strict=True
+            )
+        )
+        history_rows.extend({"fold": fold, **item} for item in history)
+
+    predictions = pd.DataFrame(rows)
+    metrics = _arm_metrics(predictions, seed=args.seed)
+    args.outdir.mkdir(parents=True, exist_ok=True)
+    predictions.to_csv(args.outdir / "patient_predictions.csv", index=False)
+    (args.outdir / "metrics.json").write_text(json.dumps(metrics, indent=2) + "\n")
+    (args.outdir / "history.json").write_text(
+        json.dumps({args.arm: history_rows}, indent=2) + "\n"
+    )
+    write_finetune_readme(
+        args=args,
+        manifest=manifest,
+        metrics=metrics,
+        predictions=predictions,
+        aggregate=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/gnn/temporal_finetune.py
+++ b/gnn/temporal_finetune.py
@@ -296,8 +296,8 @@ def fit_fold(
     inner_val_fraction: float,
     seed: int,
     device: torch.device,
-) -> tuple[torch.nn.Module, list[dict[str, float]]]:
-    """Fine-tune the entire encoder and head from epoch one."""
+) -> tuple[torch.nn.Module, list[dict[str, float]], dict[str, int]]:
+    """Select the training duration on a patient-level inner split."""
     fit_patients, inner_patients = _inner_patient_split(
         train_groups, val_fraction=inner_val_fraction, seed=seed
     )
@@ -307,6 +307,7 @@ def fit_fold(
     generator = torch.Generator().manual_seed(seed)
     best_state = None
     best_loss = float("inf")
+    best_epoch = 0
     history = []
     for epoch in range(1, epochs + 1):
         model.train()
@@ -341,10 +342,62 @@ def fit_fold(
         )
         if inner_loss < best_loss:
             best_loss = inner_loss
+            best_epoch = epoch
             best_state = deepcopy(model.state_dict())
     if best_state is None:
         raise RuntimeError("fine-tuning produced no selected checkpoint")
     model.load_state_dict(best_state)
+    return (
+        model,
+        history,
+        {
+            "selection_fit_patients": len(fit_patients),
+            "inner_val_patients": len(inner_patients),
+            "selected_epoch": best_epoch,
+        },
+    )
+
+
+def refit_fold_on_all_outer_train(
+    model: torch.nn.Module,
+    initial_state: dict[str, torch.Tensor],
+    train_groups: dict[str, list[dict[str, object]]],
+    *,
+    uses_graph: bool,
+    epochs: int,
+    learning_rate: float,
+    seed: int,
+    device: torch.device,
+) -> tuple[torch.nn.Module, list[dict[str, float]]]:
+    """Restart from initialization and fit every outer-training patient."""
+    model.load_state_dict(initial_state)
+    model.to(device)
+    torch.manual_seed(seed)
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+    criterion = torch.nn.BCEWithLogitsLoss()
+    generator = torch.Generator().manual_seed(seed)
+    patients = sorted(train_groups)
+    history = []
+    for epoch in range(1, epochs + 1):
+        model.train()
+        order = torch.randperm(len(patients), generator=generator).tolist()
+        epoch_losses = []
+        for patient_index in order:
+            patient = patients[patient_index]
+            exams = train_groups[patient]
+            exam_index = int(torch.randint(len(exams), (1,), generator=generator))
+            record = exams[exam_index]
+            data = _load_record(record, device)
+            optimizer.zero_grad()
+            logit = _forward_exam(model, data, uses_graph).squeeze()
+            label = torch.tensor(float(record["pcr"]), device=device)
+            loss = criterion(logit, label)
+            loss.backward()
+            optimizer.step()
+            epoch_losses.append(loss.item())
+        history.append(
+            {"epoch": float(epoch), "train_loss": float(np.mean(epoch_losses))}
+        )
     return model, history
 
 
@@ -494,9 +547,9 @@ def write_finetune_readme(
     commit, status = _git_provenance()
     cache_manifest = args.cache_dir / "temporal_cache_manifest.json"
     source_manifest = Path(str(manifest["source_manifest"]))
-    cohort_exam_count = pd.read_csv(
-        args.cohort_manifest, usecols=["exam_id"]
-    )["exam_id"].nunique()
+    cohort_exam_count = pd.read_csv(args.cohort_manifest, usecols=["exam_id"])[
+        "exam_id"
+    ].nunique()
     fold_counts = (
         predictions.drop_duplicates("patient_key")["fold"]
         .value_counts()
@@ -540,7 +593,9 @@ def write_finetune_readme(
         arm = str(predictions["arm"].iloc[0])
         arm_metric = metrics[arm]
         title = f"UChicago temporal-transfer arm: {arm}"
-        status_line = "Complete as one arm; scientific interpretation awaits aggregation."
+        status_line = (
+            "Complete as one arm; scientific interpretation awaits aggregation."
+        )
         results_text = (
             "| Arm | Patient-level pooled OOF AUC | 95% CI low | 95% CI high |\n"
             "|---|---:|---:|---:|---:|\n"
@@ -576,11 +631,13 @@ message passing improves patient-level pCR discrimination.
 - GNN checkpoint SHA-256: `{_sha256(args.gnn_checkpoint)}`
 - Graph-free pretraining checkpoint: `{args.graph_free_checkpoint}`
 - Graph-free checkpoint SHA-256: `{_sha256(args.graph_free_checkpoint)}`
-- Cached usable exams: {len(manifest['records'])} of {cohort_exam_count} cohort exams
-- Patients: {predictions['patient_key'].nunique()}
+- Cached usable exams: {len(manifest["records"])} of {cohort_exam_count} cohort exams
+- Patients: {predictions["patient_key"].nunique()}
 - Outer split: predefined patient-grouped five-fold OOF; patient counts {fold_counts}
 - Inner selection split: pCR-stratified patient split, fraction {args.inner_val_fraction},
   seed `seed + outer_fold`; outer labels are used only for final prediction.
+- After epoch selection, the model restarts from the fold's original initialization and
+  trains on every outer-training patient before predicting the untouched outer fold.
 
 ## Matched configuration
 
@@ -589,14 +646,15 @@ message passing improves patient-level pCR discrimination.
 - Seed: {args.seed}
 - Encoder: hidden dimension 32, two frame layers, one GRU layer, dropout 0.2
 - Fine-tuning: full encoder and linear classification head from epoch one
+- Final fold model: refit on the complete outer-training set for the selected epoch count
 - Patient prediction: mean of exam probabilities
 - Primary metric: pooled patient-level OOF AUC
 - Uncertainty: 2,000 paired patient-resampling bootstrap replicates
 
 ## Scheduler and artifacts
 
-- Slurm job ID: `{os.environ.get('SLURM_JOB_ID', 'not available')}`
-- Parallel arm job IDs: `{os.environ.get('ARM_JOB_IDS', 'not available')}`
+- Slurm job ID: `{os.environ.get("SLURM_JOB_ID", "not available")}`
+- Parallel arm job IDs: `{os.environ.get("ARM_JOB_IDS", "not available")}`
 {chr(10).join(artifacts)}
 
 ## Reproduce
@@ -775,13 +833,25 @@ def main(argv: list[str] | None = None) -> None:
         model, uses_graph = _build_classifier(
             checkpoint_by_kind[kind], pretrained=pretrained
         )
-        model, history = fit_fold(
+        initial_state = deepcopy(model.state_dict())
+        model, history, fit_metadata = fit_fold(
             model,
             train_groups,
             uses_graph=uses_graph,
             epochs=args.epochs,
             learning_rate=args.learning_rate,
             inner_val_fraction=args.inner_val_fraction,
+            seed=args.seed + fold,
+            device=device,
+        )
+        fit_metadata["refit_patients"] = len(train_groups)
+        model, refit_history = refit_fold_on_all_outer_train(
+            model,
+            initial_state,
+            train_groups,
+            uses_graph=uses_graph,
+            epochs=fit_metadata["selected_epoch"],
+            learning_rate=args.learning_rate,
             seed=args.seed + fold,
             device=device,
         )
@@ -801,11 +871,16 @@ def main(argv: list[str] | None = None) -> None:
                 "y_prob": float(prob),
                 "n_exams": len(patient_groups[patient]),
             }
-            for patient, label, prob in zip(
-                outer_patients, y, probability, strict=True
-            )
+            for patient, label, prob in zip(outer_patients, y, probability, strict=True)
         )
-        history_rows.extend({"fold": fold, **item} for item in history)
+        history_rows.extend(
+            {"fold": fold, "phase": "selection", **fit_metadata, **item}
+            for item in history
+        )
+        history_rows.extend(
+            {"fold": fold, "phase": "refit", **fit_metadata, **item}
+            for item in refit_history
+        )
 
     predictions = pd.DataFrame(rows)
     metrics = _arm_metrics(predictions, seed=args.seed)

--- a/gnn/temporal_model.py
+++ b/gnn/temporal_model.py
@@ -1,0 +1,357 @@
+"""Shared temporal encoders for forecasting and patient-level pCR models.
+
+The forecasting and downstream models own different heads, but they use the
+same encoder object.  Encoder checkpoints can therefore be loaded strictly;
+there is no manual layer copying between architectures with different inputs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+from torch import nn
+from torch_geometric.nn import GCNConv
+
+from gnn.model import _graph_readout
+
+_TIME_CHANNELS = 1
+_VALIDITY_CHANNELS = 1
+_NDIM_TEMPORAL = 3
+BASELINE_POLICY = "finite_S0_gt_0.05_case_median_then_simultaneous_neighbor_median"
+
+
+def _validate_temporal_inputs(
+    node_series: torch.Tensor,
+    acquisition_times: torch.Tensor,
+    baseline_observed: torch.Tensor,
+) -> tuple[int, int]:
+    if node_series.ndim != _NDIM_TEMPORAL:
+        raise ValueError(
+            "node_series must be (num_nodes, num_frames, signal_channels); "
+            f"got {tuple(node_series.shape)}"
+        )
+    num_nodes, num_frames, _ = node_series.shape
+    if acquisition_times.ndim != 1 or acquisition_times.shape[0] != num_frames:
+        raise ValueError(
+            f"acquisition_times/input_times must be 1D with {num_frames} entries; "
+            f"got {tuple(acquisition_times.shape)}"
+        )
+    if baseline_observed.ndim != 1 or baseline_observed.shape[0] != num_nodes:
+        raise ValueError(
+            f"baseline_observed must be 1D with {num_nodes} entries; "
+            f"got {tuple(baseline_observed.shape)}"
+        )
+    return num_nodes, num_frames
+
+
+def _augment_frames(
+    node_series: torch.Tensor,
+    acquisition_times: torch.Tensor,
+    baseline_observed: torch.Tensor,
+) -> torch.Tensor:
+    """Append acquisition time and original-baseline validity to every frame."""
+    num_nodes, num_frames = _validate_temporal_inputs(
+        node_series, acquisition_times, baseline_observed
+    )
+    times = (
+        acquisition_times.to(device=node_series.device, dtype=node_series.dtype)
+        .view(1, num_frames, _TIME_CHANNELS)
+        .expand(num_nodes, num_frames, _TIME_CHANNELS)
+    )
+    observed = (
+        baseline_observed.to(device=node_series.device, dtype=node_series.dtype)
+        .view(num_nodes, 1, _VALIDITY_CHANNELS)
+        .expand(num_nodes, num_frames, _VALIDITY_CHANNELS)
+    )
+    return torch.cat([node_series, times, observed], dim=-1)
+
+
+class TemporalGraphEncoder(nn.Module):
+    """Per-frame GCN stack followed by a per-node GRU.
+
+    Inputs use minutes relative to the exam's last baseline acquisition.  The
+    return value is one hidden vector per node and is shared without adaptation
+    by forecasting and downstream classification.
+    """
+
+    encoder_type = "graph"
+
+    def __init__(
+        self,
+        *,
+        signal_channels: int = 1,
+        hidden_dim: int = 32,
+        num_gcn_layers: int = 2,
+        num_gru_layers: int = 1,
+        dropout: float = 0.2,
+    ) -> None:
+        super().__init__()
+        if signal_channels < 1:
+            raise ValueError("signal_channels must be >= 1")
+        if hidden_dim < 1:
+            raise ValueError("hidden_dim must be >= 1")
+        if num_gcn_layers < 1:
+            raise ValueError("num_gcn_layers must be >= 1")
+        if num_gru_layers < 1:
+            raise ValueError("num_gru_layers must be >= 1")
+        self.signal_channels = signal_channels
+        self.hidden_dim = hidden_dim
+        self.num_gcn_layers = num_gcn_layers
+        self.num_gru_layers = num_gru_layers
+        self.dropout_p = dropout
+
+        self.convs = nn.ModuleList()
+        in_dim = signal_channels + _TIME_CHANNELS + _VALIDITY_CHANNELS
+        for _ in range(num_gcn_layers):
+            self.convs.append(GCNConv(in_dim, hidden_dim))
+            in_dim = hidden_dim
+        self.dropout = nn.Dropout(dropout)
+        self.gru = nn.GRU(
+            input_size=hidden_dim,
+            hidden_size=hidden_dim,
+            num_layers=num_gru_layers,
+            batch_first=True,
+        )
+
+    def config(self) -> dict[str, object]:
+        """Architecture/preprocessing fields required for strict reconstruction."""
+        return {
+            "encoder_type": self.encoder_type,
+            "graph_mode": "voxel",
+            "input_channels": ["relative_enhancement", "baseline_observed"],
+            "signal_channels": self.signal_channels,
+            "hidden_dim": self.hidden_dim,
+            "num_gcn_layers": self.num_gcn_layers,
+            "num_gru_layers": self.num_gru_layers,
+            "dropout": self.dropout_p,
+            "time_units": "minutes_since_last_baseline",
+            "baseline_policy": BASELINE_POLICY,
+        }
+
+    def forward(
+        self,
+        node_series: torch.Tensor,
+        edge_index: torch.Tensor,
+        acquisition_times: torch.Tensor,
+        baseline_observed: torch.Tensor,
+    ) -> torch.Tensor:
+        frames = _augment_frames(node_series, acquisition_times, baseline_observed)
+        encoded_frames: list[torch.Tensor] = []
+        for frame_idx in range(frames.shape[1]):
+            h = frames[:, frame_idx, :]
+            for conv in self.convs:
+                h = self.dropout(torch.relu(conv(h, edge_index)))
+            encoded_frames.append(h)
+        sequence = torch.stack(encoded_frames, dim=1)
+        output, _ = self.gru(sequence)
+        return output[:, -1, :]
+
+
+class PerNodeTemporalEncoder(nn.Module):
+    """Graph-free matched encoder: frame MLP followed by the same GRU."""
+
+    encoder_type = "graph_free"
+
+    def __init__(
+        self,
+        *,
+        signal_channels: int = 1,
+        hidden_dim: int = 32,
+        num_gcn_layers: int = 2,
+        num_gru_layers: int = 1,
+        dropout: float = 0.2,
+    ) -> None:
+        super().__init__()
+        if signal_channels < 1 or hidden_dim < 1:
+            raise ValueError("signal_channels and hidden_dim must be >= 1")
+        if num_gcn_layers < 1:
+            raise ValueError("num_layers/num_gcn_layers must be >= 1")
+        if num_gru_layers < 1:
+            raise ValueError("num_gru_layers must be >= 1")
+        self.signal_channels = signal_channels
+        self.hidden_dim = hidden_dim
+        self.num_gcn_layers = num_gcn_layers
+        self.num_gru_layers = num_gru_layers
+        self.dropout_p = dropout
+        layers: list[nn.Module] = []
+        in_dim = signal_channels + _TIME_CHANNELS + _VALIDITY_CHANNELS
+        for _ in range(num_gcn_layers):
+            layers.extend(
+                [nn.Linear(in_dim, hidden_dim), nn.ReLU(), nn.Dropout(dropout)]
+            )
+            in_dim = hidden_dim
+        self.frame_encoder = nn.Sequential(*layers)
+        self.gru = nn.GRU(
+            input_size=hidden_dim,
+            hidden_size=hidden_dim,
+            num_layers=num_gru_layers,
+            batch_first=True,
+        )
+
+    def config(self) -> dict[str, object]:
+        return {
+            "encoder_type": self.encoder_type,
+            "graph_mode": "voxel",
+            "input_channels": ["relative_enhancement", "baseline_observed"],
+            "signal_channels": self.signal_channels,
+            "hidden_dim": self.hidden_dim,
+            "num_gcn_layers": self.num_gcn_layers,
+            "num_gru_layers": self.num_gru_layers,
+            "dropout": self.dropout_p,
+            "time_units": "minutes_since_last_baseline",
+            "baseline_policy": BASELINE_POLICY,
+        }
+
+    def forward(
+        self,
+        node_series: torch.Tensor,
+        acquisition_times: torch.Tensor,
+        baseline_observed: torch.Tensor,
+    ) -> torch.Tensor:
+        frames = _augment_frames(node_series, acquisition_times, baseline_observed)
+        num_nodes, num_frames, channels = frames.shape
+        encoded = self.frame_encoder(frames.reshape(num_nodes * num_frames, channels))
+        encoded = encoded.reshape(num_nodes, num_frames, self.hidden_dim)
+        output, _ = self.gru(encoded)
+        return output[:, -1, :]
+
+
+class TimeConditionedForecastDecoder(nn.Module):
+    """Decode future enhancement at horizons relative to the last input frame."""
+
+    def __init__(self, hidden_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(hidden_dim + 1, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(
+        self, node_embedding: torch.Tensor, target_horizon: torch.Tensor
+    ) -> torch.Tensor:
+        if target_horizon.ndim != 1:
+            raise ValueError("target_horizon must be one-dimensional")
+        num_nodes, hidden_dim = node_embedding.shape
+        num_targets = target_horizon.shape[0]
+        h = node_embedding.unsqueeze(1).expand(num_nodes, num_targets, hidden_dim)
+        tau = (
+            target_horizon.to(node_embedding)
+            .view(1, num_targets, 1)
+            .expand(num_nodes, num_targets, 1)
+        )
+        return self.net(torch.cat([h, tau], dim=-1)).squeeze(-1)
+
+
+def masked_mean_max_pool(
+    node_embedding: torch.Tensor, baseline_observed: torch.Tensor
+) -> torch.Tensor:
+    """Return one concatenated masked mean/max vector for a single graph."""
+    if (
+        baseline_observed.ndim != 1
+        or baseline_observed.shape[0] != node_embedding.shape[0]
+    ):
+        raise ValueError("baseline_observed must align with node_embedding rows")
+    batch_index = torch.zeros(
+        node_embedding.shape[0], dtype=torch.long, device=node_embedding.device
+    )
+    return _graph_readout(
+        node_embedding,
+        batch_index,
+        "mean_max",
+        baseline_observed,
+    )
+
+
+class TemporalGraphClassifier(nn.Module):
+    """Shared graph encoder -> masked mean/max readout -> one pCR logit."""
+
+    def __init__(self, encoder: TemporalGraphEncoder, *, graph_dim: int = 0) -> None:
+        super().__init__()
+        if graph_dim < 0:
+            raise ValueError("graph_dim must be >= 0")
+        self.encoder = encoder
+        self.graph_dim = graph_dim
+        self.classifier = nn.Linear(2 * encoder.hidden_dim + graph_dim, 1)
+
+    def forward(
+        self,
+        node_series: torch.Tensor,
+        edge_index: torch.Tensor,
+        acquisition_times: torch.Tensor,
+        baseline_observed: torch.Tensor,
+        graph_features: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        embedding = self.encoder(
+            node_series, edge_index, acquisition_times, baseline_observed
+        )
+        pooled = masked_mean_max_pool(embedding, baseline_observed)
+        if self.graph_dim:
+            if graph_features is None or graph_features.shape != (1, self.graph_dim):
+                raise ValueError(
+                    f"graph_features must have shape (1, {self.graph_dim})"
+                )
+            pooled = torch.cat([pooled, graph_features], dim=1)
+        return self.classifier(pooled).view(-1)
+
+
+class TemporalPerNodeClassifier(nn.Module):
+    """Graph-free temporal encoder with the identical masked classifier head."""
+
+    def __init__(self, encoder: PerNodeTemporalEncoder, *, graph_dim: int = 0) -> None:
+        super().__init__()
+        if graph_dim < 0:
+            raise ValueError("graph_dim must be >= 0")
+        self.encoder = encoder
+        self.graph_dim = graph_dim
+        self.classifier = nn.Linear(2 * encoder.hidden_dim + graph_dim, 1)
+
+    def forward(
+        self,
+        node_series: torch.Tensor,
+        acquisition_times: torch.Tensor,
+        baseline_observed: torch.Tensor,
+        graph_features: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        embedding = self.encoder(node_series, acquisition_times, baseline_observed)
+        pooled = masked_mean_max_pool(embedding, baseline_observed)
+        if self.graph_dim:
+            if graph_features is None or graph_features.shape != (1, self.graph_dim):
+                raise ValueError(
+                    f"graph_features must have shape (1, {self.graph_dim})"
+                )
+            pooled = torch.cat([pooled, graph_features], dim=1)
+        return self.classifier(pooled).view(-1)
+
+
+def build_encoder_from_config(config: Mapping[str, object]) -> nn.Module:
+    """Reconstruct an encoder from a saved checkpoint configuration."""
+    kwargs = {
+        "signal_channels": int(config["signal_channels"]),
+        "hidden_dim": int(config["hidden_dim"]),
+        "num_gcn_layers": int(config["num_gcn_layers"]),
+        "num_gru_layers": int(config["num_gru_layers"]),
+        "dropout": float(config["dropout"]),
+    }
+    encoder_type = str(config["encoder_type"])
+    if encoder_type == "graph":
+        encoder: nn.Module = TemporalGraphEncoder(**kwargs)
+    elif encoder_type == "graph_free":
+        encoder = PerNodeTemporalEncoder(**kwargs)
+    else:
+        raise ValueError(f"unknown encoder_type {encoder_type!r}")
+    if encoder.config() != dict(config):
+        raise ValueError("encoder_config does not match the supported contract")
+    return encoder
+
+
+def load_encoder_strict(encoder: nn.Module, checkpoint: Mapping[str, object]) -> None:
+    """Validate the complete encoder contract, then load weights strictly."""
+    expected = encoder.config()
+    actual = checkpoint.get("encoder_config")
+    if actual != expected:
+        raise ValueError(
+            f"encoder configuration mismatch: checkpoint={actual}, requested={expected}"
+        )
+    encoder.load_state_dict(checkpoint["encoder_state_dict"], strict=True)

--- a/gnn/train.py
+++ b/gnn/train.py
@@ -842,6 +842,7 @@ def run_gnn_pipeline(config: Any, outdir: Path) -> KFoldResults:
         max_missing_clinical_frac=float(params.gnn_max_missing_clinical_frac),
         id_column=data_paths.gnn_id_column,
         label_column=data_paths.gnn_label_column,
+        kinetic_baseline_floor_frac=float(params.gnn_kinetic_baseline_floor_frac),
         allow_manifest_mismatch=bool(data_paths.gnn_allow_manifest_mismatch),
         breast_split_mode=params.gnn_breast_split_mode or None,
         breast_split_skeleton_root=data_paths.gnn_breast_split_skeleton_root or None,

--- a/gnn/train.py
+++ b/gnn/train.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import matplotlib
+import networkx as nx
 import numpy as np
 import pandas as pd
 import torch
@@ -47,6 +48,12 @@ _DECISION_THRESHOLD = 0.5
 # Smallest usable StratifiedKFold: fewer than 2 folds (or 2 of either class)
 # can't hold out a stratified inner-validation split -- see _stratified_inner_split.
 _MIN_INNER_SPLIT_FOLDS = 2
+# Edge-ablation arms for the "is the topology used at all?" control. See
+# ``_apply_edge_ablation``. "none" is the real adjacency and the default.
+EDGE_ABLATION_MODES: tuple[str, ...] = ("none", "rewire", "drop")
+# Degree-preserving swaps per edge for the "rewire" arm. Two passes over the edge
+# set is well past the point where the wiring still resembles the original tree.
+_REWIRE_SWAPS_PER_EDGE = 2
 
 
 def parse_args() -> argparse.Namespace:
@@ -317,6 +324,81 @@ def _apply_pcr_dummy_noise(
         graph.x[:, col] = class_mean + noise_by_index[index]
 
 
+def _apply_edge_ablation(
+    graphs: list[Data],
+    graph_indices: list[int],
+    mode: str,
+    seed: int,
+) -> None:
+    """In place: replace each graph's ``edge_index`` to test whether topology is used.
+
+    The control that separates "vessel topology carries no pCR signal" from "this
+    model never looked at the topology." A GCNConv stack with a mean-pool readout
+    is a low-pass filter followed by an average, and at ``num_layers=2`` on
+    skeleton graphs whose diameter is several hundred hops each node sees only its
+    immediate neighbourhood -- so the graph may be contributing nothing more than a
+    short moving average. Comparing the three modes measures that directly instead
+    of assuming it:
+
+    - ``"none"``   -- the real skeleton adjacency (default, a no-op).
+    - ``"rewire"`` -- degree-preserving random rewiring (``nx.double_edge_swap``).
+      Every node keeps its degree and the graph keeps its size and edge count, so
+      only *which* nodes are adjacent changes. Isolates the specific vessel
+      topology from generic "some graph with this degree sequence."
+    - ``"drop"``   -- no edges at all. ``GCNConv`` adds self-loops, so each node
+      reduces to a per-node linear map and the model becomes a Deep Sets-style
+      permutation-invariant readout over nodes. Isolates message passing entirely.
+
+    If all three score the same, topology is provably unused and every graph-mode
+    null to date is explained by the operator rather than by the vasculature.
+
+    The swap RNG is keyed by ``graph_index`` (the graph's position in the cached
+    dataset), matching ``_apply_pcr_dummy_noise``, so a case gets the same
+    rewiring across folds, seeds, and reruns.
+
+    Refuses to run on graphs carrying ``edge_attr`` (junction mode): rewiring
+    would silently break the correspondence between each edge and its cached
+    segment summary, and dropping edges would discard those features outright.
+    """
+    if mode not in EDGE_ABLATION_MODES:
+        raise ValueError(
+            f"gnn_edge_ablation must be one of {list(EDGE_ABLATION_MODES)}; got {mode!r}"
+        )
+    if mode == "none":
+        return
+    if getattr(graphs[0], "edge_attr", None) is not None:
+        raise NotImplementedError(
+            f"gnn_edge_ablation={mode!r} is not defined for a graph mode with "
+            "edge_attr (junction): edge features are aligned with edge_index, so "
+            "rewiring or dropping edges would invalidate them. Run the ablation "
+            "on voxel or segment mode."
+        )
+    for graph, index in zip(graphs, graph_indices, strict=True):
+        if mode == "drop":
+            graph.edge_index = torch.empty((2, 0), dtype=torch.long)
+            continue
+        edge_index = graph.edge_index.numpy()
+        undirected = nx.Graph()
+        undirected.add_nodes_from(range(int(graph.num_nodes)))
+        undirected.add_edges_from(zip(edge_index[0], edge_index[1], strict=True))
+        num_edges = undirected.number_of_edges()
+        # Two passes over the edge set randomize the wiring well past the point
+        # where the result still resembles the original tree, and cost ~0.1 s on a
+        # 5k-node graph. max_tries is generous because a degree-constrained swap
+        # can fail on the sparse, near-path-like stretches of a skeleton.
+        nx.double_edge_swap(
+            undirected,
+            nswap=_REWIRE_SWAPS_PER_EDGE * num_edges,
+            max_tries=100 * _REWIRE_SWAPS_PER_EDGE * num_edges,
+            seed=seed + index,
+        )
+        # edge_index stores each undirected edge in both directions, matching how
+        # the cached graphs were built.
+        rewired = list(undirected.edges())
+        both_ways = rewired + [(v, u) for u, v in rewired]
+        graph.edge_index = torch.tensor(both_ways, dtype=torch.long).t().contiguous()
+
+
 class FocalWithLogitsLoss(nn.Module):
     """Sigmoid focal loss for class-imbalanced binary classification.
 
@@ -577,6 +659,12 @@ def fit_predict_one_fold(
         train_graph_idx + val_graph_idx,
         node_features=tuple(params.gnn_node_features),
         params=params,
+    )
+    _apply_edge_ablation(
+        train_graphs + val_graphs,
+        train_graph_idx + val_graph_idx,
+        mode=str(params.gnn_edge_ablation),
+        seed=int(params.gnn_edge_ablation_seed),
     )
     mean, std = fit_node_standardizer(train_graphs)
     for graph in train_graphs + val_graphs:

--- a/gnn/uchicago_temporal_data.py
+++ b/gnn/uchicago_temporal_data.py
@@ -1,0 +1,253 @@
+"""Manifest-driven temporal graph cache for UChicago ultrafast DCE exams.
+
+This is separate from the historical Duke forecasting smoke. UChicago exam
+identity, longitudinal patient grouping, pCR labels, and provided outer folds
+come from its manifests; graph/DCE pixels remain read-only inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import torch
+
+from gnn.data_loader import (
+    _CENTERLINE_SUFFIX,
+    _MODE_DEFAULT_FEATURES,
+    _VOXEL_MODE,
+    _build_case,
+    _git_commit,
+)
+
+REQUIRED_ID_COLUMNS = ("exam_id", "patient_key", "dataset")
+
+
+@dataclass(frozen=True)
+class TemporalCacheRecord:
+    """One cached UChicago exam and its longitudinal/evaluation identity."""
+
+    exam_id: str
+    patient_key: str
+    dataset: str
+    graph_path: str
+    n_frames: int
+    duration_seconds: float
+    median_dt_seconds: float
+    fold: int | None
+    pcr: int | None
+
+
+def load_exam_manifest(path: str | Path) -> pd.DataFrame:
+    """Load one row per UChicago exam and validate longitudinal identity."""
+    frame = pd.read_csv(path)
+    missing = set(REQUIRED_ID_COLUMNS) - set(frame.columns)
+    if missing:
+        raise ValueError(f"UChicago manifest is missing columns: {sorted(missing)}")
+    frame = frame.copy()
+    for column in REQUIRED_ID_COLUMNS:
+        if frame[column].isna().any():
+            raise ValueError(
+                f"UChicago manifest column {column!r} contains missing values"
+            )
+        frame[column] = frame[column].astype(str)
+    duplicated = frame.loc[frame["exam_id"].duplicated(), "exam_id"].tolist()
+    if duplicated:
+        raise ValueError(
+            f"UChicago manifest has duplicate exam_id values: {duplicated}"
+        )
+    return frame
+
+
+def exclude_labeled_patients(
+    pretrain_manifest: pd.DataFrame, labeled_manifest: pd.DataFrame
+) -> pd.DataFrame:
+    """Remove every labeled-cohort patient once, before SSL splitting."""
+    labeled_patients = set(labeled_manifest["patient_key"].astype(str))
+    keep = ~pretrain_manifest["patient_key"].astype(str).isin(labeled_patients)
+    filtered = pretrain_manifest.loc[keep].copy()
+    overlap = set(filtered["patient_key"]) & labeled_patients
+    if overlap:
+        raise RuntimeError(
+            f"labeled patients remain in pretraining data: {sorted(overlap)}"
+        )
+    if filtered.empty:
+        raise ValueError(
+            "excluding labeled patients removed the entire pretraining cohort"
+        )
+    return filtered
+
+
+def _resolve_centerline(centerline_root: Path, dataset: str, exam_id: str) -> Path:
+    filename = f"{exam_id}{_CENTERLINE_SUFFIX}"
+    candidates = (
+        centerline_root / dataset / exam_id / filename,
+        centerline_root / exam_id / filename,
+    )
+    found = [path for path in candidates if path.exists()]
+    if len(found) == 1:
+        return found[0]
+    if len(found) > 1:
+        raise ValueError(f"multiple centerline paths resolve for {exam_id}: {found}")
+    matches = list(centerline_root.rglob(filename))
+    if len(matches) != 1:
+        raise FileNotFoundError(
+            f"expected exactly one centerline for {exam_id} under {centerline_root}; "
+            f"found {matches}"
+        )
+    return matches[0]
+
+
+def build_temporal_exam(
+    row: pd.Series,
+    *,
+    centerline_root: Path,
+    dce_root: Path,
+) -> object:
+    """Build one voxel graph under the final temporal preprocessing contract."""
+    exam_id = str(row["exam_id"])
+    label = None
+    if "pcr" in row.index and pd.notna(row["pcr"]):
+        label = int(row["pcr"])
+    mask_path = _resolve_centerline(centerline_root, str(row["dataset"]), exam_id)
+    data, _ = _build_case(
+        exam_id,
+        mask_path,
+        label,
+        dce_root=dce_root,
+        node_features=_MODE_DEFAULT_FEATURES[_VOXEL_MODE],
+        node_mode=_VOXEL_MODE,
+        attach_temporal_contract=True,
+        baseline_floor_frac=0.0,
+    )
+    data.patient_key = str(row["patient_key"])
+    data.exam_id = exam_id
+    data.dataset = str(row["dataset"])
+    if "fold" in row.index and pd.notna(row["fold"]):
+        data.fold = int(row["fold"])
+    return data
+
+
+def build_temporal_cache(
+    *,
+    manifest_path: str | Path,
+    centerline_root: str | Path,
+    dce_root: str | Path,
+    cache_dir: str | Path,
+    exclude_labeled_manifest: str | Path | None = None,
+    cases: list[str] | None = None,
+    resume: bool = False,
+    write_manifest: bool = True,
+) -> list[TemporalCacheRecord]:
+    """Build per-exam graphs and an auditable JSON manifest.
+
+    This function is intentionally sequential; the checked-in Slurm entrypoint
+    owns resource allocation, and parallel case building can be added only after
+    a small UChicago smoke validates the final contract.
+    """
+    source = load_exam_manifest(manifest_path)
+    if exclude_labeled_manifest is not None:
+        labeled = load_exam_manifest(exclude_labeled_manifest)
+        source = exclude_labeled_patients(source, labeled)
+    if cases is not None:
+        requested = set(cases)
+        available = set(source["exam_id"])
+        missing = sorted(requested - available)
+        if missing:
+            raise ValueError(
+                f"requested exam_id values are absent after filtering: {missing}"
+            )
+        source = source.loc[source["exam_id"].isin(requested)].copy()
+    cache_dir = Path(cache_dir)
+    graph_dir = cache_dir / "exams"
+    graph_dir.mkdir(parents=True, exist_ok=True)
+    records: list[TemporalCacheRecord] = []
+    for row in source.itertuples(index=False):
+        row_series = pd.Series(row._asdict())
+        exam_id = str(row_series["exam_id"])
+        graph_path = graph_dir / f"{exam_id}.pt"
+        if resume and graph_path.exists():
+            logging.info("Reusing cached UChicago temporal graph: %s", exam_id)
+            data = torch.load(graph_path)
+            cached_exam_id = str(getattr(data, "exam_id", ""))
+            cached_patient_key = str(getattr(data, "patient_key", ""))
+            if cached_exam_id != exam_id or cached_patient_key != str(
+                row_series["patient_key"]
+            ):
+                raise ValueError(
+                    f"cached graph identity mismatch for {exam_id}: "
+                    f"exam_id={cached_exam_id!r}, patient_key={cached_patient_key!r}"
+                )
+        else:
+            logging.info("Building UChicago temporal graph: %s", exam_id)
+            data = build_temporal_exam(
+                row_series,
+                centerline_root=Path(centerline_root),
+                dce_root=Path(dce_root),
+            )
+            torch.save(data, graph_path)
+        times = data.times_seconds.detach().cpu()
+        records.append(
+            TemporalCacheRecord(
+                exam_id=exam_id,
+                patient_key=str(row_series["patient_key"]),
+                dataset=str(row_series["dataset"]),
+                graph_path=str(graph_path),
+                n_frames=int(times.numel()),
+                duration_seconds=float(times[-1] - times[0]),
+                median_dt_seconds=float(torch.median(torch.diff(times))),
+                fold=(
+                    int(row_series["fold"])
+                    if "fold" in row_series and pd.notna(row_series["fold"])
+                    else None
+                ),
+                pcr=(
+                    int(row_series["pcr"])
+                    if "pcr" in row_series and pd.notna(row_series["pcr"])
+                    else None
+                ),
+            )
+        )
+    manifest = {
+        "source_manifest": str(Path(manifest_path)),
+        "excluded_labeled_manifest": (
+            str(Path(exclude_labeled_manifest))
+            if exclude_labeled_manifest is not None
+            else None
+        ),
+        "requested_cases": sorted(cases) if cases is not None else None,
+        "resumed_existing_graphs": resume,
+        "centerline_root": str(Path(centerline_root)),
+        "dce_root": str(Path(dce_root)),
+        "git_commit": _git_commit(),
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "preprocessing_contract": {
+            "enhancement": "(S-S0_imputed)/S0_imputed",
+            "baseline_imputation": "simultaneous_iterative_neighbor_median",
+            "validity_threshold": "S0 > 0.05 * median(finite S0)",
+            "future_frame_eligibility": False,
+            "per_curve_normalization": False,
+            "clipping": False,
+        },
+        "records": [asdict(record) for record in records],
+    }
+    if write_manifest:
+        (cache_dir / "temporal_cache_manifest.json").write_text(
+            json.dumps(manifest, indent=2) + "\n"
+        )
+    return records
+
+
+def load_temporal_cache_manifest(cache_dir: str | Path) -> dict[str, object]:
+    """Load and minimally validate a temporal cache manifest."""
+    path = Path(cache_dir) / "temporal_cache_manifest.json"
+    if not path.exists():
+        raise FileNotFoundError(f"temporal cache manifest not found: {path}")
+    manifest = json.loads(path.read_text())
+    if not manifest.get("records"):
+        raise ValueError(f"temporal cache manifest has no records: {path}")
+    return manifest

--- a/gnn/uchicago_temporal_data.py
+++ b/gnn/uchicago_temporal_data.py
@@ -126,9 +126,7 @@ def build_temporal_exam(
     if "pcr" in row.index and pd.notna(row["pcr"]):
         label = int(row["pcr"])
     mask_path = _resolve_centerline(centerline_root, str(row["dataset"]), exam_id)
-    resolved_dce_root = _resolve_dce_root(
-        Path(dce_root), str(row["dataset"]), exam_id
-    )
+    resolved_dce_root = _resolve_dce_root(Path(dce_root), str(row["dataset"]), exam_id)
     data, _ = _build_case(
         exam_id,
         mask_path,

--- a/gnn/uchicago_temporal_data.py
+++ b/gnn/uchicago_temporal_data.py
@@ -102,6 +102,18 @@ def _resolve_centerline(centerline_root: Path, dataset: str, exam_id: str) -> Pa
     return matches[0]
 
 
+def _resolve_dce_root(dce_root: Path, dataset: str, exam_id: str) -> Path:
+    """Return the root directly containing ``exam_id`` for either cohort layout."""
+    candidates = (dce_root / dataset, dce_root)
+    found = [root for root in candidates if (root / exam_id).is_dir()]
+    if len(found) != 1:
+        raise FileNotFoundError(
+            f"expected exactly one DCE exam directory for {exam_id} under "
+            f"{dce_root}; found {[str(root / exam_id) for root in found]}"
+        )
+    return found[0]
+
+
 def build_temporal_exam(
     row: pd.Series,
     *,
@@ -114,11 +126,14 @@ def build_temporal_exam(
     if "pcr" in row.index and pd.notna(row["pcr"]):
         label = int(row["pcr"])
     mask_path = _resolve_centerline(centerline_root, str(row["dataset"]), exam_id)
+    resolved_dce_root = _resolve_dce_root(
+        Path(dce_root), str(row["dataset"]), exam_id
+    )
     data, _ = _build_case(
         exam_id,
         mask_path,
         label,
-        dce_root=dce_root,
+        dce_root=resolved_dce_root,
         node_features=_MODE_DEFAULT_FEATURES[_VOXEL_MODE],
         node_mode=_VOXEL_MODE,
         attach_temporal_contract=True,
@@ -140,6 +155,8 @@ def build_temporal_cache(
     cache_dir: str | Path,
     exclude_labeled_manifest: str | Path | None = None,
     cases: list[str] | None = None,
+    shard_index: int | None = None,
+    num_shards: int | None = None,
     resume: bool = False,
     write_manifest: bool = True,
 ) -> list[TemporalCacheRecord]:
@@ -162,6 +179,16 @@ def build_temporal_cache(
                 f"requested exam_id values are absent after filtering: {missing}"
             )
         source = source.loc[source["exam_id"].isin(requested)].copy()
+    if (shard_index is None) != (num_shards is None):
+        raise ValueError("shard_index and num_shards must be provided together")
+    if shard_index is not None and num_shards is not None:
+        if num_shards < 1 or not 0 <= shard_index < num_shards:
+            raise ValueError(
+                f"shard_index must be in [0, num_shards); got "
+                f"{shard_index}/{num_shards}"
+            )
+        source = source.sort_values("exam_id").iloc[shard_index::num_shards].copy()
+
     cache_dir = Path(cache_dir)
     graph_dir = cache_dir / "exams"
     graph_dir.mkdir(parents=True, exist_ok=True)
@@ -220,6 +247,8 @@ def build_temporal_cache(
             else None
         ),
         "requested_cases": sorted(cases) if cases is not None else None,
+        "shard_index": shard_index,
+        "num_shards": num_shards,
         "resumed_existing_graphs": resume,
         "centerline_root": str(Path(centerline_root)),
         "dce_root": str(Path(dce_root)),

--- a/tabular/gnn_feature_baseline.py
+++ b/tabular/gnn_feature_baseline.py
@@ -44,7 +44,7 @@ import pandas as pd
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_auc_score
-from sklearn.pipeline import make_pipeline
+from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.preprocessing import StandardScaler
 from torch_geometric.data import Data
 from xgboost import XGBClassifier
@@ -54,6 +54,36 @@ from load_cohort import load_config
 
 _SUMMARY_QUANTILES = (0.10, 0.50, 0.90)
 _SEEDS = (42, 142, 242)
+_N_BOOTSTRAP = 2000
+_CI_PCT = (2.5, 97.5)
+
+
+def _build_model(model_name: str, seed: int) -> Pipeline:
+    """The imputer -> scaler -> classifier pipeline for one model/seed.
+
+    SimpleImputer (mean) is fit on each fold's training split only (see
+    ``oof_predictions`` / ``run_cv``), so the NaN ``summarize_graph`` emits for
+    an all-no-arrival case's TTE timing summaries never draws on validation
+    data. It is a near-no-op otherwise (only the handful of all-no-arrival cases
+    carry any NaN).
+    """
+    if model_name == "logistic_regression":
+        return make_pipeline(
+            SimpleImputer(strategy="mean"),
+            StandardScaler(),
+            LogisticRegression(max_iter=1000, random_state=seed),
+        )
+    if model_name == "xgboost":
+        return make_pipeline(
+            SimpleImputer(strategy="mean"),
+            XGBClassifier(
+                n_estimators=100,
+                max_depth=3,
+                random_state=seed,
+                eval_metric="logloss",
+            ),
+        )
+    raise ValueError(f"Unknown model_name: {model_name!r}")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -81,6 +111,10 @@ def load_dataset_from_config(
         cache_dir=dp.gnn_cache_dir,
         node_mode=str(mp.gnn_node_mode),
         node_features=node_features,
+        # Must match the cache manifest's floor: a floored cache (UChicago 0.05)
+        # refuses an unfloored (0.0) request and vice versa, so this cannot be
+        # left at the default when reading a floored cache.
+        kinetic_baseline_floor_frac=float(mp.gnn_kinetic_baseline_floor_frac),
     )
     return dataset, node_features
 
@@ -169,30 +203,7 @@ def run_cv(
         test = feature_table[feature_table["fold"] == fold]
         x_train, y_train = train[feature_cols].to_numpy(), train["pcr"].to_numpy()
         x_test, y_test = test[feature_cols].to_numpy(), test["pcr"].to_numpy()
-
-        # SimpleImputer (mean) is fit on this fold's training split only, so the
-        # NaN that summarize_graph emits for an all-no-arrival case's TTE timing
-        # summaries never draws on validation data. It is a near-no-op otherwise
-        # (only the handful of all-no-arrival cases carry any NaN).
-        if model_name == "logistic_regression":
-            model = make_pipeline(
-                SimpleImputer(strategy="mean"),
-                StandardScaler(),
-                LogisticRegression(max_iter=1000, random_state=seed),
-            )
-        elif model_name == "xgboost":
-            model = make_pipeline(
-                SimpleImputer(strategy="mean"),
-                XGBClassifier(
-                    n_estimators=100,
-                    max_depth=3,
-                    random_state=seed,
-                    eval_metric="logloss",
-                ),
-            )
-        else:
-            raise ValueError(f"Unknown model_name: {model_name!r}")
-
+        model = _build_model(model_name, seed)
         model.fit(x_train, y_train)
         y_prob = model.predict_proba(x_test)[:, 1]
         auc = roc_auc_score(y_test, y_prob)
@@ -206,6 +217,48 @@ def run_cv(
             }
         )
     return rows
+
+
+def oof_predictions(
+    feature_table: pd.DataFrame, feature_cols: list[str], *, model_name: str, seed: int
+) -> np.ndarray:
+    """Out-of-fold predicted probabilities, aligned to ``feature_table`` row order.
+
+    Each case is scored only by the model trained on the folds that exclude it,
+    so the stacked vector holds exactly one held-out prediction per case. Feeding
+    it to a single ``roc_auc_score`` over all cases gives the **pooled OOF AUC**
+    -- the plan's metric convention and the estimand the GNN's ~0.61 is measured
+    on -- as opposed to averaging the noisier per-fold AUCs ``run_cv`` reports.
+    """
+    oof = np.full(len(feature_table), np.nan)
+    fold = feature_table["fold"].to_numpy()
+    y = feature_table["pcr"].to_numpy()
+    x = feature_table[feature_cols].to_numpy()
+    for f in sorted(np.unique(fold)):
+        train_mask, test_mask = fold != f, fold == f
+        model = _build_model(model_name, seed)
+        model.fit(x[train_mask], y[train_mask])
+        oof[test_mask] = model.predict_proba(x[test_mask])[:, 1]
+    return oof
+
+
+def bootstrap_auc_ci(
+    y: np.ndarray, prob: np.ndarray, *, n_boot: int = _N_BOOTSTRAP, seed: int = 0
+) -> tuple[float, float]:
+    """Percentile bootstrap CI for a pooled AUC, resampling cases with replacement.
+
+    Quantifies sampling uncertainty of the pooled-OOF AUC at this fixed N -- the
+    Phase 0.3 requirement that tier/model deltas be read against a CI rather than
+    a bare point estimate.
+    """
+    rng = np.random.default_rng(seed)
+    n = len(y)
+    aucs = np.empty(n_boot, dtype=float)
+    for b in range(n_boot):
+        idx = rng.integers(0, n, n)
+        aucs[b] = roc_auc_score(y[idx], prob[idx])
+    lo, hi = np.percentile(aucs, _CI_PCT)
+    return float(lo), float(hi)
 
 
 def main() -> None:
@@ -235,7 +288,7 @@ def main() -> None:
 
     results = pd.DataFrame(all_rows)
     print()
-    print("=== Per-model aggregated AUC (mean +/- std across seed x fold) ===")
+    print("=== Per-model per-fold AUC (mean +/- std across seed x fold) ===")
     print(results.groupby("model")["auc"].agg(["mean", "std", "count"]))
     print()
     print(f"=== Per-fold AUC, one model at a time (seed={_SEEDS[0]}) ===")
@@ -245,8 +298,47 @@ def main() -> None:
         )
     )
 
+    # Pooled OOF AUC is the plan's headline metric (comparable to the GNN's
+    # ~0.61): score every case once from the fold that held it out, average those
+    # OOF probabilities across seeds to damp init noise, then take a single AUC
+    # over all cases plus a bootstrap CI on it (Phase 0.3).
+    y = feature_table["pcr"].to_numpy()
+    pooled: list[dict[str, object]] = []
+    print()
+    print("=== Pooled OOF AUC over all cases (headline metric) ===")
+    for model_name in ("logistic_regression", "xgboost"):
+        per_seed = np.stack(
+            [
+                oof_predictions(
+                    feature_table, feature_cols, model_name=model_name, seed=s
+                )
+                for s in _SEEDS
+            ]
+        )
+        seed_pooled = [float(roc_auc_score(y, per_seed[i])) for i in range(len(_SEEDS))]
+        mean_oof = per_seed.mean(axis=0)
+        auc = float(roc_auc_score(y, mean_oof))
+        ci_lo, ci_hi = bootstrap_auc_ci(y, mean_oof)
+        pooled.append(
+            {
+                "model": model_name,
+                "pooled_oof_auc_seed_mean": auc,
+                "pooled_oof_auc_ci95": [ci_lo, ci_hi],
+                "pooled_oof_auc_per_seed": seed_pooled,
+                "n_cases": int(len(y)),
+                "n_features": len(feature_cols),
+            }
+        )
+        print(
+            f"  {model_name:20s} AUC={auc:.3f}  "
+            f"95% CI [{ci_lo:.3f}, {ci_hi:.3f}]  "
+            f"per-seed={[round(v, 3) for v in seed_pooled]}"
+        )
+
     out_path = args.out_dir / "tabular_baseline_results.json"
-    out_path.write_text(json.dumps(all_rows, indent=2))
+    out_path.write_text(
+        json.dumps({"per_fold": all_rows, "pooled_oof": pooled}, indent=2)
+    )
     print(f"\nWrote {out_path}")
 
 

--- a/tests/test_gnn_baseline_validity.py
+++ b/tests/test_gnn_baseline_validity.py
@@ -1,0 +1,46 @@
+"""Baseline validity and graph-local S0 repair under the temporal contract."""
+
+from __future__ import annotations
+
+import networkx as nx
+import numpy as np
+import pytest
+
+from gnn.baseline_validity import observed_valid_mask, repair_baselines
+
+
+def test_validity_threshold_uses_only_case_baselines() -> None:
+    """Validity follows the exact precontrast-only case-relative threshold."""
+    s0 = np.asarray([100.0, 4.0, np.nan, 10.0])
+    valid, threshold = observed_valid_mask(s0)
+    # finite median = 10, threshold = 0.5
+    assert threshold == pytest.approx(0.5)
+    assert valid.tolist() == [True, True, False, True]
+
+
+def test_imputation_propagates_one_hop_per_simultaneous_round() -> None:
+    """A filled value advances by at most one graph hop in each round."""
+    graph = nx.path_graph([0, 1, 2])
+    result = repair_baselines(
+        graph,
+        [0, 1, 2],
+        np.asarray([10.0, 0.0, 0.0]),
+        mode="impute",
+    )
+    assert result.observed_valid.tolist() == [True, False, False]
+    np.testing.assert_allclose(result.s0_filled, [10.0, 10.0, 10.0])
+    assert result.imputation_round.tolist() == [0, 1, 2]
+
+
+def test_component_without_valid_seed_remains_unrepaired() -> None:
+    """An all-invalid disconnected component stays masked and unfilled."""
+    graph = nx.Graph([(0, 1)])
+    graph.add_edge(2, 3)
+    result = repair_baselines(
+        graph,
+        [0, 1, 2, 3],
+        np.asarray([10.0, 0.0, 0.0, 0.0]),
+        mode="impute",
+    )
+    assert result.has_baseline.tolist() == [True, True, False, False]
+    assert np.isnan(result.s0_filled[2:]).all()

--- a/tests/test_gnn_junction_graph.py
+++ b/tests/test_gnn_junction_graph.py
@@ -31,6 +31,12 @@ CENTRE_DEGREE_Y = 3.0
 CENTRE_DEGREE_X = 4.0
 TIP_DEGREE = 1.0
 
+# Baseline-floor cap check: a 0.01 baseline vs. a floor of 0.05*peak(2.0)=0.1
+# shrinks the relative-enhancement denominator exactly 10x; the unfloored peak
+# is far above physiological (~0-5), confirming the divide-by-near-zero pathology.
+FLOOR_DENOM_RATIO = 10.0
+PATHOLOGICAL_PEAK_MIN = 100.0
+
 
 def _make_graph(edges: list[tuple[tuple, tuple]]) -> nx.Graph:
     graph = nx.Graph()
@@ -49,6 +55,31 @@ def _uniform_inputs(graph: nx.Graph) -> tuple[dict, np.ndarray]:
     for t in range(NUM_TIMEPOINTS):
         dce_4d[t] = float(t)
     return radius_map, dce_4d
+
+
+def test_baseline_floor_caps_junction_relative_enhancement() -> None:
+    """Baseline floor threads into junction node kinetics, capping a void baseline."""
+    coords = [(x, 5, 0) for x in range(1, 6)]
+    graph = _make_graph(_line(coords))
+    radius_map = dict.fromkeys(graph.nodes(), 1.0)
+    dce_4d = np.empty((NUM_TIMEPOINTS, *VOLUME_ZYX), dtype=np.float32)
+    dce_4d[0], dce_4d[1], dce_4d[2] = 0.01, 1.0, 2.0
+
+    def junction_peak(floor: float) -> float:
+        data = build_junction_graph(
+            graph,
+            radius_map,
+            dce_4d,
+            TIME_AXIS,
+            relative_enhancement=True,
+            baseline_floor_frac=floor,
+        )
+        return float(data.peak_enhancement.max())
+
+    unfloored = junction_peak(0.0)
+    floored = junction_peak(0.05)
+    assert unfloored > PATHOLOGICAL_PEAK_MIN
+    assert unfloored == pytest.approx(floored * FLOOR_DENOM_RATIO, rel=1e-3)
 
 
 def test_straight_vessel_two_nodes_one_segment_edge() -> None:

--- a/tests/test_gnn_segment_graph.py
+++ b/tests/test_gnn_segment_graph.py
@@ -34,6 +34,12 @@ STRAIGHT_VESSEL_LENGTH = 4.0
 Y_ARMS, Y_EDGES, Y_DEGREE = 3, 3, 2  # K3 (triangle)
 X_ARMS, X_EDGES, X_DEGREE = 4, 6, 3  # K4
 
+# Baseline-floor cap check: a 0.01 baseline vs. a floor of 0.05*peak(2.0)=0.1
+# shrinks the relative-enhancement denominator exactly 10x; the unfloored peak
+# is far above physiological (~0-5), confirming the divide-by-near-zero pathology.
+FLOOR_DENOM_RATIO = 10.0
+PATHOLOGICAL_PEAK_MIN = 100.0
+
 
 def _make_graph(edges: list[tuple[tuple, tuple]]) -> nx.Graph:
     """Build a voxel skeleton graph from (x,y,z) endpoint pairs."""
@@ -86,6 +92,46 @@ def test_straight_vessel_is_one_node_no_edges() -> None:
     assert attrs["seg_degree_max"] == pytest.approx(1.0)
     # Enhancement peaks at the last timepoint -> no washout window (den == 0).
     assert attrs["seg_washout_slope_mean"] == pytest.approx(0.0)
+
+
+def test_baseline_floor_caps_segment_relative_enhancement() -> None:
+    """Baseline floor threads into segment kinetics: caps a void baseline, no-op otherwise.
+
+    With relative enhancement and a near-void baseline the floor caps the
+    otherwise-exploding per-voxel peak enhancement; with a healthy baseline
+    (already above the floor) it changes nothing.
+    """
+    coords = [(x, 5, 0) for x in range(1, 6)]
+    graph = _make_graph(_line(coords))
+    radius_map = dict.fromkeys(graph.nodes(), 1.0)
+
+    # Near-void baseline (0.01) under a peak signal of 2.0: (S - S0)/S0 explodes.
+    void_baseline = np.empty((NUM_TIMEPOINTS, *VOLUME_ZYX), dtype=np.float32)
+    void_baseline[0], void_baseline[1], void_baseline[2] = 0.01, 1.0, 2.0
+
+    def seg_peak(dce_4d: np.ndarray, floor: float) -> float:
+        line = build_segment_line_graph(
+            graph,
+            radius_map,
+            dce_4d,
+            TIME_AXIS,
+            relative_enhancement=True,
+            baseline_floor_frac=floor,
+        )
+        return line.nodes[0]["seg_peak_enhancement_mean"]
+
+    unfloored = seg_peak(void_baseline, 0.0)
+    floored = seg_peak(void_baseline, 0.05)
+    # Denominator goes from S0=0.01 to max(0.01, 0.05*2)=0.1 -> exactly 10x
+    # smaller, independent of the exact peak definition (linear in 1/denom).
+    assert unfloored > PATHOLOGICAL_PEAK_MIN  # the divide-by-near-zero pathology
+    assert unfloored == pytest.approx(floored * FLOOR_DENOM_RATIO, rel=1e-3)
+
+    # Healthy baseline (1.0; floor 0.05*2=0.1 < baseline) -> floor is a no-op.
+    healthy = np.stack(
+        [np.full(VOLUME_ZYX, v, dtype=np.float32) for v in (1.0, 1.5, 2.0)]
+    )
+    assert seg_peak(healthy, 0.0) == pytest.approx(seg_peak(healthy, 0.05))
 
 
 def test_y_junction_gives_triangle_line_graph() -> None:

--- a/tests/test_uchicago_temporal.py
+++ b/tests/test_uchicago_temporal.py
@@ -1,0 +1,470 @@
+"""Synthetic tests for the UChicago temporal-transfer path."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+
+from torch_geometric.data import Data  # noqa: E402
+
+from gnn.pretrain.model import ContrastForecastGNN  # noqa: E402
+from gnn.pretrain.uchicago import (  # noqa: E402
+    HORIZON,
+    eligible_starts,
+    make_window,
+    split_records_by_patient,
+    write_pretraining_readme,
+)
+from gnn.pretrain.uchicago import (  # noqa: E402
+    parse_args as parse_pretrain_args,
+)
+from gnn.temporal_finetune import (  # noqa: E402
+    load_parallel_arm_predictions,
+    load_tabular_reference,
+    protocol_only_oof,
+    validate_cache_against_cohort,
+    validate_matched_encoder_configs,
+    write_finetune_readme,
+)
+from gnn.temporal_finetune import (  # noqa: E402
+    parse_args as parse_finetune_args,
+)
+from gnn.temporal_model import (  # noqa: E402
+    PerNodeTemporalEncoder,
+    TemporalGraphClassifier,
+    TemporalGraphEncoder,
+    load_encoder_strict,
+    masked_mean_max_pool,
+)
+from gnn.uchicago_temporal_data import (  # noqa: E402
+    build_temporal_cache,
+    exclude_labeled_patients,
+)
+
+
+def _exam() -> Data:
+    series = torch.arange(3 * 7, dtype=torch.float).reshape(3, 7, 1)
+    series[1, 5, 0] = float("nan")
+    return Data(
+        node_series=series,
+        node_valid=torch.tensor([True, False, True]),
+        times_seconds=torch.tensor([0.0, 5.0, 40.0, 45.0, 50.0, 55.0, 60.0]),
+        baseline_frame_count=2,
+        edge_index=torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]]),
+        exam_id="exam-a",
+    )
+
+
+def test_labeled_patients_are_removed_once_before_pretraining() -> None:
+    """All exams of a labeled patient are absent from the SSL cohort."""
+    pretrain = pd.DataFrame(
+        {
+            "exam_id": ["e1", "e2", "e3"],
+            "patient_key": ["p1", "p1", "p2"],
+            "dataset": ["u", "u", "u"],
+        }
+    )
+    labeled = pd.DataFrame({"exam_id": ["l1"], "patient_key": ["p1"], "dataset": ["u"]})
+    filtered = exclude_labeled_patients(pretrain, labeled)
+    assert filtered["exam_id"].tolist() == ["e3"]
+
+
+def test_temporal_cache_resume_reuses_and_validates_existing_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resumed cache rebuilds its manifest without recomputing valid graphs."""
+    manifest_path = tmp_path / "manifest.csv"
+    pd.DataFrame(
+        {"exam_id": ["e1"], "patient_key": ["p1"], "dataset": ["u"]}
+    ).to_csv(manifest_path, index=False)
+    cached = Data(
+        times_seconds=torch.tensor([0.0, 5.0, 10.0]),
+        exam_id="e1",
+        patient_key="p1",
+        dataset="u",
+    )
+
+    def build_once(*args: object, **kwargs: object) -> Data:
+        return cached
+
+    monkeypatch.setattr(
+        "gnn.uchicago_temporal_data.build_temporal_exam", build_once
+    )
+    cache_dir = tmp_path / "cache"
+    build_temporal_cache(
+        manifest_path=manifest_path,
+        centerline_root=tmp_path,
+        dce_root=tmp_path,
+        cache_dir=cache_dir,
+        write_manifest=False,
+    )
+    assert not (cache_dir / "temporal_cache_manifest.json").exists()
+
+    def fail_if_rebuilt(*args: object, **kwargs: object) -> Data:
+        raise AssertionError("resume recomputed an existing graph")
+
+    monkeypatch.setattr(
+        "gnn.uchicago_temporal_data.build_temporal_exam", fail_if_rebuilt
+    )
+    records = build_temporal_cache(
+        manifest_path=manifest_path,
+        centerline_root=tmp_path,
+        dce_root=tmp_path,
+        cache_dir=cache_dir,
+        resume=True,
+    )
+    assert [record.exam_id for record in records] == ["e1"]
+
+    wrong = torch.load(cache_dir / "exams" / "e1.pt")
+    wrong.patient_key = "wrong"
+    torch.save(wrong, cache_dir / "exams" / "e1.pt")
+    with pytest.raises(ValueError, match="cached graph identity mismatch"):
+        build_temporal_cache(
+            manifest_path=manifest_path,
+            centerline_root=tmp_path,
+            dce_root=tmp_path,
+            cache_dir=cache_dir,
+            resume=True,
+        )
+
+
+def test_patient_split_keeps_longitudinal_exams_together() -> None:
+    """Random pretraining splits operate on patient_key, never exam_id."""
+    records = [
+        {"exam_id": "a1", "patient_key": "a"},
+        {"exam_id": "a2", "patient_key": "a"},
+        {"exam_id": "b1", "patient_key": "b"},
+        {"exam_id": "c1", "patient_key": "c"},
+    ]
+    train, val = split_records_by_patient(records, val_fraction=0.34, seed=3)
+    assert {r["patient_key"] for r in train}.isdisjoint({r["patient_key"] for r in val})
+    location = {r["exam_id"]: "train" for r in train} | {
+        r["exam_id"]: "val" for r in val
+    }
+    assert location["a1"] == location["a2"]
+
+
+def test_pretraining_cli_selects_one_isolated_arm(tmp_path: Path) -> None:
+    """GPU-QoS-compatible jobs can train matched arms independently."""
+    args = parse_pretrain_args(
+        [
+            "--cache-dir",
+            str(tmp_path / "cache"),
+            "--outdir",
+            str(tmp_path / "out"),
+            "--arm",
+            "graph_free",
+        ]
+    )
+    assert args.arm == "graph_free"
+
+
+def test_pretraining_result_directory_gets_readme(tmp_path: Path) -> None:
+    """A completed pretraining outdir is not handoff-ready without provenance."""
+    cache_dir = tmp_path / "cache"
+    outdir = tmp_path / "out"
+    cache_dir.mkdir()
+    outdir.mkdir()
+    manifest = {
+        "source_manifest": "/source.csv",
+        "excluded_labeled_manifest": "/labeled.csv",
+        "records": [{"exam_id": "e1"}],
+    }
+    (cache_dir / "temporal_cache_manifest.json").write_text("{}\n")
+    args = parse_pretrain_args(
+        [
+            "--cache-dir",
+            str(cache_dir),
+            "--outdir",
+            str(outdir),
+            "--arm",
+            "graph_free",
+        ]
+    )
+    results = {
+        "requested_arm": "graph_free",
+        "graph_free": {
+            "validation_mae": 0.2,
+            "persistence_mae": 0.25,
+            "beats_persistence": True,
+            "best_epoch": 3,
+        },
+        "train_patient_count": 8,
+        "val_patient_count": 2,
+    }
+    torch.save({}, outdir / "graph_free_encoder.pt")
+    (outdir / "pretraining_results.json").write_text("{}\n")
+    path = write_pretraining_readme(args=args, results=results, manifest=manifest)
+    text = path.read_text()
+    assert "# UChicago temporal pretraining result" in text
+    assert "graph_free" in text
+    assert "Train patients: 8" in text
+    assert "Dirty-worktree status" in text
+
+
+def test_window_policy_uses_b_minus_one_and_minutes_from_last_baseline() -> None:
+    """Windows and physical-time anchoring match the saved UChicago plan."""
+    data = _exam()
+    assert eligible_starts(data) == [1, 2]
+    window = make_window(data, 1)
+    assert window.x_seq.shape == (3, HORIZON.input_len, 1)
+    assert window.target.shape == (3, HORIZON.target_len)
+    torch.testing.assert_close(
+        window.acquisition_times, torch.tensor([0.0, 35.0 / 60.0, 40.0 / 60.0])
+    )
+    assert not window.target_mask[1].any()
+    assert window.target_mask[0].all()
+    assert torch.isfinite(window.target).all()
+
+
+def test_masked_pool_excludes_invalid_nodes_from_mean_and_max() -> None:
+    """Originally invalid nodes influence neither downstream pooling operator."""
+    embedding = torch.tensor([[1.0, 2.0], [100.0, 100.0], [3.0, 0.0]])
+    pooled = masked_mean_max_pool(embedding, torch.tensor([True, False, True]))
+    torch.testing.assert_close(pooled, torch.tensor([[2.0, 1.0, 3.0, 2.0]]))
+
+
+def test_forecaster_and_classifier_share_exact_encoder_state() -> None:
+    """Forecast weights load strictly into the identical downstream encoder."""
+    forecaster = ContrastForecastGNN(
+        in_channels=1, hidden_dim=8, num_layers=2, dropout=0.0
+    )
+    classifier_encoder = TemporalGraphEncoder(
+        signal_channels=1,
+        hidden_dim=8,
+        num_gcn_layers=2,
+        num_gru_layers=1,
+        dropout=0.0,
+    )
+    checkpoint = {
+        "encoder_config": forecaster.encoder.config(),
+        "encoder_state_dict": forecaster.encoder.state_dict(),
+    }
+    load_encoder_strict(classifier_encoder, checkpoint)
+    classifier = TemporalGraphClassifier(classifier_encoder)
+    for expected, actual in zip(
+        forecaster.encoder.parameters(), classifier.encoder.parameters(), strict=True
+    ):
+        torch.testing.assert_close(expected, actual)
+
+
+def test_strict_transfer_rejects_architecture_mismatch() -> None:
+    """A different hidden width fails before any partial weight load."""
+    source = TemporalGraphEncoder(hidden_dim=8, dropout=0.0)
+    target = TemporalGraphEncoder(hidden_dim=16, dropout=0.0)
+    checkpoint = {
+        "encoder_config": source.config(),
+        "encoder_state_dict": source.state_dict(),
+    }
+    with pytest.raises(ValueError, match="configuration mismatch"):
+        load_encoder_strict(target, checkpoint)
+
+
+def test_graph_and_free_checkpoints_must_be_architecturally_matched() -> None:
+    """The 2x2 comparison cannot silently vary width or depth by arm."""
+    graph = {"encoder_config": TemporalGraphEncoder(hidden_dim=8).config()}
+    free = {"encoder_config": PerNodeTemporalEncoder(hidden_dim=8).config()}
+    validate_matched_encoder_configs(graph, free)
+    free["encoder_config"]["hidden_dim"] = 16
+    with pytest.raises(ValueError, match="matched encoder configurations"):
+        validate_matched_encoder_configs(graph, free)
+
+
+def test_protocol_only_audit_is_patient_level_and_oof() -> None:
+    """Protocol audit aggregates exams and respects the provided patient fold."""
+    groups = {}
+    for index in range(8):
+        patient = f"p{index}"
+        groups[patient] = [
+            {
+                "patient_key": patient,
+                "fold": index % 2,
+                "pcr": (index // 2) % 2,
+                "n_frames": 10 + index,
+                "duration_seconds": 50.0 + index,
+                "median_dt_seconds": 5.0,
+            }
+        ]
+    predictions = protocol_only_oof(groups)
+    assert predictions["patient_key"].nunique() == len(groups)
+    assert predictions["y_prob"].between(0.0, 1.0).all()
+
+
+def test_existing_tabular_reference_selects_best_tabular_row(tmp_path: Path) -> None:
+    """Historical non-tabular rows cannot become the declared reference."""
+    path = tmp_path / "reference.csv"
+    pd.DataFrame(
+        [
+            {
+                "model": "gnn_old",
+                "pooled_oof_auc": 0.9,
+                "ci_lo": 0.8,
+                "ci_hi": 1.0,
+            },
+            {
+                "model": "tabular_vessel",
+                "pooled_oof_auc": 0.6,
+                "ci_lo": 0.5,
+                "ci_hi": 0.7,
+            },
+        ]
+    ).to_csv(path, index=False)
+    reference = load_tabular_reference(path)
+    assert reference["model"] == "tabular_vessel"
+
+
+def _finetune_cli_paths(tmp_path: Path) -> list[str]:
+    return [
+        "--cache-dir",
+        str(tmp_path / "cache"),
+        "--cohort-manifest",
+        str(tmp_path / "cohort.csv"),
+        "--gnn-checkpoint",
+        str(tmp_path / "gnn.pt"),
+        "--graph-free-checkpoint",
+        str(tmp_path / "free.pt"),
+        "--outdir",
+        str(tmp_path / "out"),
+    ]
+
+
+def test_finetune_cli_separates_parallel_arms_from_aggregation(
+    tmp_path: Path,
+) -> None:
+    """Each GPU job runs one arm and only the dependent CPU job aggregates."""
+    arm_args = parse_finetune_args(
+        [*_finetune_cli_paths(tmp_path), "--arm", "gnn_pretrained"]
+    )
+    assert arm_args.arm == "gnn_pretrained"
+    assert not arm_args.aggregate_only
+    aggregate_args = parse_finetune_args(
+        [
+            *_finetune_cli_paths(tmp_path),
+            "--arm",
+            "all",
+            "--aggregate-only",
+        ]
+    )
+    assert aggregate_args.aggregate_only
+
+
+def test_labeled_cache_must_match_confirmed_downstream_cohort(
+    tmp_path: Path,
+) -> None:
+    """Fine-tuning fails before training if identity, label, or fold drifted."""
+    cohort_path = tmp_path / "cohort.csv"
+    pd.DataFrame(
+        {
+            "exam_id": ["e1", "e2"],
+            "patient_key": ["p1", "p2"],
+            "fold": [0, 1],
+            "pcr": [0, 1],
+        }
+    ).to_csv(cohort_path, index=False)
+    records = [
+        {"exam_id": "e1", "patient_key": "p1", "fold": 0, "pcr": 0},
+        {"exam_id": "e2", "patient_key": "p2", "fold": 1, "pcr": 1},
+    ]
+    validate_cache_against_cohort(records, cohort_path)
+    records[1]["fold"] = 0
+    with pytest.raises(ValueError, match="identity/split mismatch"):
+        validate_cache_against_cohort(records, cohort_path)
+
+
+def test_parallel_prediction_loader_requires_identical_complete_arms(
+    tmp_path: Path,
+) -> None:
+    """Aggregation cannot silently accept a missing patient or wrong arm label."""
+    arms = (
+        "graph_free_random",
+        "graph_free_pretrained",
+        "gnn_random",
+        "gnn_pretrained",
+    )
+    for arm in arms:
+        arm_dir = tmp_path / arm
+        arm_dir.mkdir()
+        pd.DataFrame(
+            {
+                "arm": [arm, arm],
+                "fold": [0, 1],
+                "patient_key": ["p0", "p1"],
+                "y_true": [0, 1],
+                "y_prob": [0.2, 0.8],
+                "n_exams": [1, 1],
+            }
+        ).to_csv(arm_dir / "patient_predictions.csv", index=False)
+    predictions = load_parallel_arm_predictions(tmp_path)
+    assert len(predictions) == 2 * len(arms)
+    assert set(predictions["arm"]) == set(arms)
+
+    broken = pd.read_csv(tmp_path / "gnn_pretrained" / "patient_predictions.csv")
+    broken.iloc[:1].to_csv(
+        tmp_path / "gnn_pretrained" / "patient_predictions.csv", index=False
+    )
+    with pytest.raises(ValueError, match="identical patient sets"):
+        load_parallel_arm_predictions(tmp_path)
+
+
+def test_finetune_arm_result_gets_provenance_readme(tmp_path: Path) -> None:
+    """A completed fine-tuning arm writes its required result README."""
+    cache_dir = tmp_path / "cache"
+    outdir = tmp_path / "out"
+    cache_dir.mkdir()
+    outdir.mkdir()
+    source_manifest = tmp_path / "usable.csv"
+    cohort_manifest = tmp_path / "cohort.csv"
+    pd.DataFrame({"exam_id": ["e0", "e1"]}).to_csv(
+        source_manifest, index=False
+    )
+    pd.DataFrame({"exam_id": ["e0", "e1"]}).to_csv(
+        cohort_manifest, index=False
+    )
+    (cache_dir / "temporal_cache_manifest.json").write_text("{}\n")
+    (tmp_path / "gnn.pt").write_bytes(b"gnn")
+    (tmp_path / "free.pt").write_bytes(b"free")
+    args = parse_finetune_args(
+        [
+            *_finetune_cli_paths(tmp_path),
+            "--arm",
+            "graph_free_random",
+            "--device",
+            "cpu",
+        ]
+    )
+    predictions = pd.DataFrame(
+        {
+            "arm": ["graph_free_random", "graph_free_random"],
+            "fold": [0, 1],
+            "patient_key": ["p0", "p1"],
+            "y_true": [0, 1],
+            "y_prob": [0.25, 0.75],
+            "n_exams": [1, 1],
+        }
+    )
+    predictions.to_csv(outdir / "patient_predictions.csv", index=False)
+    metrics = {
+        "graph_free_random": {"auc": 1.0, "ci_low": 1.0, "ci_high": 1.0}
+    }
+    (outdir / "metrics.json").write_text("{}\n")
+    (outdir / "history.json").write_text("{}\n")
+    manifest = {
+        "source_manifest": str(source_manifest),
+        "records": [{"exam_id": "e0"}, {"exam_id": "e1"}],
+    }
+    readme = write_finetune_readme(
+        args=args,
+        manifest=manifest,
+        metrics=metrics,
+        predictions=predictions,
+        aggregate=False,
+    )
+    text = readme.read_text()
+    assert "graph_free_random" in text
+    assert "Anna-confirmed larger downstream cohort" in text
+    assert "Dirty-worktree status" in text

--- a/tests/test_uchicago_temporal.py
+++ b/tests/test_uchicago_temporal.py
@@ -27,6 +27,7 @@ from gnn.temporal_finetune import (  # noqa: E402
     load_parallel_arm_predictions,
     load_tabular_reference,
     protocol_only_oof,
+    refit_fold_on_all_outer_train,
     validate_cache_against_cohort,
     validate_matched_encoder_configs,
     write_finetune_readme,
@@ -79,9 +80,9 @@ def test_temporal_cache_resume_reuses_and_validates_existing_graph(
 ) -> None:
     """A resumed cache rebuilds its manifest without recomputing valid graphs."""
     manifest_path = tmp_path / "manifest.csv"
-    pd.DataFrame(
-        {"exam_id": ["e1"], "patient_key": ["p1"], "dataset": ["u"]}
-    ).to_csv(manifest_path, index=False)
+    pd.DataFrame({"exam_id": ["e1"], "patient_key": ["p1"], "dataset": ["u"]}).to_csv(
+        manifest_path, index=False
+    )
     cached = Data(
         times_seconds=torch.tensor([0.0, 5.0, 10.0]),
         exam_id="e1",
@@ -92,9 +93,7 @@ def test_temporal_cache_resume_reuses_and_validates_existing_graph(
     def build_once(*args: object, **kwargs: object) -> Data:
         return cached
 
-    monkeypatch.setattr(
-        "gnn.uchicago_temporal_data.build_temporal_exam", build_once
-    )
+    monkeypatch.setattr("gnn.uchicago_temporal_data.build_temporal_exam", build_once)
     cache_dir = tmp_path / "cache"
     build_temporal_cache(
         manifest_path=manifest_path,
@@ -353,6 +352,51 @@ def test_finetune_cli_separates_parallel_arms_from_aggregation(
     assert aggregate_args.aggregate_only
 
 
+def test_outer_refit_restarts_and_uses_every_training_patient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The final fold model resets before consuming the full outer train split."""
+    seen = []
+
+    def load_record(record: dict[str, object], device: torch.device) -> object:
+        seen.append(str(record["patient_key"]))
+        return record
+
+    def forward_exam(
+        model: torch.nn.Module, data: object, uses_graph: bool
+    ) -> torch.Tensor:
+        parameter = next(model.parameters())
+        return model(torch.ones((1, 1), device=parameter.device))
+
+    monkeypatch.setattr("gnn.temporal_finetune._load_record", load_record)
+    monkeypatch.setattr("gnn.temporal_finetune._forward_exam", forward_exam)
+    model = torch.nn.Linear(1, 1)
+    initial_state = {
+        name: torch.zeros_like(value) for name, value in model.state_dict().items()
+    }
+    with torch.no_grad():
+        for parameter in model.parameters():
+            parameter.fill_(9.0)
+    groups = {
+        f"p{index}": [{"patient_key": f"p{index}", "pcr": index % 2}]
+        for index in range(3)
+    }
+    model, history = refit_fold_on_all_outer_train(
+        model,
+        initial_state,
+        groups,
+        uses_graph=False,
+        epochs=1,
+        learning_rate=0.0,
+        seed=3,
+        device=torch.device("cpu"),
+    )
+    assert set(seen) == set(groups)
+    assert len(history) == 1
+    for value in model.state_dict().values():
+        torch.testing.assert_close(value, torch.zeros_like(value))
+
+
 def test_labeled_cache_must_match_confirmed_downstream_cohort(
     tmp_path: Path,
 ) -> None:
@@ -419,12 +463,8 @@ def test_finetune_arm_result_gets_provenance_readme(tmp_path: Path) -> None:
     outdir.mkdir()
     source_manifest = tmp_path / "usable.csv"
     cohort_manifest = tmp_path / "cohort.csv"
-    pd.DataFrame({"exam_id": ["e0", "e1"]}).to_csv(
-        source_manifest, index=False
-    )
-    pd.DataFrame({"exam_id": ["e0", "e1"]}).to_csv(
-        cohort_manifest, index=False
-    )
+    pd.DataFrame({"exam_id": ["e0", "e1"]}).to_csv(source_manifest, index=False)
+    pd.DataFrame({"exam_id": ["e0", "e1"]}).to_csv(cohort_manifest, index=False)
     (cache_dir / "temporal_cache_manifest.json").write_text("{}\n")
     (tmp_path / "gnn.pt").write_bytes(b"gnn")
     (tmp_path / "free.pt").write_bytes(b"free")
@@ -448,9 +488,7 @@ def test_finetune_arm_result_gets_provenance_readme(tmp_path: Path) -> None:
         }
     )
     predictions.to_csv(outdir / "patient_predictions.csv", index=False)
-    metrics = {
-        "graph_free_random": {"auc": 1.0, "ci_low": 1.0, "ci_high": 1.0}
-    }
+    metrics = {"graph_free_random": {"auc": 1.0, "ci_low": 1.0, "ci_high": 1.0}}
     (outdir / "metrics.json").write_text("{}\n")
     (outdir / "history.json").write_text("{}\n")
     manifest = {


### PR DESCRIPTION
Message from my agent below. I propose merging this without review since we're down to the wire and it will smooth integration overhead in our final experiments.



## Summary

Anna asked me to consolidate my current UChicago graph-analysis and temporal-modeling work into one integration PR so the team can build on a stable branch while the summer work is wrapping up.

- Adds the kinetic baseline-floor diagnostics, graph-representation comparisons, tabular and edge-ablation gates, relational features, and protocol-confounding analyses from my current branch.
- Adds the UChicago temporal forecasting pipeline: baseline validity and neighbor imputation, relative enhancement without squashing dynamics, physical acquisition times, unlabeled patient-split pretraining, graph and graph-free forecasters, strict encoder checkpoint transfer, and patient-level downstream pCR fine-tuning.
- Adds reproducible temporal-cache and Slurm entry points. A separate Anna-authored integration commit supports both cohort directory layouts and deterministic cache sharding.
- Merges current `main` so this sits on top of the latest preprocessing and vessel-segmentation work.

## Scope and attribution

The scientific and temporal-modeling commits retain Spencer Venancio as author. Anna Woodard packaged the active work, added the small cohort-layout/sharding integration, and merged current `main`. This PR intentionally consolidates the related active branches; it does not include imaging data, generated results, scratch plans, or experimental performance patches that are still being evaluated.

## Validation

- 122 focused GNN, preprocessing-contract, forecasting, transfer, and graph-construction tests passed; 1 skipped.
- New Python modules compile successfully.
- All four new Slurm launchers pass `bash -n`.