### PR TITLE
Add UChicago tumor segmentation pipeline

### DIFF
--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -218,3 +218,73 @@ The submission prints three job IDs. Corresponding array tasks are linked with
 `aftercorr`, so one failed case does not block unrelated cases. Completed stages
 are skipped on resubmission. The documented Vanguard environment can be
 overridden explicitly with `VANGUARD_PYTHON` when validating another checkout.
+
+### High-resolution tumor masks
+
+`preprocessing/tumor.py` owns the DICOM-to-mask handoff for the released
+MAMA-MIA nnU-Net tumor model from Garrucho et al., *Scientific Data* 12, 453
+(2025), <https://doi.org/10.1038/s41597-025-04707-4>. It motion-aligns the HR
+series to precontrast, uses the first postcontrast HR phase for the final mask,
+uses later phases only for temporal QC, keeps the largest component as the
+primary tumor, and maps that mask by physical coordinates onto the same
+source-aligned 1-mm UFAST grid used by the dynamic images and vessel skeletons.
+A substantial component in the opposite breast is flagged for bilateral review
+rather than silently merged into the primary mask.
+
+Aakrithi Ram designed and implemented the initial UChicago HR/UFAST tumor
+segmentation workflow, shared-window QC renderer, and 30-case validation pilot.
+Anna Woodard subsequently generalized that implementation for restartable
+cohort-scale execution, multi-source publication, and longitudinal laterality
+provenance. The Git history keeps the original implementation as an
+Aakrithi-authored commit before the production extensions.
+
+The supported cohort entrypoint is the restartable CPU/GPU/CPU Slurm chain:
+
+```bash
+export RUN_ROOT=/path/to/derived/uchicago_tumor
+export INVENTORY=/path/to/dicom_file_manifest.parquet
+export CASE_MANIFEST=/path/to/paired_preprocessing_case_manifest.csv
+export COHORT_MANIFEST=/path/to/dce2d_internal_ultrafast_manifest.csv
+export MODEL_DIR=/path/to/full_image_dce_mri_tumor_segmentation
+export NNUNET_ENV=/path/to/nnunet-2.5-environment
+bash slurm/submit_tumor_pipeline.sh
+```
+
+The entrypoint chains `prepare-case`, `index-cohort`, released-model inference,
+and `finalize-cohort`. Each run records the exact inventory, case manifest,
+segmentation policy, model checkpoint hashes, model plans hash, physical DICOM
+geometry, timestamps, and motion decisions in `tumor_run_provenance.json` and
+per-case `tumor_preprocessing_provenance.json` files.
+
+Each component run writes `tumor_mask_manifest.csv` for its directly runnable
+exams. After all components have finished, publish their masks into a stable
+cohort root with one repeated `--direct-manifest` argument per component:
+
+```bash
+python -m preprocessing.tumor publish-cohort \
+  --output-root /path/to/student-facing-cohort/tumor \
+  --cohort-manifest /path/to/student-facing-cohort/dce2d_internal_ultrafast_manifest.csv \
+  --centerline-root /path/to/student-facing-cohort/centerlines \
+  --direct-manifest /path/to/legacy/tumor_mask_manifest.csv \
+  --direct-manifest /path/to/extension/tumor_mask_manifest.csv
+```
+
+`preprocessing/slurm/tumor_publish_cohort.slurm` is the Slurm wrapper for this
+publication command and accepts the same paths through exported variables.
+
+Published `masks/<exam-id>.nii.gz` files contain only the primary component.
+`longitudinal_tumor_manifest.csv` joins direct mask status and unambiguous
+same-patient laterality to every cohort row. Missing direct masks and conflicting
+patient-level laterality remain explicit rather than receiving invented values.
+
+Render the original visual-QC contract against any prepared cohort run with:
+
+```bash
+python scripts/qc_uchicago_tumor_contract_30.py \
+  --run-root /path/to/derived/uchicago_tumor \
+  --out-dir /path/to/qc/tumor_panels
+```
+
+The renderer uses one shared HR intensity window across all DCE phases so that
+true enhancement and washout differences are not hidden by per-timepoint
+windowing.

--- a/preprocessing/slurm/tumor_finalize_cohort.slurm
+++ b/preprocessing/slurm/tumor_finalize_cohort.slurm
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uchic-tumor-finalize
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=04:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+export PYTHONNOUSERSITE=1
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -euo pipefail
+
+: "${REPO_ROOT:?set REPO_ROOT}"
+: "${RUN_ROOT:?set RUN_ROOT}"
+: "${INVENTORY:?set INVENTORY}"
+: "${CASE_MANIFEST:?set CASE_MANIFEST}"
+: "${COHORT_MANIFEST:?set COHORT_MANIFEST}"
+: "${MODEL_DIR:?set MODEL_DIR}"
+
+cd "${REPO_ROOT}"
+
+ARGS=(python -m preprocessing.tumor finalize-cohort \
+  --output-root "${RUN_ROOT}" \
+  --inventory "${INVENTORY}" \
+  --case-manifest "${CASE_MANIFEST}" \
+  --cohort-manifest "${COHORT_MANIFEST}" \
+  --model-dir "${MODEL_DIR}")
+if [[ -n "${CENTERLINE_ROOT:-}" ]]; then
+  ARGS+=(--centerline-root "${CENTERLINE_ROOT}")
+fi
+"${ARGS[@]}"

--- a/preprocessing/slurm/tumor_index_cohort.slurm
+++ b/preprocessing/slurm/tumor_index_cohort.slurm
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uchic-tumor-index
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+#SBATCH --time=01:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+export PYTHONNOUSERSITE=1
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -euo pipefail
+
+: "${REPO_ROOT:?set REPO_ROOT}"
+: "${RUN_ROOT:?set RUN_ROOT}"
+: "${INVENTORY:?set INVENTORY}"
+: "${CASE_MANIFEST:?set CASE_MANIFEST}"
+: "${MODEL_DIR:?set MODEL_DIR}"
+
+cd "${REPO_ROOT}"
+
+python -m preprocessing.tumor index-cohort \
+  --output-root "${RUN_ROOT}" \
+  --inventory "${INVENTORY}" \
+  --case-manifest "${CASE_MANIFEST}" \
+  --model-dir "${MODEL_DIR}"

--- a/preprocessing/slurm/tumor_infer_case.slurm
+++ b/preprocessing/slurm/tumor_infer_case.slurm
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uchic-tumor-infer
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=gpuq
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=48G
+#SBATCH --time=04:00:00
+#SBATCH --output=logs/slurm/%x-%A-%a.out
+#SBATCH --error=logs/slurm/%x-%A-%a.err
+
+export PYTHONNOUSERSITE=1
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -euo pipefail
+
+: "${REPO_ROOT:?set REPO_ROOT}"
+: "${RUN_ROOT:?set RUN_ROOT}"
+: "${MODEL_DIR:?set MODEL_DIR}"
+: "${NNUNET_ENV:?set NNUNET_ENV}"
+
+cd "${REPO_ROOT}"
+VANGUARD_PYTHON="$(which python)"
+EXAM_ID="$(${VANGUARD_PYTHON} - "${RUN_ROOT}/tumor_case_manifest.csv" "${SLURM_ARRAY_TASK_ID}" <<'PY'
+import csv
+import sys
+
+with open(sys.argv[1], newline="") as stream:
+    rows = sorted(csv.DictReader(stream), key=lambda row: row["exam_id"])
+print(rows[int(sys.argv[2])]["exam_id"])
+PY
+)"
+INPUT_DIR="${RUN_ROOT}/work/${EXAM_ID}/nnunet_postcontrast_inputs"
+OUTPUT_DIR="${RUN_ROOT}/work/${EXAM_ID}/nnunet_postcontrast_predictions"
+
+mkdir -p "${OUTPUT_DIR}"
+shopt -s nullglob
+INPUTS=("${INPUT_DIR}"/*_0000.nii.gz)
+if (( ${#INPUTS[@]} == 0 )); then
+  echo "no nnU-Net inputs found for ${EXAM_ID}" >&2
+  exit 2
+fi
+missing_prediction=0
+for input_path in "${INPUTS[@]}"; do
+  prediction_name="$(basename "${input_path}" _0000.nii.gz).nii.gz"
+  [[ -f "${OUTPUT_DIR}/${prediction_name}" ]] || missing_prediction=1
+done
+if (( missing_prediction == 0 )); then
+  echo "reusing ${#INPUTS[@]} complete predictions for ${EXAM_ID}"
+  exit 0
+fi
+export nnUNet_raw="${RUN_ROOT}/nnunet_runtime/raw"
+export nnUNet_preprocessed="${RUN_ROOT}/nnunet_runtime/preprocessed"
+export nnUNet_results="$(dirname "${MODEL_DIR}")"
+mkdir -p "${nnUNet_raw}" "${nnUNet_preprocessed}"
+export LD_LIBRARY_PATH="${NNUNET_ENV}/lib:${LD_LIBRARY_PATH:-}"
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK:-4}"
+export MKL_NUM_THREADS="${SLURM_CPUS_PER_TASK:-4}"
+
+echo "exam_id=${EXAM_ID}"
+echo "python=${NNUNET_ENV}/bin/python"
+echo "model=${MODEL_DIR}"
+"${NNUNET_ENV}/bin/python" -c \
+  'import torch; print("torch", torch.__version__, "cuda", torch.cuda.is_available())'
+
+"${NNUNET_ENV}/bin/nnUNetv2_predict_from_modelfolder" \
+  -i "${INPUT_DIR}" \
+  -o "${OUTPUT_DIR}" \
+  -m "${MODEL_DIR}" \
+  -f 0 1 2 3 4 \
+  -device cuda \
+  -npp "${SLURM_CPUS_PER_TASK:-4}" \
+  -nps "${SLURM_CPUS_PER_TASK:-4}" \
+  --disable_progress_bar

--- a/preprocessing/slurm/tumor_prepare_case.slurm
+++ b/preprocessing/slurm/tumor_prepare_case.slurm
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uchic-tumor-prep
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=04:00:00
+#SBATCH --output=logs/slurm/%x-%A-%a.out
+#SBATCH --error=logs/slurm/%x-%A-%a.err
+
+export PYTHONNOUSERSITE=1
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -euo pipefail
+
+: "${REPO_ROOT:?set REPO_ROOT}"
+: "${RUN_ROOT:?set RUN_ROOT}"
+: "${INVENTORY:?set INVENTORY}"
+: "${CASE_MANIFEST:?set CASE_MANIFEST}"
+
+cd "${REPO_ROOT}"
+
+python -m preprocessing.tumor prepare-case \
+  --output-root "${RUN_ROOT}" \
+  --inventory "${INVENTORY}" \
+  --case-manifest "${CASE_MANIFEST}" \
+  --array-index "${SLURM_ARRAY_TASK_ID}"

--- a/preprocessing/slurm/tumor_publish_cohort.slurm
+++ b/preprocessing/slurm/tumor_publish_cohort.slurm
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=uchic-tumor-publish
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+export PYTHONNOUSERSITE=1
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -euo pipefail
+
+: "${REPO_ROOT:?set REPO_ROOT}"
+: "${OUTPUT_ROOT:?set OUTPUT_ROOT}"
+: "${COHORT_MANIFEST:?set COHORT_MANIFEST}"
+: "${CENTERLINE_ROOT:?set CENTERLINE_ROOT}"
+: "${DIRECT_MANIFEST_1:?set at least DIRECT_MANIFEST_1}"
+
+cd "${REPO_ROOT}"
+
+arguments=(
+  --output-root "${OUTPUT_ROOT}"
+  --cohort-manifest "${COHORT_MANIFEST}"
+  --centerline-root "${CENTERLINE_ROOT}"
+  --direct-manifest "${DIRECT_MANIFEST_1}"
+)
+for variable in DIRECT_MANIFEST_2 DIRECT_MANIFEST_3; do
+  value="${!variable:-}"
+  if [[ -n "${value}" ]]; then
+    arguments+=(--direct-manifest "${value}")
+  fi
+done
+
+python -m preprocessing.tumor publish-cohort "${arguments[@]}"

--- a/preprocessing/tumor.py
+++ b/preprocessing/tumor.py
@@ -1,9 +1,19 @@
-"""MAMA-MIA nnU-Net tumor-mask workflow for paired UChicago HR/UFAST DCE."""
+"""MAMA-MIA nnU-Net tumor-mask workflow for paired UChicago HR/UFAST DCE.
+
+The released model and preprocessing plan are from Garrucho et al., Scientific
+Data 12, 453 (2025), https://doi.org/10.1038/s41597-025-04707-4, and the
+official MAMA-MIA nnU-Net fork.
+
+Aakrithi Ram designed and implemented the initial UChicago HR/UFAST tumor
+segmentation and shared-window visual-QC workflow and validated it on a 30-case
+pilot. Anna Woodard generalized that implementation for restartable
+cohort-scale execution, multi-source publication, and longitudinal laterality
+provenance.
+"""
 
 from __future__ import annotations
 
 import argparse
-import csv
 import hashlib
 import json
 from pathlib import Path
@@ -22,12 +32,18 @@ from preprocessing.dicom import (
 )
 from preprocessing.motion import DEFAULT_MOTION_SETTINGS, correct_phase
 from preprocessing.pipeline import _identity_alignment_qc
-from preprocessing.spatial import resample_to_geometry, save_nifti_xyz
+from preprocessing.spatial import (
+    isotropic_geometry,
+    resample_to_geometry,
+    save_nifti_xyz,
+)
 
 POLICY_NAME = "mama_mia_first_postcontrast_hr_tumor_v1"
 FIRST_POSTCONTRAST_PHASE = 1
 TEMPORAL_INSTABILITY_DICE_THRESHOLD = 0.60
 TINY_VOLUME_ML_THRESHOLD = 0.10
+BILATERAL_MIN_OPPOSITE_VOLUME_ML = 0.10
+BILATERAL_MIN_OPPOSITE_TO_PRIMARY_RATIO = 0.10
 COMPONENT_CONNECTIVITY = 3
 BINARY_THRESHOLD = 0.5
 
@@ -39,13 +55,13 @@ DEFAULT_CASE_MANIFEST = Path(
     "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
     "paired_hr_ufast_source_dicom/paired_preprocessing_case_manifest.csv"
 )
-DEFAULT_SELECTED_CASES = Path(
-    "results/uchicago_nnunet_timepoint_pilot/"
-    "all_datasets_random10_per_dataset_seed20260727/selected_cases.csv"
+DEFAULT_COHORT_MANIFEST = Path(
+    "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
+    "dce2d_internal_ultrafast_with_high_resolution_manifest.csv"
 )
 DEFAULT_MODEL_DIR = Path(
-    "/ess/scratch/scratch1/aakrithiram/nnunet_vanguard/results/"
-    "full_image_dce_mri_tumor_segmentation"
+    "/gpfs/data/karczmar-lab/MAMA-MIA-syn60868042/"
+    "nnUNet_pretrained_weights/full_image_dce_mri_tumor_segmentation"
 )
 
 
@@ -164,7 +180,7 @@ def prepare_case_for_tumor(
                 input_link = nnunet_input_dir / image_path.name
                 _safe_symlink(image_path, input_link)
             else:
-                input_link = Path("")
+                input_link = Path()
             rows.append(
                 {
                     "exam_id": exam_id,
@@ -205,7 +221,11 @@ def prepare_case_for_tumor(
             "inventory_path": str(inventory.expanduser().resolve()),
             "case_manifest_path": str(case_manifest.expanduser().resolve()),
             "hr_source": {
-                "archive_path": str(hr.archive_path),
+                "source_kind": hr.source_kind,
+                "source_location": str(hr.archive_path),
+                "archive_path": (
+                    str(hr.archive_path) if hr.source_kind == "zip" else None
+                ),
                 "selected_dicom_sha256": hr.source_sha256,
                 "series_instance_uid": record.hr_series_instance_uid,
                 "geometry": hr.geometry.to_dict(),
@@ -214,7 +234,11 @@ def prepare_case_for_tumor(
                 "shared_4d_window": _shared_window(hr.signal_tzyx),
             },
             "ufast_source": {
-                "archive_path": str(ufast.archive_path),
+                "source_kind": ufast.source_kind,
+                "source_location": str(ufast.archive_path),
+                "archive_path": (
+                    str(ufast.archive_path) if ufast.source_kind == "zip" else None
+                ),
                 "selected_dicom_sha256": ufast.source_sha256,
                 "series_instance_uid": record.ufast_series_instance_uid,
                 "geometry": ufast.geometry.to_dict(),
@@ -240,9 +264,12 @@ def prepare_case_for_tumor(
         raise
 
 
-def prepare_cohort(args: argparse.Namespace) -> None:
-    selected = pd.read_csv(args.selected_cases, dtype=str)
+def _selected_cases(args: argparse.Namespace) -> pd.DataFrame:
+    """Return the requested cases, or every runnable manifest row."""
     case_manifest = pd.read_csv(args.case_manifest, dtype=str)
+    if args.selected_cases is None:
+        return case_manifest.sort_values("exam_id").reset_index(drop=True)
+    selected = pd.read_csv(args.selected_cases, dtype=str)
     cases = selected[["exam_id", "dataset"]].merge(
         case_manifest,
         on=["exam_id", "dataset"],
@@ -252,17 +279,44 @@ def prepare_cohort(args: argparse.Namespace) -> None:
     if len(cases) != len(selected):
         missing = selected.loc[~selected["exam_id"].isin(cases["exam_id"])]
         raise RuntimeError(f"selected cases missing runnable HR rows:\n{missing}")
+    return cases.sort_values("exam_id").reset_index(drop=True)
+
+
+def prepare_case_command(args: argparse.Namespace) -> None:
+    """Prepare one stable case-manifest row for use in a Slurm array."""
+    if args.exam_id is not None:
+        exam_id = args.exam_id
+    else:
+        index = args.array_index
+        if index is None:
+            import os
+
+            index = int(os.environ["SLURM_ARRAY_TASK_ID"])
+        cases = _selected_cases(args)
+        if index < 0 or index >= len(cases):
+            raise IndexError(f"array index {index} outside [0, {len(cases) - 1}]")
+        exam_id = str(cases.iloc[index]["exam_id"])
+    provenance = prepare_case_for_tumor(
+        inventory=args.inventory,
+        case_manifest=args.case_manifest,
+        exam_id=exam_id,
+        output_root=args.output_root,
+    )
+    print(f"prepared {exam_id}: {provenance['outputs']['nnunet_postcontrast_inputs']}")
+
+
+def write_cohort_manifests(args: argparse.Namespace) -> None:
+    """Index already prepared cases and pin the released model provenance."""
+    cases = _selected_cases(args)
 
     all_rows = []
     job_rows = []
     for row in cases.sort_values("exam_id").itertuples(index=False):
-        provenance = prepare_case_for_tumor(
-            inventory=args.inventory,
-            case_manifest=args.case_manifest,
-            exam_id=str(row.exam_id),
-            output_root=args.output_root,
-        )
         case_root = _case_root(args.output_root, str(row.exam_id))
+        provenance_path = case_root / "tumor_preprocessing_provenance.json"
+        if not provenance_path.is_file():
+            raise FileNotFoundError(f"case is not prepared: {provenance_path}")
+        provenance = json.loads(provenance_path.read_text())
         phase_manifest = pd.read_csv(case_root / "hr_phase_manifest.csv")
         all_rows.append(phase_manifest)
         job_rows.append(
@@ -286,7 +340,11 @@ def prepare_cohort(args: argparse.Namespace) -> None:
             "policy": POLICY_NAME,
             "inventory": str(args.inventory.expanduser().resolve()),
             "case_manifest": str(args.case_manifest.expanduser().resolve()),
-            "selected_cases": str(args.selected_cases.expanduser().resolve()),
+            "selected_cases": (
+                "all runnable case-manifest rows"
+                if args.selected_cases is None
+                else str(args.selected_cases.expanduser().resolve())
+            ),
             "model_dir": str(args.model_dir.expanduser().resolve()),
             "model_dir_sha256s": {
                 str(path.relative_to(args.model_dir)): _sha256(path)
@@ -305,6 +363,18 @@ def prepare_cohort(args: argparse.Namespace) -> None:
     print(f"n_postcontrast_inputs={sum(row['n_postcontrast_phases'] for row in job_rows)}")
 
 
+def prepare_cohort(args: argparse.Namespace) -> None:
+    """Prepare cases sequentially, then write the cohort manifests."""
+    for row in _selected_cases(args).itertuples(index=False):
+        prepare_case_for_tumor(
+            inventory=args.inventory,
+            case_manifest=args.case_manifest,
+            exam_id=str(row.exam_id),
+            output_root=args.output_root,
+        )
+    write_cohort_manifests(args)
+
+
 def _load_mask(path: Path) -> tuple[np.ndarray, nib.Nifti1Image]:
     image = nib.load(path)
     return np.asanyarray(image.dataobj) > 0, image
@@ -319,7 +389,9 @@ def _dice(a: np.ndarray, b: np.ndarray) -> float | None:
     return float((2.0 * np.logical_and(a, b).sum()) / denom) if denom else None
 
 
-def _component_outputs(mask: np.ndarray, img: nib.Nifti1Image, out_dir: Path) -> dict[str, Any]:
+def _component_outputs(
+    mask: np.ndarray, img: nib.Nifti1Image, out_dir: Path
+) -> dict[str, Any]:
     out_dir.mkdir(parents=True, exist_ok=True)
     all_path = out_dir / "tumor_all_components_hr.nii.gz"
     primary_path = out_dir / "tumor_primary_hr.nii.gz"
@@ -332,6 +404,28 @@ def _component_outputs(mask: np.ndarray, img: nib.Nifti1Image, out_dir: Path) ->
         primary_label = 0
         primary = np.zeros_like(mask, dtype=bool)
     voxel_ml = float(abs(np.linalg.det(img.affine[:3, :3])) / 1000.0)
+    field_center_xyz = (np.asarray(mask.shape, dtype=float) - 1.0) / 2.0
+    field_center_ras_x = float(
+        nib.affines.apply_affine(img.affine, field_center_xyz)[0]
+    )
+    components = []
+    for label in range(1, n_components + 1):
+        component = labeled == label
+        centroid_xyz = np.asarray(ndimage.center_of_mass(component), dtype=float)
+        centroid_ras = nib.affines.apply_affine(img.affine, centroid_xyz)
+        components.append(
+            {
+                "label": label,
+                "volume_ml": float(component.sum() * voxel_ml),
+                "centroid_xyz": centroid_xyz.tolist(),
+                "centroid_ras_mm": np.asarray(centroid_ras, dtype=float).tolist(),
+                "laterality": (
+                    "right"
+                    if float(centroid_ras[0]) > field_center_ras_x
+                    else "left"
+                ),
+            }
+        )
     for path, arr in ((all_path, mask), (primary_path, primary)):
         out = nib.Nifti1Image(arr.astype(np.uint8), img.affine, img.header)
         out.set_data_dtype(np.uint8)
@@ -343,11 +437,14 @@ def _component_outputs(mask: np.ndarray, img: nib.Nifti1Image, out_dir: Path) ->
         "primary_label": primary_label,
         "all_components_volume_ml": float(mask.sum() * voxel_ml),
         "primary_component_volume_ml": float(primary.sum() * voxel_ml),
+        "field_center_ras_x_mm": field_center_ras_x,
+        "components": components,
         "primary_mask": primary,
     }
 
 
 def finalize_cohort(args: argparse.Namespace) -> None:
+    """Select the primary mask, map it to UFAST, and write the cohort manifest."""
     cases = pd.read_csv(args.output_root / "tumor_case_manifest.csv", dtype=str)
     phase_manifest = pd.read_csv(args.output_root / "tumor_phase_manifest.csv")
     rows = []
@@ -373,6 +470,38 @@ def finalize_cohort(args: argparse.Namespace) -> None:
         median_later_dice = float(np.median(later_dice)) if later_dice else None
         tumor_empty = not bool(first_mask.any())
         primary_volume_ml = float(component_info["primary_component_volume_ml"])
+        primary_component = next(
+            (
+                component
+                for component in component_info["components"]
+                if component["label"] == component_info["primary_label"]
+            ),
+            None,
+        )
+        tumor_laterality_direct = (
+            "unknown"
+            if primary_component is None
+            else str(primary_component["laterality"])
+        )
+        opposite_components = [
+            component
+            for component in component_info["components"]
+            if component["laterality"] != tumor_laterality_direct
+        ]
+        opposite_volume_ml = max(
+            (float(component["volume_ml"]) for component in opposite_components),
+            default=0.0,
+        )
+        opposite_ratio = (
+            opposite_volume_ml / primary_volume_ml
+            if primary_volume_ml > 0
+            else None
+        )
+        bilateral_candidate = bool(
+            opposite_volume_ml >= BILATERAL_MIN_OPPOSITE_VOLUME_ML
+            and opposite_ratio is not None
+            and opposite_ratio >= BILATERAL_MIN_OPPOSITE_TO_PRIMARY_RATIO
+        )
         review_temporal = bool(
             tumor_empty
             or median_later_dice is None
@@ -385,21 +514,55 @@ def finalize_cohort(args: argparse.Namespace) -> None:
         )
         hr_geometry = DicomGeometry.from_dict(provenance["hr_source"]["geometry"])
         ufast_geometry = DicomGeometry.from_dict(provenance["ufast_source"]["geometry"])
+        # Vanguard's published UFAST phases and mapped vessel skeletons use the
+        # source-aligned 1 mm output grid, not the native DICOM voxel grid.  Keep
+        # the tumor mask on that exact downstream grid so array indices, shape,
+        # and affine all agree without a second consumer-side resampling step.
+        ufast_output_geometry = isotropic_geometry(ufast_geometry, spacing_mm=1.0)
         primary_ufast = (
-            resample_to_geometry(primary_hr_zyx, hr_geometry, ufast_geometry, nearest=True)
+            resample_to_geometry(
+                primary_hr_zyx,
+                hr_geometry,
+                ufast_output_geometry,
+                nearest=True,
+            )
             > BINARY_THRESHOLD
         )
         primary_ufast_path = case_root / "tumor_masks" / "tumor_primary_ufast.nii.gz"
-        save_nifti_xyz(primary_ufast_path, np.transpose(primary_ufast.astype(np.float32), (2, 1, 0)), ufast_geometry)
+        save_nifti_xyz(
+            primary_ufast_path,
+            np.transpose(primary_ufast.astype(np.float32), (2, 1, 0)),
+            ufast_output_geometry,
+        )
+
+        provenance["tumor_mapping"] = {
+            "source": "motion-corrected HR first-postcontrast primary component",
+            "target": "Vanguard source-aligned 1 mm UFAST output grid",
+            "transform": "physical-coordinate mapping in shared DICOM frame",
+            "interpolator": "nearest_neighbor",
+            "target_geometry": ufast_output_geometry.to_dict(),
+            "output_path": str(primary_ufast_path),
+            "output_voxels": int(primary_ufast.sum()),
+        }
+        _write_json(
+            case_root / "tumor_preprocessing_provenance.json",
+            provenance,
+        )
 
         alignment_status = str(provenance["identity_alignment_qc"]["status"])
         mapping_status = "pass" if alignment_status == "pass" else "review_required"
-        exclude_downstream = mapping_status != "pass"
-        exclude_reason = "alignment_review_required" if exclude_downstream else ""
+        exclusion_reasons = []
+        if mapping_status != "pass":
+            exclusion_reasons.append("alignment_review_required")
+        if bilateral_candidate:
+            exclusion_reasons.append("bilateral_candidate_review_required")
+        exclude_downstream = bool(exclusion_reasons)
+        exclude_reason = ";".join(exclusion_reasons)
 
         rows.append(
             {
                 "exam_id": exam_id,
+                "dataset": case.dataset,
                 "hr_series_instance_uid": case.hr_series_instance_uid,
                 "ufast_series_instance_uid": case.ufast_series_instance_uid,
                 "first_postcontrast_phase": FIRST_POSTCONTRAST_PHASE,
@@ -408,26 +571,327 @@ def finalize_cohort(args: argparse.Namespace) -> None:
                 "median_first_to_later_dice": median_later_dice,
                 "all_components_volume_ml": component_info["all_components_volume_ml"],
                 "primary_component_volume_ml": primary_volume_ml,
-                "opposite_breast_component_ml": None,
-                "opposite_to_primary_volume_ratio": None,
+                "tumor_laterality_direct": tumor_laterality_direct,
+                "laterality_method": (
+                    "primary-component centroid relative to the HR physical "
+                    "field center; NIfTI RAS x increases toward patient right"
+                ),
+                "opposite_breast_component_ml": opposite_volume_ml,
+                "opposite_to_primary_volume_ratio": opposite_ratio,
                 "tumor_mask_empty": tumor_empty,
                 "review_tiny": review_tiny,
                 "review_temporal_instability": review_temporal,
-                "bilateral_candidate": None,
-                "bilateral_review_status": "not_evaluated_no_aligned_bilateral_hr_mask",
+                "bilateral_candidate": bilateral_candidate,
+                "bilateral_review_status": (
+                    "review_required" if bilateral_candidate else "not_suspected"
+                ),
                 "alignment_qc_status": alignment_status,
                 "mapping_status": mapping_status,
+                "primary_ufast_grid": "vanguard_source_aligned_1mm_output",
                 "exclude_downstream": exclude_downstream,
                 "exclude_reason": exclude_reason,
                 "primary_hr_mask": component_info["primary_path"],
                 "primary_ufast_mask": str(primary_ufast_path),
                 "all_components_hr_mask": component_info["all_components_path"],
-                "qc_panel": "",
             }
         )
     manifest = pd.DataFrame(rows)
     manifest.to_csv(args.output_root / "tumor_mask_manifest.csv", index=False)
     print(f"wrote {args.output_root / 'tumor_mask_manifest.csv'}")
+    _write_longitudinal_manifest(args, manifest)
+
+
+def _write_longitudinal_manifest(
+    args: argparse.Namespace, direct_manifest: pd.DataFrame
+) -> None:
+    """Add every cohort exam and propagate an unambiguous patient tumor side."""
+    cohort = pd.read_csv(args.cohort_manifest, dtype=str)
+    direct = direct_manifest.copy()
+    for column in ("tumor_mask_empty", "review_tiny", "bilateral_candidate"):
+        direct[column] = direct[column].astype(bool)
+    usable = direct.loc[
+        direct["tumor_laterality_direct"].isin(["left", "right"])
+        & ~direct["tumor_mask_empty"]
+        & ~direct["review_tiny"]
+        & ~direct["bilateral_candidate"]
+    ]
+    patient_lookup = cohort[["exam_id", "patient_id"]].merge(
+        usable[["exam_id", "tumor_laterality_direct"]],
+        on="exam_id",
+        how="inner",
+        validate="one_to_one",
+    )
+    consensus: dict[str, tuple[str, str, bool]] = {}
+    for patient_id, group in patient_lookup.groupby("patient_id", sort=False):
+        sides = sorted(set(group["tumor_laterality_direct"]))
+        source_exams = ";".join(sorted(group["exam_id"]))
+        consensus[str(patient_id)] = (
+            sides[0] if len(sides) == 1 else "unknown",
+            source_exams,
+            len(sides) > 1,
+        )
+
+    duplicate_source_columns = [
+        column
+        for column in direct.columns
+        if column != "exam_id" and column in cohort.columns
+    ]
+    direct_for_join = direct.drop(columns=duplicate_source_columns)
+    combined = cohort.merge(
+        direct_for_join, on="exam_id", how="left", validate="one_to_one"
+    )
+    final_side = []
+    side_source = []
+    source_exams = []
+    conflicts = []
+    for row in combined.itertuples(index=False):
+        direct_side = getattr(row, "tumor_laterality_direct", None)
+        direct_valid = bool(
+            direct_side in {"left", "right"}
+            and not bool(getattr(row, "tumor_mask_empty", True))
+            and not bool(getattr(row, "review_tiny", True))
+            and not bool(getattr(row, "bilateral_candidate", True))
+        )
+        patient_side, patient_sources, conflict = consensus.get(
+            str(row.patient_id), ("unknown", "", False)
+        )
+        if conflict:
+            final_side.append("unknown")
+            side_source.append("unknown_patient_conflict")
+            source_exams.append(patient_sources)
+        elif direct_valid:
+            final_side.append(direct_side)
+            side_source.append("direct_segmentation")
+            source_exams.append(str(row.exam_id))
+        elif patient_side in {"left", "right"}:
+            final_side.append(patient_side)
+            side_source.append("same_patient_consensus")
+            source_exams.append(patient_sources)
+        else:
+            final_side.append("unknown")
+            side_source.append("unknown_no_unambiguous_valid_source")
+            source_exams.append(patient_sources)
+        conflicts.append(conflict)
+    combined["tumor_laterality"] = final_side
+    combined["tumor_laterality_source"] = side_source
+    combined["tumor_laterality_source_exam_ids"] = source_exams
+    combined["patient_laterality_conflict"] = conflicts
+    direct_exclusion = combined["exclude_downstream"].eq(True)
+    combined["exclude_downstream"] = direct_exclusion | combined[
+        "patient_laterality_conflict"
+    ]
+    direct_reasons = combined["exclude_reason"].fillna("").astype(str)
+    combined["exclude_reason"] = [
+        ";".join(
+            reason
+            for reason in (
+                direct_reason,
+                "patient_laterality_conflict" if conflict else "",
+            )
+            if reason
+        )
+        for direct_reason, conflict in zip(
+            direct_reasons,
+            combined["patient_laterality_conflict"],
+            strict=True,
+        )
+    ]
+    combined["tumor_segmentation_status"] = np.where(
+        combined["primary_hr_mask"].notna(),
+        "segmented",
+        combined.get("hr_selection_status", pd.Series("not_runnable", index=combined.index)),
+    )
+    if args.centerline_root is not None:
+        centerline_rows = []
+        for case_dir in sorted(args.centerline_root.expanduser().resolve().glob("*/*")):
+            exam_id = case_dir.name
+            skeleton = case_dir / f"{exam_id}_skeleton_4d_exam_mask.npy"
+            support = case_dir / f"{exam_id}_skeleton_4d_exam_support_mask.npy"
+            morphometry = case_dir / f"{exam_id}_morphometry.json"
+            if skeleton.is_file() or support.is_file() or morphometry.is_file():
+                centerline_rows.append(
+                    {
+                        "exam_id": exam_id,
+                        "skeleton_path": str(skeleton) if skeleton.is_file() else "",
+                        "support_path": str(support) if support.is_file() else "",
+                        "morphometry_path": (
+                            str(morphometry) if morphometry.is_file() else ""
+                        ),
+                        "centerline_status": (
+                            "complete"
+                            if all(
+                                path.is_file()
+                                for path in (skeleton, support, morphometry)
+                            )
+                            else "incomplete"
+                        ),
+                    }
+                )
+        centerlines = pd.DataFrame(centerline_rows)
+        if centerlines["exam_id"].duplicated().any():
+            raise ValueError("centerline root contains duplicate exam IDs")
+        combined = combined.merge(
+            centerlines, on="exam_id", how="left", validate="one_to_one"
+        )
+        combined["centerline_status"] = combined["centerline_status"].fillna(
+            "missing"
+        )
+    output_path = args.output_root / "longitudinal_tumor_manifest.csv"
+    combined.to_csv(output_path, index=False)
+    print(f"wrote {output_path}")
+
+
+def publish_cohort(args: argparse.Namespace) -> None:
+    """Publish direct masks on the exact student-facing UFAST cohort grid."""
+    if args.centerline_root is None:
+        raise ValueError("publish-cohort requires --centerline-root")
+    cohort_path = args.cohort_manifest.expanduser().resolve()
+    cohort = pd.read_csv(cohort_path, dtype=str)
+    if cohort["exam_id"].duplicated().any():
+        raise ValueError("cohort manifest repeats exam_id")
+    cohort_by_exam = cohort.set_index("exam_id")
+
+    parts = []
+    for path in args.direct_manifest:
+        resolved = path.expanduser().resolve()
+        part = pd.read_csv(resolved)
+        part["source_direct_manifest"] = str(resolved)
+        parts.append(part)
+    direct = pd.concat(parts, ignore_index=True)
+    if direct["exam_id"].astype(str).duplicated().any():
+        repeated = direct.loc[
+            direct["exam_id"].astype(str).duplicated(keep=False), "exam_id"
+        ].tolist()
+        raise ValueError(f"direct tumor manifests repeat exam IDs: {repeated[:3]}")
+    direct = direct.loc[
+        direct["exam_id"].astype(str).isin(cohort_by_exam.index)
+    ].copy()
+    if direct.empty:
+        raise ValueError("no direct tumor masks overlap the cohort")
+    if not direct["primary_ufast_grid"].eq(
+        "vanguard_source_aligned_1mm_output"
+    ).all():
+        raise ValueError("a direct tumor mask isn't on the Vanguard UFAST output grid")
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    mask_dir = args.output_root / "masks"
+    mask_dir.mkdir(parents=True, exist_ok=True)
+    checksums = []
+    canonical_paths = []
+    source_paths = []
+    normalized_datasets = []
+    centerline_root = args.centerline_root.expanduser().resolve()
+    for row in direct.itertuples(index=False):
+        exam_id = str(row.exam_id)
+        cohort_row = cohort_by_exam.loc[exam_id]
+        dataset = str(cohort_row["dataset"])
+        source_mask = Path(row.primary_ufast_mask).expanduser().resolve()
+        if not source_mask.is_file():
+            raise FileNotFoundError(source_mask)
+        canonical_mask = mask_dir / f"{exam_id}.nii.gz"
+        _safe_symlink(source_mask, canonical_mask)
+
+        phase_paths = [Path(value) for value in json.loads(cohort_row["phase_files"])]
+        if not phase_paths or not phase_paths[0].is_file():
+            raise FileNotFoundError(f"{exam_id}: published UFAST phase is missing")
+        mask_image = nib.load(source_mask)
+        phase_image = nib.load(phase_paths[0])
+        skeleton_path = (
+            centerline_root
+            / dataset
+            / exam_id
+            / f"{exam_id}_skeleton_4d_exam_mask.npy"
+        )
+        if not skeleton_path.is_file():
+            raise FileNotFoundError(skeleton_path)
+        skeleton_shape_xyz = tuple(reversed(np.load(skeleton_path, mmap_mode="r").shape))
+        if mask_image.shape != phase_image.shape or mask_image.shape != skeleton_shape_xyz:
+            raise ValueError(
+                f"{exam_id}: tumor/image/skeleton shapes disagree: "
+                f"{mask_image.shape}, {phase_image.shape}, {skeleton_shape_xyz}"
+            )
+        if not np.allclose(mask_image.affine, phase_image.affine):
+            raise ValueError(f"{exam_id}: tumor and UFAST image affines disagree")
+
+        source_paths.append(str(source_mask))
+        canonical_paths.append(str(canonical_mask))
+        normalized_datasets.append(dataset)
+        checksums.append(
+            {
+                "exam_id": exam_id,
+                "primary_ufast_mask": str(canonical_mask),
+                "sha256": _sha256(source_mask),
+            }
+        )
+
+    direct["source_dataset"] = direct["dataset"]
+    direct["dataset"] = normalized_datasets
+    direct["source_primary_ufast_mask"] = source_paths
+    direct["primary_ufast_mask"] = canonical_paths
+    direct = direct.sort_values("exam_id").reset_index(drop=True)
+    expected_mask_names = {Path(path).name for path in canonical_paths}
+    for published_mask in mask_dir.glob("*.nii.gz"):
+        if published_mask.is_symlink() and published_mask.name not in expected_mask_names:
+            published_mask.unlink()
+    direct_path = args.output_root / "tumor_mask_manifest.csv"
+    direct.to_csv(direct_path, index=False)
+    pd.DataFrame(checksums).sort_values("exam_id").to_csv(
+        args.output_root / "mask_checksums.csv", index=False
+    )
+    _write_longitudinal_manifest(args, direct)
+
+    missing = sorted(set(cohort["exam_id"].astype(str)) - set(direct["exam_id"]))
+    provenance = {
+        "policy": POLICY_NAME,
+        "cohort_manifest": str(cohort_path),
+        "cohort_manifest_sha256": _sha256(cohort_path),
+        "direct_manifests": [
+            {
+                "path": str(path.expanduser().resolve()),
+                "sha256": _sha256(path.expanduser().resolve()),
+            }
+            for path in args.direct_manifest
+        ],
+        "centerline_root": str(centerline_root),
+        "cohort_exams": int(len(cohort)),
+        "direct_masks": int(len(direct)),
+        "missing_direct_exam_ids": missing,
+        "spatial_validation": (
+            "every direct mask has the exact published UFAST phase shape and "
+            "affine and the exact published skeleton shape"
+        ),
+    }
+    _write_json(args.output_root / "provenance.json", provenance)
+    (args.output_root / "README.md").write_text(
+        "# UChicago tumor masks\n\n"
+        f"This directory contains {len(direct)} direct primary-tumor masks for "
+        f"the {len(cohort)}-exam cohort. Each mask is the largest connected "
+        "component from MAMA-MIA inference on the first postcontrast "
+        "higher-spatial-resolution image, mapped in physical coordinates to "
+        "the exact 1 mm Vanguard UFAST image and vessel-skeleton grid. "
+        "Possible bilateral cases remain flagged in the manifests; the flat "
+        "`masks/` directory always contains only the primary component.\n\n"
+        "`tumor_mask_manifest.csv` lists direct segmentations, "
+        "`longitudinal_tumor_manifest.csv` joins tumor status and unambiguous "
+        "same-patient laterality to every cohort row, and "
+        "`mask_checksums.csv` records mask content checksums.\n",
+        encoding="utf-8",
+    )
+    checksum_paths = [
+        args.output_root / "tumor_mask_manifest.csv",
+        args.output_root / "longitudinal_tumor_manifest.csv",
+        args.output_root / "mask_checksums.csv",
+        args.output_root / "provenance.json",
+        args.output_root / "README.md",
+    ]
+    (args.output_root / "SHA256SUMS").write_text(
+        "".join(f"{_sha256(path)}  {path.name}\n" for path in checksum_paths),
+        encoding="utf-8",
+    )
+    print(
+        f"published {len(direct)}/{len(cohort)} direct masks under "
+        f"{args.output_root}; missing_direct={len(missing)}"
+    )
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -437,19 +901,38 @@ def _parser() -> argparse.ArgumentParser:
     common.add_argument("--output-root", type=Path, required=True)
     common.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
     common.add_argument("--case-manifest", type=Path, default=DEFAULT_CASE_MANIFEST)
-    common.add_argument("--selected-cases", type=Path, default=DEFAULT_SELECTED_CASES)
+    common.add_argument(
+        "--cohort-manifest", type=Path, default=DEFAULT_COHORT_MANIFEST
+    )
+    common.add_argument("--centerline-root", type=Path)
+    common.add_argument("--selected-cases", type=Path)
     common.add_argument("--model-dir", type=Path, default=DEFAULT_MODEL_DIR)
     sub.add_parser("prepare-cohort", parents=[common])
+    prepare_case_parser = sub.add_parser("prepare-case", parents=[common])
+    prepare_case_parser.add_argument("--exam-id")
+    prepare_case_parser.add_argument("--array-index", type=int)
+    sub.add_parser("index-cohort", parents=[common])
     sub.add_parser("finalize-cohort", parents=[common])
+    publish_parser = sub.add_parser("publish-cohort", parents=[common])
+    publish_parser.add_argument(
+        "--direct-manifest", action="append", required=True, type=Path
+    )
     return parser
 
 
 def main() -> None:
+    """Run one tumor-segmentation workflow stage."""
     args = _parser().parse_args()
     if args.command == "prepare-cohort":
         prepare_cohort(args)
+    elif args.command == "prepare-case":
+        prepare_case_command(args)
+    elif args.command == "index-cohort":
+        write_cohort_manifests(args)
     elif args.command == "finalize-cohort":
         finalize_cohort(args)
+    elif args.command == "publish-cohort":
+        publish_cohort(args)
     else:
         raise ValueError(args.command)
 

--- a/preprocessing/tumor.py
+++ b/preprocessing/tumor.py
@@ -87,7 +87,9 @@ def _shared_window(signal_tzyx: np.ndarray) -> list[float]:
     return [float(value) for value in np.percentile(values, [0.5, 99.5])]
 
 
-def _motion_correct_hr(signal_tzyx: np.ndarray, geometry: DicomGeometry) -> tuple[np.ndarray, list[dict[str, Any]]]:
+def _motion_correct_hr(
+    signal_tzyx: np.ndarray, geometry: DicomGeometry
+) -> tuple[np.ndarray, list[dict[str, Any]]]:
     signal_tzyx = np.asarray(signal_tzyx, dtype=np.float32)
     fixed_xyz = np.transpose(signal_tzyx[0], (2, 1, 0))
     corrected = [signal_tzyx[0]]
@@ -164,7 +166,9 @@ def prepare_case_for_tumor(
             ufast,
             baseline_frame_count=record.ufast_baseline_frame_count,
         )
-        corrected_hr_tzyx, motion_metrics = _motion_correct_hr(hr.signal_tzyx, hr.geometry)
+        corrected_hr_tzyx, motion_metrics = _motion_correct_hr(
+            hr.signal_tzyx, hr.geometry
+        )
         hr_dir = case_root / "hr_images"
         nnunet_input_dir = case_root / "nnunet_postcontrast_inputs"
         rows = []
@@ -197,8 +201,12 @@ def prepare_case_for_tumor(
                         )
                     ),
                     "hr_image": str(image_path),
-                    "nnunet_input": str(input_link) if phase_index >= FIRST_POSTCONTRAST_PHASE else "",
-                    "prediction": str(prediction_path) if phase_index >= FIRST_POSTCONTRAST_PHASE else "",
+                    "nnunet_input": str(input_link)
+                    if phase_index >= FIRST_POSTCONTRAST_PHASE
+                    else "",
+                    "prediction": str(prediction_path)
+                    if phase_index >= FIRST_POSTCONTRAST_PHASE
+                    else "",
                 }
             )
 
@@ -252,7 +260,9 @@ def prepare_case_for_tumor(
             "outputs": {
                 "hr_images": str(hr_dir),
                 "nnunet_postcontrast_inputs": str(nnunet_input_dir),
-                "nnunet_postcontrast_predictions": str(case_root / "nnunet_postcontrast_predictions"),
+                "nnunet_postcontrast_predictions": str(
+                    case_root / "nnunet_postcontrast_predictions"
+                ),
             },
         }
         _write_json(provenance_path, provenance)
@@ -327,13 +337,19 @@ def write_cohort_manifests(args: argparse.Namespace) -> None:
                 "ufast_series_instance_uid": row.ufast_series_instance_uid,
                 "input_dir": provenance["outputs"]["nnunet_postcontrast_inputs"],
                 "output_dir": provenance["outputs"]["nnunet_postcontrast_predictions"],
-                "n_postcontrast_phases": int((phase_manifest["phase_index"] >= FIRST_POSTCONTRAST_PHASE).sum()),
+                "n_postcontrast_phases": int(
+                    (phase_manifest["phase_index"] >= FIRST_POSTCONTRAST_PHASE).sum()
+                ),
             }
         )
 
     args.output_root.mkdir(parents=True, exist_ok=True)
-    pd.DataFrame(job_rows).to_csv(args.output_root / "tumor_case_manifest.csv", index=False)
-    pd.concat(all_rows, ignore_index=True).to_csv(args.output_root / "tumor_phase_manifest.csv", index=False)
+    pd.DataFrame(job_rows).to_csv(
+        args.output_root / "tumor_case_manifest.csv", index=False
+    )
+    pd.concat(all_rows, ignore_index=True).to_csv(
+        args.output_root / "tumor_phase_manifest.csv", index=False
+    )
     _write_json(
         args.output_root / "tumor_run_provenance.json",
         {
@@ -360,7 +376,9 @@ def write_cohort_manifests(args: argparse.Namespace) -> None:
     print(f"wrote {args.output_root / 'tumor_case_manifest.csv'}")
     print(f"wrote {args.output_root / 'tumor_phase_manifest.csv'}")
     print(f"n_cases={len(job_rows)}")
-    print(f"n_postcontrast_inputs={sum(row['n_postcontrast_phases'] for row in job_rows)}")
+    print(
+        f"n_postcontrast_inputs={sum(row['n_postcontrast_phases'] for row in job_rows)}"
+    )
 
 
 def prepare_cohort(args: argparse.Namespace) -> None:
@@ -395,7 +413,9 @@ def _component_outputs(
     out_dir.mkdir(parents=True, exist_ok=True)
     all_path = out_dir / "tumor_all_components_hr.nii.gz"
     primary_path = out_dir / "tumor_primary_hr.nii.gz"
-    labeled, n_components = ndimage.label(mask, structure=np.ones((3, 3, 3), dtype=np.uint8))
+    labeled, n_components = ndimage.label(
+        mask, structure=np.ones((3, 3, 3), dtype=np.uint8)
+    )
     if n_components:
         sizes = ndimage.sum(mask, labeled, index=np.arange(1, n_components + 1))
         primary_label = int(np.argmax(sizes) + 1)
@@ -420,9 +440,7 @@ def _component_outputs(
                 "centroid_xyz": centroid_xyz.tolist(),
                 "centroid_ras_mm": np.asarray(centroid_ras, dtype=float).tolist(),
                 "laterality": (
-                    "right"
-                    if float(centroid_ras[0]) > field_center_ras_x
-                    else "left"
+                    "right" if float(centroid_ras[0]) > field_center_ras_x else "left"
                 ),
             }
         )
@@ -451,15 +469,25 @@ def finalize_cohort(args: argparse.Namespace) -> None:
     for case in cases.itertuples(index=False):
         exam_id = str(case.exam_id)
         case_root = _case_root(args.output_root, exam_id)
-        provenance = json.loads((case_root / "tumor_preprocessing_provenance.json").read_text())
-        case_phases = phase_manifest.loc[phase_manifest["exam_id"].astype(str).eq(exam_id)].copy()
-        first_row = case_phases.loc[case_phases["phase_index"].eq(FIRST_POSTCONTRAST_PHASE)].iloc[0]
+        provenance = json.loads(
+            (case_root / "tumor_preprocessing_provenance.json").read_text()
+        )
+        case_phases = phase_manifest.loc[
+            phase_manifest["exam_id"].astype(str).eq(exam_id)
+        ].copy()
+        first_row = case_phases.loc[
+            case_phases["phase_index"].eq(FIRST_POSTCONTRAST_PHASE)
+        ].iloc[0]
         first_pred = Path(first_row["prediction"])
         first_mask, first_img = _load_mask(first_pred)
-        component_info = _component_outputs(first_mask, first_img, case_root / "tumor_masks")
+        component_info = _component_outputs(
+            first_mask, first_img, case_root / "tumor_masks"
+        )
 
         later_dice = []
-        for _, later in case_phases.loc[case_phases["phase_index"].gt(FIRST_POSTCONTRAST_PHASE)].iterrows():
+        for _, later in case_phases.loc[
+            case_phases["phase_index"].gt(FIRST_POSTCONTRAST_PHASE)
+        ].iterrows():
             later_pred = Path(later["prediction"])
             if not later_pred.exists():
                 continue
@@ -493,9 +521,7 @@ def finalize_cohort(args: argparse.Namespace) -> None:
             default=0.0,
         )
         opposite_ratio = (
-            opposite_volume_ml / primary_volume_ml
-            if primary_volume_ml > 0
-            else None
+            opposite_volume_ml / primary_volume_ml if primary_volume_ml > 0 else None
         )
         bilateral_candidate = bool(
             opposite_volume_ml >= BILATERAL_MIN_OPPOSITE_VOLUME_ML
@@ -567,7 +593,9 @@ def finalize_cohort(args: argparse.Namespace) -> None:
                 "ufast_series_instance_uid": case.ufast_series_instance_uid,
                 "first_postcontrast_phase": FIRST_POSTCONTRAST_PHASE,
                 "first_postcontrast_time_seconds": float(first_row["time_seconds"]),
-                "n_later_postcontrast_phases": int(case_phases["phase_index"].gt(FIRST_POSTCONTRAST_PHASE).sum()),
+                "n_later_postcontrast_phases": int(
+                    case_phases["phase_index"].gt(FIRST_POSTCONTRAST_PHASE).sum()
+                ),
                 "median_first_to_later_dice": median_later_dice,
                 "all_components_volume_ml": component_info["all_components_volume_ml"],
                 "primary_component_volume_ml": primary_volume_ml,
@@ -677,9 +705,9 @@ def _write_longitudinal_manifest(
     combined["tumor_laterality_source_exam_ids"] = source_exams
     combined["patient_laterality_conflict"] = conflicts
     direct_exclusion = combined["exclude_downstream"].eq(True)
-    combined["exclude_downstream"] = direct_exclusion | combined[
-        "patient_laterality_conflict"
-    ]
+    combined["exclude_downstream"] = (
+        direct_exclusion | combined["patient_laterality_conflict"]
+    )
     direct_reasons = combined["exclude_reason"].fillna("").astype(str)
     combined["exclude_reason"] = [
         ";".join(
@@ -699,7 +727,9 @@ def _write_longitudinal_manifest(
     combined["tumor_segmentation_status"] = np.where(
         combined["primary_hr_mask"].notna(),
         "segmented",
-        combined.get("hr_selection_status", pd.Series("not_runnable", index=combined.index)),
+        combined.get(
+            "hr_selection_status", pd.Series("not_runnable", index=combined.index)
+        ),
     )
     if args.centerline_root is not None:
         centerline_rows = []
@@ -733,9 +763,7 @@ def _write_longitudinal_manifest(
         combined = combined.merge(
             centerlines, on="exam_id", how="left", validate="one_to_one"
         )
-        combined["centerline_status"] = combined["centerline_status"].fillna(
-            "missing"
-        )
+        combined["centerline_status"] = combined["centerline_status"].fillna("missing")
     output_path = args.output_root / "longitudinal_tumor_manifest.csv"
     combined.to_csv(output_path, index=False)
     print(f"wrote {output_path}")
@@ -763,14 +791,10 @@ def publish_cohort(args: argparse.Namespace) -> None:
             direct["exam_id"].astype(str).duplicated(keep=False), "exam_id"
         ].tolist()
         raise ValueError(f"direct tumor manifests repeat exam IDs: {repeated[:3]}")
-    direct = direct.loc[
-        direct["exam_id"].astype(str).isin(cohort_by_exam.index)
-    ].copy()
+    direct = direct.loc[direct["exam_id"].astype(str).isin(cohort_by_exam.index)].copy()
     if direct.empty:
         raise ValueError("no direct tumor masks overlap the cohort")
-    if not direct["primary_ufast_grid"].eq(
-        "vanguard_source_aligned_1mm_output"
-    ).all():
+    if not direct["primary_ufast_grid"].eq("vanguard_source_aligned_1mm_output").all():
         raise ValueError("a direct tumor mask isn't on the Vanguard UFAST output grid")
 
     args.output_root.mkdir(parents=True, exist_ok=True)
@@ -797,15 +821,17 @@ def publish_cohort(args: argparse.Namespace) -> None:
         mask_image = nib.load(source_mask)
         phase_image = nib.load(phase_paths[0])
         skeleton_path = (
-            centerline_root
-            / dataset
-            / exam_id
-            / f"{exam_id}_skeleton_4d_exam_mask.npy"
+            centerline_root / dataset / exam_id / f"{exam_id}_skeleton_4d_exam_mask.npy"
         )
         if not skeleton_path.is_file():
             raise FileNotFoundError(skeleton_path)
-        skeleton_shape_xyz = tuple(reversed(np.load(skeleton_path, mmap_mode="r").shape))
-        if mask_image.shape != phase_image.shape or mask_image.shape != skeleton_shape_xyz:
+        skeleton_shape_xyz = tuple(
+            reversed(np.load(skeleton_path, mmap_mode="r").shape)
+        )
+        if (
+            mask_image.shape != phase_image.shape
+            or mask_image.shape != skeleton_shape_xyz
+        ):
             raise ValueError(
                 f"{exam_id}: tumor/image/skeleton shapes disagree: "
                 f"{mask_image.shape}, {phase_image.shape}, {skeleton_shape_xyz}"
@@ -831,7 +857,10 @@ def publish_cohort(args: argparse.Namespace) -> None:
     direct = direct.sort_values("exam_id").reset_index(drop=True)
     expected_mask_names = {Path(path).name for path in canonical_paths}
     for published_mask in mask_dir.glob("*.nii.gz"):
-        if published_mask.is_symlink() and published_mask.name not in expected_mask_names:
+        if (
+            published_mask.is_symlink()
+            and published_mask.name not in expected_mask_names
+        ):
             published_mask.unlink()
     direct_path = args.output_root / "tumor_mask_manifest.csv"
     direct.to_csv(direct_path, index=False)
@@ -901,9 +930,7 @@ def _parser() -> argparse.ArgumentParser:
     common.add_argument("--output-root", type=Path, required=True)
     common.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
     common.add_argument("--case-manifest", type=Path, default=DEFAULT_CASE_MANIFEST)
-    common.add_argument(
-        "--cohort-manifest", type=Path, default=DEFAULT_COHORT_MANIFEST
-    )
+    common.add_argument("--cohort-manifest", type=Path, default=DEFAULT_COHORT_MANIFEST)
     common.add_argument("--centerline-root", type=Path)
     common.add_argument("--selected-cases", type=Path)
     common.add_argument("--model-dir", type=Path, default=DEFAULT_MODEL_DIR)

--- a/preprocessing/tumor.py
+++ b/preprocessing/tumor.py
@@ -1,0 +1,458 @@
+"""MAMA-MIA nnU-Net tumor-mask workflow for paired UChicago HR/UFAST DCE."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import nibabel as nib
+import numpy as np
+import pandas as pd
+from scipy import ndimage
+
+from preprocessing.cases import select_case
+from preprocessing.dicom import (
+    DicomGeometry,
+    geometry_alignment_checks,
+    load_dicom_series,
+)
+from preprocessing.motion import DEFAULT_MOTION_SETTINGS, correct_phase
+from preprocessing.pipeline import _identity_alignment_qc
+from preprocessing.spatial import resample_to_geometry, save_nifti_xyz
+
+POLICY_NAME = "mama_mia_first_postcontrast_hr_tumor_v1"
+FIRST_POSTCONTRAST_PHASE = 1
+TEMPORAL_INSTABILITY_DICE_THRESHOLD = 0.60
+TINY_VOLUME_ML_THRESHOLD = 0.10
+COMPONENT_CONNECTIVITY = 3
+BINARY_THRESHOLD = 0.5
+
+DEFAULT_INVENTORY = Path(
+    "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
+    "paired_hr_ufast_source_dicom/dicom_file_manifest.parquet"
+)
+DEFAULT_CASE_MANIFEST = Path(
+    "/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/"
+    "paired_hr_ufast_source_dicom/paired_preprocessing_case_manifest.csv"
+)
+DEFAULT_SELECTED_CASES = Path(
+    "results/uchicago_nnunet_timepoint_pilot/"
+    "all_datasets_random10_per_dataset_seed20260727/selected_cases.csv"
+)
+DEFAULT_MODEL_DIR = Path(
+    "/ess/scratch/scratch1/aakrithiram/nnunet_vanguard/results/"
+    "full_image_dce_mri_tumor_segmentation"
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.partial")
+    temporary.write_text(json.dumps(payload, indent=2) + "\n")
+    temporary.replace(path)
+
+
+def _shared_window(signal_tzyx: np.ndarray) -> list[float]:
+    values = np.asarray(signal_tzyx)[np.asarray(signal_tzyx) > 0]
+    if not values.size:
+        raise ValueError("HR DCE sequence has no positive values")
+    return [float(value) for value in np.percentile(values, [0.5, 99.5])]
+
+
+def _motion_correct_hr(signal_tzyx: np.ndarray, geometry: DicomGeometry) -> tuple[np.ndarray, list[dict[str, Any]]]:
+    signal_tzyx = np.asarray(signal_tzyx, dtype=np.float32)
+    fixed_xyz = np.transpose(signal_tzyx[0], (2, 1, 0))
+    corrected = [signal_tzyx[0]]
+    metrics: list[dict[str, Any]] = [
+        {
+            "phase_index": 0,
+            "transform_accepted": True,
+            "transform_rejection_reason": "reference_phase",
+            "translation_voxels": [0.0, 0.0, 0.0],
+        }
+    ]
+    for phase_index, moving_zyx in enumerate(signal_tzyx[1:], start=1):
+        corrected_xyz, _, phase_metrics = correct_phase(
+            fixed_xyz,
+            np.transpose(moving_zyx, (2, 1, 0)),
+            support=None,
+            spacing_xyz_mm=np.asarray(geometry.spacing_xyz_mm),
+            settings=DEFAULT_MOTION_SETTINGS,
+        )
+        corrected.append(np.transpose(corrected_xyz, (2, 1, 0)))
+        metrics.append({"phase_index": phase_index, **phase_metrics})
+    return np.stack(corrected, axis=0), metrics
+
+
+def _case_root(output_root: Path, exam_id: str) -> Path:
+    return output_root.expanduser().resolve() / "work" / exam_id
+
+
+def _safe_symlink(target: Path, link: Path) -> None:
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.exists() or link.is_symlink():
+        if link.resolve() != target.resolve():
+            raise FileExistsError(f"{link} points to {link.resolve()}, not {target}")
+        return
+    link.symlink_to(target.resolve())
+
+
+def prepare_case_for_tumor(
+    *,
+    inventory: Path,
+    case_manifest: Path,
+    exam_id: str,
+    output_root: Path,
+) -> dict[str, Any]:
+    """Prepare one exact paired case for MAMA-MIA tumor nnU-Net inference."""
+    record = select_case(case_manifest, exam_id)
+    case_root = _case_root(output_root, exam_id)
+    provenance_path = case_root / "tumor_preprocessing_provenance.json"
+    if provenance_path.exists():
+        return json.loads(provenance_path.read_text())
+    if case_root.exists():
+        raise FileExistsError(f"refusing to reuse partial case directory: {case_root}")
+
+    case_root.mkdir(parents=True)
+    try:
+        hr = load_dicom_series(
+            inventory,
+            study_uid=record.study_instance_uid,
+            series_uid=record.hr_series_instance_uid,
+        )
+        ufast = load_dicom_series(
+            inventory,
+            study_uid=record.study_instance_uid,
+            series_uid=record.ufast_series_instance_uid,
+        )
+        if hr.signal_tzyx.shape[0] <= FIRST_POSTCONTRAST_PHASE:
+            raise ValueError(f"{exam_id}: HR series has no first postcontrast phase")
+        if not np.all(np.diff(hr.times_seconds) > 0):
+            raise ValueError(f"{exam_id}: HR DICOM times are not increasing")
+
+        geometry_checks = geometry_alignment_checks(hr.geometry, ufast.geometry)
+        alignment_qc = _identity_alignment_qc(
+            hr,
+            ufast,
+            baseline_frame_count=record.ufast_baseline_frame_count,
+        )
+        corrected_hr_tzyx, motion_metrics = _motion_correct_hr(hr.signal_tzyx, hr.geometry)
+        hr_dir = case_root / "hr_images"
+        nnunet_input_dir = case_root / "nnunet_postcontrast_inputs"
+        rows = []
+        for phase_index, phase_zyx in enumerate(corrected_hr_tzyx):
+            image_path = hr_dir / f"{exam_id}__hr_tp{phase_index:04d}_0000.nii.gz"
+            save_nifti_xyz(image_path, np.transpose(phase_zyx, (2, 1, 0)), hr.geometry)
+            prediction_path = (
+                case_root
+                / "nnunet_postcontrast_predictions"
+                / f"{exam_id}__hr_tp{phase_index:04d}.nii.gz"
+            )
+            if phase_index >= FIRST_POSTCONTRAST_PHASE:
+                input_link = nnunet_input_dir / image_path.name
+                _safe_symlink(image_path, input_link)
+            else:
+                input_link = Path("")
+            rows.append(
+                {
+                    "exam_id": exam_id,
+                    "dataset": record.dataset,
+                    "phase_index": phase_index,
+                    "time_seconds": float(hr.times_seconds[phase_index]),
+                    "role": (
+                        "precontrast"
+                        if phase_index == 0
+                        else (
+                            "final_candidate"
+                            if phase_index == FIRST_POSTCONTRAST_PHASE
+                            else "temporal_qc"
+                        )
+                    ),
+                    "hr_image": str(image_path),
+                    "nnunet_input": str(input_link) if phase_index >= FIRST_POSTCONTRAST_PHASE else "",
+                    "prediction": str(prediction_path) if phase_index >= FIRST_POSTCONTRAST_PHASE else "",
+                }
+            )
+
+        pd.DataFrame(rows).to_csv(case_root / "hr_phase_manifest.csv", index=False)
+        provenance = {
+            "status": "prepared",
+            "policy": {
+                "name": POLICY_NAME,
+                "tumor_source": "first postcontrast HR image",
+                "first_postcontrast_phase": FIRST_POSTCONTRAST_PHASE,
+                "precontrast_phase": 0,
+                "later_phases": "temporal QC only",
+                "breast_mask": "not used as nnU-Net input and not intersected with tumor output",
+                "hr_motion_reference_phase": 0,
+                "hr_motion_output_interpolator": "linear",
+                "nnunet_normalization": "handled by released nnU-Net 3d_fullres plan",
+                "nnunet_resampling": "handled by released nnU-Net 3d_fullres plan",
+            },
+            "case": record.__dict__,
+            "inventory_path": str(inventory.expanduser().resolve()),
+            "case_manifest_path": str(case_manifest.expanduser().resolve()),
+            "hr_source": {
+                "archive_path": str(hr.archive_path),
+                "selected_dicom_sha256": hr.source_sha256,
+                "series_instance_uid": record.hr_series_instance_uid,
+                "geometry": hr.geometry.to_dict(),
+                "times_seconds": hr.times_seconds.tolist(),
+                "temporal_positions": list(hr.temporal_positions),
+                "shared_4d_window": _shared_window(hr.signal_tzyx),
+            },
+            "ufast_source": {
+                "archive_path": str(ufast.archive_path),
+                "selected_dicom_sha256": ufast.source_sha256,
+                "series_instance_uid": record.ufast_series_instance_uid,
+                "geometry": ufast.geometry.to_dict(),
+                "times_seconds": ufast.times_seconds.tolist(),
+                "temporal_positions": list(ufast.temporal_positions),
+                "baseline_frame_count": record.ufast_baseline_frame_count,
+            },
+            "geometry_alignment": geometry_checks,
+            "identity_alignment_qc": alignment_qc,
+            "hr_motion_qc": {"reference_phase": 0, "metrics": motion_metrics},
+            "outputs": {
+                "hr_images": str(hr_dir),
+                "nnunet_postcontrast_inputs": str(nnunet_input_dir),
+                "nnunet_postcontrast_predictions": str(case_root / "nnunet_postcontrast_predictions"),
+            },
+        }
+        _write_json(provenance_path, provenance)
+        return provenance
+    except Exception:
+        import shutil
+
+        shutil.rmtree(case_root, ignore_errors=True)
+        raise
+
+
+def prepare_cohort(args: argparse.Namespace) -> None:
+    selected = pd.read_csv(args.selected_cases, dtype=str)
+    case_manifest = pd.read_csv(args.case_manifest, dtype=str)
+    cases = selected[["exam_id", "dataset"]].merge(
+        case_manifest,
+        on=["exam_id", "dataset"],
+        how="inner",
+        validate="one_to_one",
+    )
+    if len(cases) != len(selected):
+        missing = selected.loc[~selected["exam_id"].isin(cases["exam_id"])]
+        raise RuntimeError(f"selected cases missing runnable HR rows:\n{missing}")
+
+    all_rows = []
+    job_rows = []
+    for row in cases.sort_values("exam_id").itertuples(index=False):
+        provenance = prepare_case_for_tumor(
+            inventory=args.inventory,
+            case_manifest=args.case_manifest,
+            exam_id=str(row.exam_id),
+            output_root=args.output_root,
+        )
+        case_root = _case_root(args.output_root, str(row.exam_id))
+        phase_manifest = pd.read_csv(case_root / "hr_phase_manifest.csv")
+        all_rows.append(phase_manifest)
+        job_rows.append(
+            {
+                "exam_id": row.exam_id,
+                "dataset": row.dataset,
+                "hr_series_instance_uid": row.hr_series_instance_uid,
+                "ufast_series_instance_uid": row.ufast_series_instance_uid,
+                "input_dir": provenance["outputs"]["nnunet_postcontrast_inputs"],
+                "output_dir": provenance["outputs"]["nnunet_postcontrast_predictions"],
+                "n_postcontrast_phases": int((phase_manifest["phase_index"] >= FIRST_POSTCONTRAST_PHASE).sum()),
+            }
+        )
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(job_rows).to_csv(args.output_root / "tumor_case_manifest.csv", index=False)
+    pd.concat(all_rows, ignore_index=True).to_csv(args.output_root / "tumor_phase_manifest.csv", index=False)
+    _write_json(
+        args.output_root / "tumor_run_provenance.json",
+        {
+            "policy": POLICY_NAME,
+            "inventory": str(args.inventory.expanduser().resolve()),
+            "case_manifest": str(args.case_manifest.expanduser().resolve()),
+            "selected_cases": str(args.selected_cases.expanduser().resolve()),
+            "model_dir": str(args.model_dir.expanduser().resolve()),
+            "model_dir_sha256s": {
+                str(path.relative_to(args.model_dir)): _sha256(path)
+                for path in sorted(args.model_dir.glob("fold_*/checkpoint_final.pth"))
+            },
+            "dataset_json": json.loads((args.model_dir / "dataset.json").read_text()),
+            "plans_json_sha256": _sha256(args.model_dir / "plans.json"),
+            "folds": [0, 1, 2, 3, 4],
+            "first_postcontrast_phase": FIRST_POSTCONTRAST_PHASE,
+            "note": "nnU-Net handles 3d_fullres 1 mm resampling and ZScoreNormalization internally.",
+        },
+    )
+    print(f"wrote {args.output_root / 'tumor_case_manifest.csv'}")
+    print(f"wrote {args.output_root / 'tumor_phase_manifest.csv'}")
+    print(f"n_cases={len(job_rows)}")
+    print(f"n_postcontrast_inputs={sum(row['n_postcontrast_phases'] for row in job_rows)}")
+
+
+def _load_mask(path: Path) -> tuple[np.ndarray, nib.Nifti1Image]:
+    image = nib.load(path)
+    return np.asanyarray(image.dataobj) > 0, image
+
+
+def _dice(a: np.ndarray, b: np.ndarray) -> float | None:
+    a = np.asarray(a, dtype=bool)
+    b = np.asarray(b, dtype=bool)
+    if not a.any() and not b.any():
+        return None
+    denom = int(a.sum() + b.sum())
+    return float((2.0 * np.logical_and(a, b).sum()) / denom) if denom else None
+
+
+def _component_outputs(mask: np.ndarray, img: nib.Nifti1Image, out_dir: Path) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    all_path = out_dir / "tumor_all_components_hr.nii.gz"
+    primary_path = out_dir / "tumor_primary_hr.nii.gz"
+    labeled, n_components = ndimage.label(mask, structure=np.ones((3, 3, 3), dtype=np.uint8))
+    if n_components:
+        sizes = ndimage.sum(mask, labeled, index=np.arange(1, n_components + 1))
+        primary_label = int(np.argmax(sizes) + 1)
+        primary = labeled == primary_label
+    else:
+        primary_label = 0
+        primary = np.zeros_like(mask, dtype=bool)
+    voxel_ml = float(abs(np.linalg.det(img.affine[:3, :3])) / 1000.0)
+    for path, arr in ((all_path, mask), (primary_path, primary)):
+        out = nib.Nifti1Image(arr.astype(np.uint8), img.affine, img.header)
+        out.set_data_dtype(np.uint8)
+        nib.save(out, path)
+    return {
+        "all_components_path": str(all_path),
+        "primary_path": str(primary_path),
+        "n_components": int(n_components),
+        "primary_label": primary_label,
+        "all_components_volume_ml": float(mask.sum() * voxel_ml),
+        "primary_component_volume_ml": float(primary.sum() * voxel_ml),
+        "primary_mask": primary,
+    }
+
+
+def finalize_cohort(args: argparse.Namespace) -> None:
+    cases = pd.read_csv(args.output_root / "tumor_case_manifest.csv", dtype=str)
+    phase_manifest = pd.read_csv(args.output_root / "tumor_phase_manifest.csv")
+    rows = []
+    for case in cases.itertuples(index=False):
+        exam_id = str(case.exam_id)
+        case_root = _case_root(args.output_root, exam_id)
+        provenance = json.loads((case_root / "tumor_preprocessing_provenance.json").read_text())
+        case_phases = phase_manifest.loc[phase_manifest["exam_id"].astype(str).eq(exam_id)].copy()
+        first_row = case_phases.loc[case_phases["phase_index"].eq(FIRST_POSTCONTRAST_PHASE)].iloc[0]
+        first_pred = Path(first_row["prediction"])
+        first_mask, first_img = _load_mask(first_pred)
+        component_info = _component_outputs(first_mask, first_img, case_root / "tumor_masks")
+
+        later_dice = []
+        for _, later in case_phases.loc[case_phases["phase_index"].gt(FIRST_POSTCONTRAST_PHASE)].iterrows():
+            later_pred = Path(later["prediction"])
+            if not later_pred.exists():
+                continue
+            later_mask, _ = _load_mask(later_pred)
+            value = _dice(first_mask, later_mask)
+            if value is not None:
+                later_dice.append(value)
+        median_later_dice = float(np.median(later_dice)) if later_dice else None
+        tumor_empty = not bool(first_mask.any())
+        primary_volume_ml = float(component_info["primary_component_volume_ml"])
+        review_temporal = bool(
+            tumor_empty
+            or median_later_dice is None
+            or median_later_dice < TEMPORAL_INSTABILITY_DICE_THRESHOLD
+        )
+        review_tiny = bool(primary_volume_ml < TINY_VOLUME_ML_THRESHOLD)
+
+        primary_hr_zyx = np.transpose(
+            component_info["primary_mask"].astype(np.float32), (2, 1, 0)
+        )
+        hr_geometry = DicomGeometry.from_dict(provenance["hr_source"]["geometry"])
+        ufast_geometry = DicomGeometry.from_dict(provenance["ufast_source"]["geometry"])
+        primary_ufast = (
+            resample_to_geometry(primary_hr_zyx, hr_geometry, ufast_geometry, nearest=True)
+            > BINARY_THRESHOLD
+        )
+        primary_ufast_path = case_root / "tumor_masks" / "tumor_primary_ufast.nii.gz"
+        save_nifti_xyz(primary_ufast_path, np.transpose(primary_ufast.astype(np.float32), (2, 1, 0)), ufast_geometry)
+
+        alignment_status = str(provenance["identity_alignment_qc"]["status"])
+        mapping_status = "pass" if alignment_status == "pass" else "review_required"
+        exclude_downstream = mapping_status != "pass"
+        exclude_reason = "alignment_review_required" if exclude_downstream else ""
+
+        rows.append(
+            {
+                "exam_id": exam_id,
+                "hr_series_instance_uid": case.hr_series_instance_uid,
+                "ufast_series_instance_uid": case.ufast_series_instance_uid,
+                "first_postcontrast_phase": FIRST_POSTCONTRAST_PHASE,
+                "first_postcontrast_time_seconds": float(first_row["time_seconds"]),
+                "n_later_postcontrast_phases": int(case_phases["phase_index"].gt(FIRST_POSTCONTRAST_PHASE).sum()),
+                "median_first_to_later_dice": median_later_dice,
+                "all_components_volume_ml": component_info["all_components_volume_ml"],
+                "primary_component_volume_ml": primary_volume_ml,
+                "opposite_breast_component_ml": None,
+                "opposite_to_primary_volume_ratio": None,
+                "tumor_mask_empty": tumor_empty,
+                "review_tiny": review_tiny,
+                "review_temporal_instability": review_temporal,
+                "bilateral_candidate": None,
+                "bilateral_review_status": "not_evaluated_no_aligned_bilateral_hr_mask",
+                "alignment_qc_status": alignment_status,
+                "mapping_status": mapping_status,
+                "exclude_downstream": exclude_downstream,
+                "exclude_reason": exclude_reason,
+                "primary_hr_mask": component_info["primary_path"],
+                "primary_ufast_mask": str(primary_ufast_path),
+                "all_components_hr_mask": component_info["all_components_path"],
+                "qc_panel": "",
+            }
+        )
+    manifest = pd.DataFrame(rows)
+    manifest.to_csv(args.output_root / "tumor_mask_manifest.csv", index=False)
+    print(f"wrote {args.output_root / 'tumor_mask_manifest.csv'}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--output-root", type=Path, required=True)
+    common.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    common.add_argument("--case-manifest", type=Path, default=DEFAULT_CASE_MANIFEST)
+    common.add_argument("--selected-cases", type=Path, default=DEFAULT_SELECTED_CASES)
+    common.add_argument("--model-dir", type=Path, default=DEFAULT_MODEL_DIR)
+    sub.add_parser("prepare-cohort", parents=[common])
+    sub.add_parser("finalize-cohort", parents=[common])
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    if args.command == "prepare-cohort":
+        prepare_cohort(args)
+    elif args.command == "finalize-cohort":
+        finalize_cohort(args)
+    else:
+        raise ValueError(args.command)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qc_uchicago_tumor_contract_30.py
+++ b/scripts/qc_uchicago_tumor_contract_30.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Render QC panels for the mentor-contract 30-case UChicago tumor pilot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import nibabel as nib
+import numpy as np
+import pandas as pd
+
+from preprocessing.dicom import load_dicom_series
+
+
+DEFAULT_RUN_ROOT = Path("/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30")
+DEFAULT_OUT_DIR = Path("qc/uchic_tumor_masks_contract_30")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-root", type=Path, default=DEFAULT_RUN_ROOT)
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    return parser.parse_args()
+
+
+def _load(path: Path) -> np.ndarray:
+    return np.asanyarray(nib.load(path).dataobj)
+
+
+def _mask(path: Path) -> np.ndarray:
+    return _load(path) > 0
+
+
+def _display(arr: np.ndarray) -> np.ndarray:
+    return np.rot90(arr)
+
+
+def _shared_window(paths: list[Path]) -> tuple[float, float]:
+    samples = []
+    for path in paths:
+        arr = np.ravel(_load(path).astype(np.float32))
+        arr = arr[np.isfinite(arr)]
+        if arr.size:
+            samples.append(arr[:: max(1, arr.size // 100_000)])
+    vals = np.concatenate(samples)
+    vals = vals[vals > 0]
+    lo, hi = np.percentile(vals, [0.5, 99.5])
+    if not hi > lo:
+        hi = lo + 1.0
+    return float(lo), float(hi)
+
+
+def _best_slice(*masks: np.ndarray) -> int:
+    counts = None
+    for mask in masks:
+        z_counts = np.asarray(mask, dtype=bool).reshape(-1, mask.shape[2]).sum(axis=0)
+        counts = z_counts if counts is None else counts + z_counts
+    if counts is not None and counts.max() > 0:
+        return int(np.argmax(counts))
+    return int(masks[0].shape[2] // 2)
+
+
+def _overlay(ax: plt.Axes, image: np.ndarray, mask: np.ndarray, *, vmin: float, vmax: float, color: str) -> None:
+    ax.imshow(_display(image), cmap="gray", vmin=vmin, vmax=vmax)
+    shown = np.ma.masked_where(~mask.astype(bool), mask.astype(bool))
+    ax.imshow(_display(shown), cmap=color, alpha=0.45, vmin=0, vmax=1)
+    ax.axis("off")
+
+
+def _sub_limit(first: np.ndarray, images: list[np.ndarray]) -> float:
+    limits = []
+    for image in images:
+        sub = image.astype(np.float32) - first.astype(np.float32)
+        limits.extend([abs(float(np.percentile(sub, 1))), abs(float(np.percentile(sub, 99)))])
+    value = max(limits) if limits else 1.0
+    return value if value > 0 else 1.0
+
+
+def _ufast_baseline(provenance: dict[str, object]) -> np.ndarray:
+    case = provenance["case"]
+    ufast = load_dicom_series(
+        provenance["inventory_path"],
+        study_uid=case["study_instance_uid"],
+        series_uid=case["ufast_series_instance_uid"],
+    )
+    n_baseline = int(provenance["ufast_source"]["baseline_frame_count"])
+    return np.asarray(ufast.signal_tzyx[:n_baseline].mean(axis=0), dtype=np.float32)
+
+
+def render_case(run_root: Path, out_dir: Path, row: pd.Series) -> dict[str, object]:
+    exam_id = str(row["exam_id"])
+    case_root = run_root / "work" / exam_id
+    provenance = json.loads((case_root / "tumor_preprocessing_provenance.json").read_text())
+    phases = pd.read_csv(case_root / "hr_phase_manifest.csv")
+    image_paths = [Path(path) for path in phases["hr_image"]]
+    images = [_load(path).astype(np.float32) for path in image_paths]
+    vmin, vmax = _shared_window(image_paths)
+    pre = images[0]
+    first_post = images[1]
+    sub_lim = _sub_limit(pre, images)
+
+    all_components = _mask(case_root / "tumor_masks" / "tumor_all_components_hr.nii.gz")
+    primary = _mask(case_root / "tumor_masks" / "tumor_primary_hr.nii.gz")
+    later_rows = phases.loc[phases["phase_index"].gt(1)].copy()
+    later_masks = []
+    for _, phase in later_rows.iterrows():
+        pred = Path(str(phase["prediction"]))
+        if pred.exists():
+            later_masks.append((int(phase["phase_index"]), float(phase["time_seconds"]), _mask(pred)))
+
+    z = _best_slice(primary, all_components)
+    n_cols = 6 + len(later_masks)
+    fig, axes = plt.subplots(2, n_cols, figsize=(2.4 * n_cols, 5.2), constrained_layout=True)
+    if n_cols == 1:
+        axes = np.asarray(axes).reshape(2, 1)
+    fig.suptitle(f"{exam_id} tumor QC, HR axial z={z}", fontsize=11)
+
+    axes[0, 0].imshow(_display(pre[:, :, z]), cmap="gray", vmin=vmin, vmax=vmax)
+    axes[0, 0].set_title("HR tp0 pre", fontsize=8)
+    axes[0, 0].axis("off")
+
+    _overlay(axes[0, 1], first_post[:, :, z], primary[:, :, z], vmin=vmin, vmax=vmax, color="autumn")
+    axes[0, 1].set_title(f"HR tp1 final\n{float(phases.iloc[1]['time_seconds']):.1f}s", fontsize=8)
+
+    sub = first_post - pre
+    axes[0, 2].imshow(_display(sub[:, :, z]), cmap="seismic", vmin=-sub_lim, vmax=sub_lim)
+    axes[0, 2].imshow(_display(np.ma.masked_where(~primary[:, :, z], primary[:, :, z])), cmap="autumn", alpha=0.45)
+    axes[0, 2].set_title("tp1 - tp0", fontsize=8)
+    axes[0, 2].axis("off")
+
+    _overlay(axes[0, 3], first_post[:, :, z], all_components[:, :, z], vmin=vmin, vmax=vmax, color="spring")
+    axes[0, 3].set_title("all tp1 comps", fontsize=8)
+
+    _overlay(axes[0, 4], first_post[:, :, z], primary[:, :, z], vmin=vmin, vmax=vmax, color="autumn")
+    axes[0, 4].set_title("primary comp", fontsize=8)
+
+    ufast_base = _ufast_baseline(provenance)
+    primary_ufast = _mask(case_root / "tumor_masks" / "tumor_primary_ufast.nii.gz")
+    z_ufast = _best_slice(primary_ufast)
+    uf_vals = ufast_base[ufast_base > 0]
+    uf_vmin, uf_vmax = np.percentile(uf_vals, [0.5, 99.5]) if uf_vals.size else (0.0, 1.0)
+    _overlay(
+        axes[0, 5],
+        np.transpose(ufast_base, (2, 1, 0))[:, :, z_ufast],
+        primary_ufast[:, :, z_ufast],
+        vmin=float(uf_vmin),
+        vmax=float(uf_vmax),
+        color="autumn",
+    )
+    axes[0, 5].set_title(f"UFAST baseline\nz={z_ufast}", fontsize=8)
+
+    for col, (phase_index, time_seconds, mask) in enumerate(later_masks, start=6):
+        image = images[phase_index]
+        _overlay(axes[0, col], image[:, :, z], mask[:, :, z], vmin=vmin, vmax=vmax, color="autumn")
+        axes[0, col].set_title(f"later tp{phase_index}\n{time_seconds:.1f}s", fontsize=8)
+
+    for col in range(n_cols):
+        axes[1, col].axis("off")
+    axes[1, 0].text(
+        0,
+        0.95,
+        "\n".join(
+            [
+                f"primary ml: {float(row['primary_component_volume_ml']):.3f}",
+                f"all comps ml: {float(row['all_components_volume_ml']):.3f}",
+                f"median later Dice: {row['median_first_to_later_dice']}",
+                f"empty: {row['tumor_mask_empty']}",
+                f"tiny: {row['review_tiny']}",
+                f"temporal review: {row['review_temporal_instability']}",
+                f"alignment: {row['alignment_qc_status']}",
+                f"mapping: {row['mapping_status']}",
+            ]
+        ),
+        va="top",
+        ha="left",
+        fontsize=9,
+        family="monospace",
+    )
+    for col, image in enumerate(images[: min(n_cols, len(images))]):
+        axes[1, col].imshow(_display(image[:, :, z]), cmap="gray", vmin=vmin, vmax=vmax)
+        axes[1, col].set_title(f"natural tp{col}", fontsize=8)
+        axes[1, col].axis("off")
+
+    out_path = out_dir / f"{exam_id}_tumor_contract_qc.png"
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    return {"exam_id": exam_id, "dataset": row.get("dataset", ""), "qc_panel": str(out_path)}
+
+
+def main() -> None:
+    args = parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    manifest = pd.read_csv(args.run_root / "tumor_mask_manifest.csv")
+    rows = [render_case(args.run_root, args.out_dir, row) for _, row in manifest.iterrows()]
+    index = pd.DataFrame(rows)
+    index.to_csv(args.out_dir / "index.csv", index=False)
+    with (args.out_dir / "index.html").open("w") as stream:
+        stream.write("<html><body><h1>UChicago tumor contract QC, 30-case pilot</h1>\n")
+        for row in rows:
+            name = Path(row["qc_panel"]).name
+            stream.write(f"<h2>{row['exam_id']}</h2>\n")
+            stream.write(f"<img src='{name}' style='max-width:100%;'>\n")
+        stream.write("</body></html>\n")
+    print(f"wrote {args.out_dir / 'index.html'}")
+    print(f"n_panels={len(rows)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qc_uchicago_tumor_contract_30.py
+++ b/scripts/qc_uchicago_tumor_contract_30.py
@@ -19,11 +19,11 @@ import pandas as pd
 
 from preprocessing.dicom import load_dicom_series
 
-
 DEFAULT_OUT_DIR = Path("qc/uchic_tumor_masks_contract_30")
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse the prepared-run and output locations."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-root", type=Path, required=True)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
@@ -67,7 +67,15 @@ def _best_slice(*masks: np.ndarray) -> int:
     return int(masks[0].shape[2] // 2)
 
 
-def _overlay(ax: plt.Axes, image: np.ndarray, mask: np.ndarray, *, vmin: float, vmax: float, color: str) -> None:
+def _overlay(
+    ax: plt.Axes,
+    image: np.ndarray,
+    mask: np.ndarray,
+    *,
+    vmin: float,
+    vmax: float,
+    color: str,
+) -> None:
     ax.imshow(_display(image), cmap="gray", vmin=vmin, vmax=vmax)
     shown = np.ma.masked_where(~mask.astype(bool), mask.astype(bool))
     ax.imshow(_display(shown), cmap=color, alpha=0.45, vmin=0, vmax=1)
@@ -78,7 +86,9 @@ def _sub_limit(first: np.ndarray, images: list[np.ndarray]) -> float:
     limits = []
     for image in images:
         sub = image.astype(np.float32) - first.astype(np.float32)
-        limits.extend([abs(float(np.percentile(sub, 1))), abs(float(np.percentile(sub, 99)))])
+        limits.extend(
+            [abs(float(np.percentile(sub, 1))), abs(float(np.percentile(sub, 99)))]
+        )
     value = max(limits) if limits else 1.0
     return value if value > 0 else 1.0
 
@@ -95,9 +105,12 @@ def _ufast_baseline(provenance: dict[str, object]) -> np.ndarray:
 
 
 def render_case(run_root: Path, out_dir: Path, row: pd.Series) -> dict[str, object]:
+    """Render and index one exam's tumor QC panel."""
     exam_id = str(row["exam_id"])
     case_root = run_root / "work" / exam_id
-    provenance = json.loads((case_root / "tumor_preprocessing_provenance.json").read_text())
+    provenance = json.loads(
+        (case_root / "tumor_preprocessing_provenance.json").read_text()
+    )
     phases = pd.read_csv(case_root / "hr_phase_manifest.csv")
     image_paths = [Path(path) for path in phases["hr_image"]]
     images = [_load(path).astype(np.float32) for path in image_paths]
@@ -113,11 +126,15 @@ def render_case(run_root: Path, out_dir: Path, row: pd.Series) -> dict[str, obje
     for _, phase in later_rows.iterrows():
         pred = Path(str(phase["prediction"]))
         if pred.exists():
-            later_masks.append((int(phase["phase_index"]), float(phase["time_seconds"]), _mask(pred)))
+            later_masks.append(
+                (int(phase["phase_index"]), float(phase["time_seconds"]), _mask(pred))
+            )
 
     z = _best_slice(primary, all_components)
     n_cols = 6 + len(later_masks)
-    fig, axes = plt.subplots(2, n_cols, figsize=(2.4 * n_cols, 5.2), constrained_layout=True)
+    fig, axes = plt.subplots(
+        2, n_cols, figsize=(2.4 * n_cols, 5.2), constrained_layout=True
+    )
     if n_cols == 1:
         axes = np.asarray(axes).reshape(2, 1)
     fig.suptitle(f"{exam_id} tumor QC, HR axial z={z}", fontsize=11)
@@ -126,26 +143,57 @@ def render_case(run_root: Path, out_dir: Path, row: pd.Series) -> dict[str, obje
     axes[0, 0].set_title("HR tp0 pre", fontsize=8)
     axes[0, 0].axis("off")
 
-    _overlay(axes[0, 1], first_post[:, :, z], primary[:, :, z], vmin=vmin, vmax=vmax, color="autumn")
-    axes[0, 1].set_title(f"HR tp1 final\n{float(phases.iloc[1]['time_seconds']):.1f}s", fontsize=8)
+    _overlay(
+        axes[0, 1],
+        first_post[:, :, z],
+        primary[:, :, z],
+        vmin=vmin,
+        vmax=vmax,
+        color="autumn",
+    )
+    axes[0, 1].set_title(
+        f"HR tp1 final\n{float(phases.iloc[1]['time_seconds']):.1f}s", fontsize=8
+    )
 
     sub = first_post - pre
-    axes[0, 2].imshow(_display(sub[:, :, z]), cmap="seismic", vmin=-sub_lim, vmax=sub_lim)
-    axes[0, 2].imshow(_display(np.ma.masked_where(~primary[:, :, z], primary[:, :, z])), cmap="autumn", alpha=0.45)
+    axes[0, 2].imshow(
+        _display(sub[:, :, z]), cmap="seismic", vmin=-sub_lim, vmax=sub_lim
+    )
+    axes[0, 2].imshow(
+        _display(np.ma.masked_where(~primary[:, :, z], primary[:, :, z])),
+        cmap="autumn",
+        alpha=0.45,
+    )
     axes[0, 2].set_title("tp1 - tp0", fontsize=8)
     axes[0, 2].axis("off")
 
-    _overlay(axes[0, 3], first_post[:, :, z], all_components[:, :, z], vmin=vmin, vmax=vmax, color="spring")
+    _overlay(
+        axes[0, 3],
+        first_post[:, :, z],
+        all_components[:, :, z],
+        vmin=vmin,
+        vmax=vmax,
+        color="spring",
+    )
     axes[0, 3].set_title("all tp1 comps", fontsize=8)
 
-    _overlay(axes[0, 4], first_post[:, :, z], primary[:, :, z], vmin=vmin, vmax=vmax, color="autumn")
+    _overlay(
+        axes[0, 4],
+        first_post[:, :, z],
+        primary[:, :, z],
+        vmin=vmin,
+        vmax=vmax,
+        color="autumn",
+    )
     axes[0, 4].set_title("primary comp", fontsize=8)
 
     ufast_base = _ufast_baseline(provenance)
     primary_ufast = _mask(case_root / "tumor_masks" / "tumor_primary_ufast.nii.gz")
     z_ufast = _best_slice(primary_ufast)
     uf_vals = ufast_base[ufast_base > 0]
-    uf_vmin, uf_vmax = np.percentile(uf_vals, [0.5, 99.5]) if uf_vals.size else (0.0, 1.0)
+    uf_vmin, uf_vmax = (
+        np.percentile(uf_vals, [0.5, 99.5]) if uf_vals.size else (0.0, 1.0)
+    )
     _overlay(
         axes[0, 5],
         np.transpose(ufast_base, (2, 1, 0))[:, :, z_ufast],
@@ -158,8 +206,17 @@ def render_case(run_root: Path, out_dir: Path, row: pd.Series) -> dict[str, obje
 
     for col, (phase_index, time_seconds, mask) in enumerate(later_masks, start=6):
         image = images[phase_index]
-        _overlay(axes[0, col], image[:, :, z], mask[:, :, z], vmin=vmin, vmax=vmax, color="autumn")
-        axes[0, col].set_title(f"later tp{phase_index}\n{time_seconds:.1f}s", fontsize=8)
+        _overlay(
+            axes[0, col],
+            image[:, :, z],
+            mask[:, :, z],
+            vmin=vmin,
+            vmax=vmax,
+            color="autumn",
+        )
+        axes[0, col].set_title(
+            f"later tp{phase_index}\n{time_seconds:.1f}s", fontsize=8
+        )
 
     for col in range(n_cols):
         axes[1, col].axis("off")
@@ -191,14 +248,21 @@ def render_case(run_root: Path, out_dir: Path, row: pd.Series) -> dict[str, obje
     out_path = out_dir / f"{exam_id}_tumor_contract_qc.png"
     fig.savefig(out_path, dpi=140)
     plt.close(fig)
-    return {"exam_id": exam_id, "dataset": row.get("dataset", ""), "qc_panel": str(out_path)}
+    return {
+        "exam_id": exam_id,
+        "dataset": row.get("dataset", ""),
+        "qc_panel": str(out_path),
+    }
 
 
 def main() -> None:
+    """Render panels and an HTML index for every manifest row."""
     args = parse_args()
     args.out_dir.mkdir(parents=True, exist_ok=True)
     manifest = pd.read_csv(args.run_root / "tumor_mask_manifest.csv")
-    rows = [render_case(args.run_root, args.out_dir, row) for _, row in manifest.iterrows()]
+    rows = [
+        render_case(args.run_root, args.out_dir, row) for _, row in manifest.iterrows()
+    ]
     index = pd.DataFrame(rows)
     index.to_csv(args.out_dir / "index.csv", index=False)
     with (args.out_dir / "index.html").open("w") as stream:

--- a/scripts/qc_uchicago_tumor_contract_30.py
+++ b/scripts/qc_uchicago_tumor_contract_30.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Render QC panels for the mentor-contract 30-case UChicago tumor pilot."""
+"""Render shared-window QC panels for a prepared UChicago tumor run.
+
+Aakrithi Ram implemented this renderer for the original 30-case validation
+pilot. It remains compatible with that run while accepting any prepared tumor
+cohort root explicitly.
+"""
 
 from __future__ import annotations
 
@@ -15,13 +20,12 @@ import pandas as pd
 from preprocessing.dicom import load_dicom_series
 
 
-DEFAULT_RUN_ROOT = Path("/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30")
 DEFAULT_OUT_DIR = Path("qc/uchic_tumor_masks_contract_30")
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--run-root", type=Path, default=DEFAULT_RUN_ROOT)
+    parser.add_argument("--run-root", type=Path, required=True)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     return parser.parse_args()
 
@@ -198,7 +202,7 @@ def main() -> None:
     index = pd.DataFrame(rows)
     index.to_csv(args.out_dir / "index.csv", index=False)
     with (args.out_dir / "index.html").open("w") as stream:
-        stream.write("<html><body><h1>UChicago tumor contract QC, 30-case pilot</h1>\n")
+        stream.write("<html><body><h1>UChicago tumor segmentation QC</h1>\n")
         for row in rows:
             name = Path(row["qc_panel"]).name
             stream.write(f"<h2>{row['exam_id']}</h2>\n")

--- a/scripts/submit_uchicago_tumor_nnunet_jobs.py
+++ b/scripts/submit_uchicago_tumor_nnunet_jobs.py
@@ -13,6 +13,7 @@ DEFAULT_SLURM = Path("slurm/submit_nnunet_tumor_inference.slurm")
 
 
 def parse_args() -> argparse.Namespace:
+    """Parse the prepared run and Slurm submission settings."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-root", type=Path, required=True)
     parser.add_argument("--slurm-script", type=Path, default=DEFAULT_SLURM)
@@ -21,6 +22,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Submit one nnU-Net inference job for each prepared case."""
     args = parse_args()
     run_root = args.run_root.resolve()
     jobs_csv = args.jobs_csv or run_root / "tumor_inference_slurm_jobs.csv"
@@ -33,12 +35,13 @@ def main() -> None:
         cmd = [
             "sbatch",
             "--parsable",
-            "--export=ALL,"
-            f"INPUT_DIR={input_dir},"
-            f"OUTPUT_DIR={output_dir}",
+            f"--export=ALL,INPUT_DIR={input_dir},OUTPUT_DIR={output_dir}",
             str(args.slurm_script),
         ]
-        result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+        # This CLI intentionally executes the caller-selected Slurm wrapper.
+        result = subprocess.run(  # noqa: S603
+            cmd, check=True, text=True, capture_output=True
+        )
         job_id = result.stdout.strip().split(";", maxsplit=1)[0]
         out_row = dict(row)
         out_row["job_id"] = job_id

--- a/scripts/submit_uchicago_tumor_nnunet_jobs.py
+++ b/scripts/submit_uchicago_tumor_nnunet_jobs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Submit MAMA-MIA nnU-Net tumor inference jobs for a prepared UChicago run."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+DEFAULT_SLURM = Path("slurm/submit_nnunet_tumor_inference.slurm")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-root", type=Path, required=True)
+    parser.add_argument("--slurm-script", type=Path, default=DEFAULT_SLURM)
+    parser.add_argument("--jobs-csv", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_root = args.run_root.resolve()
+    jobs_csv = args.jobs_csv or run_root / "tumor_inference_slurm_jobs.csv"
+    cases = pd.read_csv(run_root / "tumor_case_manifest.csv")
+
+    rows = []
+    for _, row in cases.iterrows():
+        input_dir = Path(row["input_dir"]).resolve()
+        output_dir = Path(row["output_dir"]).resolve()
+        cmd = [
+            "sbatch",
+            "--parsable",
+            "--export=ALL,"
+            f"INPUT_DIR={input_dir},"
+            f"OUTPUT_DIR={output_dir}",
+            str(args.slurm_script),
+        ]
+        result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+        job_id = result.stdout.strip().split(";", maxsplit=1)[0]
+        out_row = dict(row)
+        out_row["job_id"] = job_id
+        out_row["slurm_script"] = str(args.slurm_script)
+        rows.append(out_row)
+        print(f"{job_id}\t{row['dataset']}\t{row['exam_id']}")
+
+    pd.DataFrame(rows).to_csv(jobs_csv, index=False)
+    print(f"wrote {jobs_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/slurm/finalize_uchicago_tumor_30_contract.slurm
+++ b/slurm/finalize_uchicago_tumor_30_contract.slurm
@@ -1,0 +1,29 @@
+#!/bin/bash
+#SBATCH --job-name=uchic-tumor-final30
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+set -eo pipefail
+
+cd /ess/home/home1/aakrithiram/vanguard
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+mkdir -p logs/slurm
+
+RUN_ROOT="${RUN_ROOT:-/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30}"
+
+echo "host=$(hostname)"
+echo "date=$(date -Is)"
+echo "python=$(which python)"
+echo "run_root=${RUN_ROOT}"
+
+python -m preprocessing.tumor finalize-cohort \
+  --output-root "${RUN_ROOT}"

--- a/slurm/finalize_uchicago_tumor_30_contract.slurm
+++ b/slurm/finalize_uchicago_tumor_30_contract.slurm
@@ -8,17 +8,15 @@
 #SBATCH --output=logs/slurm/%x-%j.out
 #SBATCH --error=logs/slurm/%x-%j.err
 
-set -eo pipefail
-
-cd /ess/home/home1/aakrithiram/vanguard
-
+REPO_ROOT="${REPO_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${REPO_ROOT}"
 eval "$(micromamba shell hook -s bash)"
 micromamba activate vanguard
-set -u
+set -euo pipefail
 
 mkdir -p logs/slurm
 
-RUN_ROOT="${RUN_ROOT:-/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30}"
+: "${RUN_ROOT:?set RUN_ROOT to the prepared tumor output directory}"
 
 echo "host=$(hostname)"
 echo "date=$(date -Is)"

--- a/slurm/prepare_uchicago_tumor_30_contract.slurm
+++ b/slurm/prepare_uchicago_tumor_30_contract.slurm
@@ -1,0 +1,29 @@
+#!/bin/bash
+#SBATCH --job-name=uchic-tumor-prep30
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=04:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+set -eo pipefail
+
+cd /ess/home/home1/aakrithiram/vanguard
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+mkdir -p logs/slurm
+
+RUN_ROOT="${RUN_ROOT:-/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30}"
+
+echo "host=$(hostname)"
+echo "date=$(date -Is)"
+echo "python=$(which python)"
+echo "run_root=${RUN_ROOT}"
+
+python -m preprocessing.tumor prepare-cohort \
+  --output-root "${RUN_ROOT}"

--- a/slurm/prepare_uchicago_tumor_30_contract.slurm
+++ b/slurm/prepare_uchicago_tumor_30_contract.slurm
@@ -8,17 +8,15 @@
 #SBATCH --output=logs/slurm/%x-%j.out
 #SBATCH --error=logs/slurm/%x-%j.err
 
-set -eo pipefail
-
-cd /ess/home/home1/aakrithiram/vanguard
-
+REPO_ROOT="${REPO_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${REPO_ROOT}"
 eval "$(micromamba shell hook -s bash)"
 micromamba activate vanguard
-set -u
+set -euo pipefail
 
 mkdir -p logs/slurm
 
-RUN_ROOT="${RUN_ROOT:-/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30}"
+: "${RUN_ROOT:?set RUN_ROOT to the prepared tumor output directory}"
 
 echo "host=$(hostname)"
 echo "date=$(date -Is)"

--- a/slurm/qc_uchicago_tumor_contract_30.slurm
+++ b/slurm/qc_uchicago_tumor_contract_30.slurm
@@ -8,19 +8,16 @@
 #SBATCH --output=logs/slurm/%x-%j.out
 #SBATCH --error=logs/slurm/%x-%j.err
 
-set -eo pipefail
-
-cd /ess/home/home1/aakrithiram/vanguard
-
+REPO_ROOT="${REPO_ROOT:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${REPO_ROOT}"
 eval "$(micromamba shell hook -s bash)"
 micromamba activate vanguard
-set -u
+set -euo pipefail
 
-export MPLCONFIGDIR=/ess/scratch/scratch1/aakrithiram/tmp/matplotlib
+: "${RUN_ROOT:?set RUN_ROOT to the prepared tumor output directory}"
+OUT_DIR="${OUT_DIR:-${RUN_ROOT}/qc}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-${RUN_ROOT}/.matplotlib}"
 mkdir -p "${MPLCONFIGDIR}" logs/slurm
-
-RUN_ROOT="${RUN_ROOT:-/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30}"
-OUT_DIR="${OUT_DIR:-/ess/home/home1/aakrithiram/vanguard/qc/uchic_tumor_masks_contract_30}"
 
 echo "host=$(hostname)"
 echo "date=$(date -Is)"

--- a/slurm/qc_uchicago_tumor_contract_30.slurm
+++ b/slurm/qc_uchicago_tumor_contract_30.slurm
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH --job-name=uchic-tumor-qc30
+#SBATCH --account=karczmar-lab
+#SBATCH --partition=tier1q
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#SBATCH --time=02:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+set -eo pipefail
+
+cd /ess/home/home1/aakrithiram/vanguard
+
+eval "$(micromamba shell hook -s bash)"
+micromamba activate vanguard
+set -u
+
+export MPLCONFIGDIR=/ess/scratch/scratch1/aakrithiram/tmp/matplotlib
+mkdir -p "${MPLCONFIGDIR}" logs/slurm
+
+RUN_ROOT="${RUN_ROOT:-/ess/scratch/scratch1/aakrithiram/uchic_tumor_masks_contract_30}"
+OUT_DIR="${OUT_DIR:-/ess/home/home1/aakrithiram/vanguard/qc/uchic_tumor_masks_contract_30}"
+
+echo "host=$(hostname)"
+echo "date=$(date -Is)"
+echo "python=$(which python)"
+echo "run_root=${RUN_ROOT}"
+echo "out_dir=${OUT_DIR}"
+
+python scripts/qc_uchicago_tumor_contract_30.py \
+  --run-root "${RUN_ROOT}" \
+  --out-dir "${OUT_DIR}"

--- a/slurm/submit_nnunet_tumor_inference.slurm
+++ b/slurm/submit_nnunet_tumor_inference.slurm
@@ -8,15 +8,11 @@
 #SBATCH --output=logs/slurm/%x-%j.out
 #SBATCH --error=logs/slurm/%x-%j.err
 
-set -euo pipefail
-
-: "${INPUT_DIR:?set INPUT_DIR to a folder of nnU-Net inputs named CASE_0000.nii.gz}"
-
 REPO_ROOT="${SLURM_SUBMIT_DIR:-${REPO_ROOT:-$PWD}}"
 RUN_ID="${SLURM_JOB_ID:-manual}"
 OUTPUT_DIR="${OUTPUT_DIR:-results/nnunet_tumor_inference/${RUN_ID}}"
-VANGUARD_NNUNET_ENV="${VANGUARD_NNUNET_ENV:-/ess/scratch/scratch1/aakrithiram/micromamba/envs/vanguard-nnunet}"
-NNUNET_ROOT="${NNUNET_ROOT:-/ess/scratch/scratch1/aakrithiram/nnunet_vanguard}"
+VANGUARD_NNUNET_ENV="${VANGUARD_NNUNET_ENV:?set VANGUARD_NNUNET_ENV to the nnU-Net environment prefix}"
+NNUNET_ROOT="${NNUNET_ROOT:?set NNUNET_ROOT to the nnU-Net runtime root}"
 MODEL_DIR="${MODEL_DIR:-${NNUNET_ROOT}/results/full_image_dce_mri_tumor_segmentation}"
 DEVICE="${DEVICE:-cuda}"
 FOLDS="${FOLDS:-0 1 2 3 4}"
@@ -24,15 +20,12 @@ NPP="${NPP:-${SLURM_CPUS_PER_TASK:-4}}"
 NPS="${NPS:-${SLURM_CPUS_PER_TASK:-4}}"
 
 cd "${REPO_ROOT}"
-mkdir -p logs/slurm "${OUTPUT_DIR}"
+eval "$(micromamba shell hook -s bash)"
+micromamba activate "${VANGUARD_NNUNET_ENV}"
+set -euo pipefail
 
-set +u
-source ~/.bashrc || true
-if command -v micromamba >/dev/null 2>&1; then
-  eval "$(micromamba shell hook -s bash)"
-  micromamba activate "${VANGUARD_NNUNET_ENV}"
-fi
-set -u
+: "${INPUT_DIR:?set INPUT_DIR to a folder of nnU-Net inputs named CASE_0000.nii.gz}"
+mkdir -p logs/slurm "${OUTPUT_DIR}"
 
 export nnUNet_raw="${NNUNET_ROOT}/raw"
 export nnUNet_preprocessed="${NNUNET_ROOT}/preprocessed"

--- a/slurm/submit_nnunet_tumor_inference.slurm
+++ b/slurm/submit_nnunet_tumor_inference.slurm
@@ -1,0 +1,80 @@
+#!/bin/bash
+#SBATCH --job-name=nnunet-tumor
+#SBATCH --partition=gpuq
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=48G
+#SBATCH --time=04:00:00
+#SBATCH --output=logs/slurm/%x-%j.out
+#SBATCH --error=logs/slurm/%x-%j.err
+
+set -euo pipefail
+
+: "${INPUT_DIR:?set INPUT_DIR to a folder of nnU-Net inputs named CASE_0000.nii.gz}"
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-${REPO_ROOT:-$PWD}}"
+RUN_ID="${SLURM_JOB_ID:-manual}"
+OUTPUT_DIR="${OUTPUT_DIR:-results/nnunet_tumor_inference/${RUN_ID}}"
+VANGUARD_NNUNET_ENV="${VANGUARD_NNUNET_ENV:-/ess/scratch/scratch1/aakrithiram/micromamba/envs/vanguard-nnunet}"
+NNUNET_ROOT="${NNUNET_ROOT:-/ess/scratch/scratch1/aakrithiram/nnunet_vanguard}"
+MODEL_DIR="${MODEL_DIR:-${NNUNET_ROOT}/results/full_image_dce_mri_tumor_segmentation}"
+DEVICE="${DEVICE:-cuda}"
+FOLDS="${FOLDS:-0 1 2 3 4}"
+NPP="${NPP:-${SLURM_CPUS_PER_TASK:-4}}"
+NPS="${NPS:-${SLURM_CPUS_PER_TASK:-4}}"
+
+cd "${REPO_ROOT}"
+mkdir -p logs/slurm "${OUTPUT_DIR}"
+
+set +u
+source ~/.bashrc || true
+if command -v micromamba >/dev/null 2>&1; then
+  eval "$(micromamba shell hook -s bash)"
+  micromamba activate "${VANGUARD_NNUNET_ENV}"
+fi
+set -u
+
+export nnUNet_raw="${NNUNET_ROOT}/raw"
+export nnUNet_preprocessed="${NNUNET_ROOT}/preprocessed"
+export nnUNet_results="${NNUNET_ROOT}/results"
+export LD_LIBRARY_PATH="${VANGUARD_NNUNET_ENV}/lib:${LD_LIBRARY_PATH:-}"
+export PYTHONUNBUFFERED=1
+export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK:-4}"
+export MKL_NUM_THREADS="${SLURM_CPUS_PER_TASK:-4}"
+
+echo "=== nnU-Net tumor inference ==="
+echo "Job: ${SLURM_JOB_ID:-manual}"
+echo "Node: $(hostname)"
+echo "Date: $(date)"
+echo "Repo: ${REPO_ROOT}"
+echo "Env: ${VANGUARD_NNUNET_ENV}"
+echo "Input: ${INPUT_DIR}"
+echo "Output: ${OUTPUT_DIR}"
+echo "Model: ${MODEL_DIR}"
+echo "Device: ${DEVICE}"
+echo "Folds: ${FOLDS}"
+which python
+python - <<'PY'
+import sys
+import torch
+print(sys.executable)
+print("torch", torch.__version__)
+print("cuda_available", torch.cuda.is_available())
+PY
+
+read -r -a FOLD_ARGS <<< "${FOLDS}"
+cmd=(
+  nnUNetv2_predict_from_modelfolder
+  -i "${INPUT_DIR}"
+  -o "${OUTPUT_DIR}"
+  -m "${MODEL_DIR}"
+  -f "${FOLD_ARGS[@]}"
+  -device "${DEVICE}"
+  -npp "${NPP}"
+  -nps "${NPS}"
+  --disable_progress_bar
+)
+
+echo "Command: ${cmd[*]}"
+"${cmd[@]}"
+echo "=== Finished: $(date) ==="

--- a/slurm/submit_tumor_pipeline.sh
+++ b/slurm/submit_tumor_pipeline.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Submit the UChicago high-resolution MAMA-MIA tumor-mask pipeline.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+RUN_ROOT="${RUN_ROOT:?set RUN_ROOT to a fresh output directory}"
+INVENTORY="${INVENTORY:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/paired_hr_ufast_source_dicom/dicom_file_manifest.parquet}"
+CASE_MANIFEST="${CASE_MANIFEST:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/paired_hr_ufast_source_dicom/paired_preprocessing_case_manifest.csv}"
+COHORT_MANIFEST="${COHORT_MANIFEST:-/gpfs/data/karczmar-lab/vanguard/dce2d_internal_ultrafast_manifest/dce2d_internal_ultrafast_with_high_resolution_manifest.csv}"
+MODEL_DIR="${MODEL_DIR:?set MODEL_DIR to the extracted MAMA-MIA model directory}"
+NNUNET_ENV="${NNUNET_ENV:?set NNUNET_ENV to an nnU-Net 2.5 environment prefix}"
+CENTERLINE_ROOT="${CENTERLINE_ROOT:-}"
+PREP_CONCURRENCY="${PREP_CONCURRENCY:-12}"
+GPU_CONCURRENCY="${GPU_CONCURRENCY:-8}"
+
+[[ -f "${MODEL_DIR}/fold_0/checkpoint_final.pth" ]] || {
+  echo "model is not extracted at ${MODEL_DIR}" >&2
+  exit 2
+}
+[[ -x "${NNUNET_ENV}/bin/nnUNetv2_predict_from_modelfolder" ]] || {
+  echo "nnU-Net predictor is missing from ${NNUNET_ENV}" >&2
+  exit 2
+}
+
+mkdir -p "${REPO_ROOT}/logs/slurm" "${RUN_ROOT}"
+N_CASES="$(python - "${CASE_MANIFEST}" <<'PY'
+import csv
+import sys
+
+with open(sys.argv[1], newline="") as stream:
+    print(sum(1 for _ in csv.DictReader(stream)))
+PY
+)"
+LAST_INDEX="$((N_CASES - 1))"
+EXPORTS="ALL,REPO_ROOT=${REPO_ROOT},RUN_ROOT=${RUN_ROOT},INVENTORY=${INVENTORY},CASE_MANIFEST=${CASE_MANIFEST},COHORT_MANIFEST=${COHORT_MANIFEST},MODEL_DIR=${MODEL_DIR},NNUNET_ENV=${NNUNET_ENV},CENTERLINE_ROOT=${CENTERLINE_ROOT}"
+
+cd "${REPO_ROOT}"
+PREP_JOB="$(sbatch --parsable --array="0-${LAST_INDEX}%${PREP_CONCURRENCY}" \
+  --export="${EXPORTS}" preprocessing/slurm/tumor_prepare_case.slurm)"
+INDEX_JOB="$(sbatch --parsable --dependency="afterok:${PREP_JOB}" \
+  --export="${EXPORTS}" preprocessing/slurm/tumor_index_cohort.slurm)"
+INFER_JOB="$(sbatch --parsable --dependency="afterok:${INDEX_JOB}" \
+  --array="0-${LAST_INDEX}%${GPU_CONCURRENCY}" --export="${EXPORTS}" \
+  preprocessing/slurm/tumor_infer_case.slurm)"
+FINAL_JOB="$(sbatch --parsable --dependency="afterok:${INFER_JOB}" \
+  --export="${EXPORTS}" preprocessing/slurm/tumor_finalize_cohort.slurm)"
+
+printf 'prepare=%s\nindex=%s\ninfer=%s\nfinalize=%s\n' \
+  "${PREP_JOB}" "${INDEX_JOB}" "${INFER_JOB}" "${FINAL_JOB}" \
+  | tee "${RUN_ROOT}/tumor_pipeline_jobs.txt"


### PR DESCRIPTION
  ## Summary

  This PR adds the reproducible tumor-segmentation workflow used for the UChicago HR/UFAST DCE-MRI cohorts. It includes Aakrithi’s original tumor-segmentation and QC implementation, with my cohort-scale processing and publication additions layered on top.

  The pipeline:

  - motion-corrects the high-resolution DCE phases to precontrast
  - runs the released MAMA-MIA nnU-Net model on postcontrast phases
  - uses the first postcontrast prediction for the final tumor mask
  - retains later-phase predictions for temporal QC
  - selects the largest connected component as the primary tumor
  - maps the tumor mask onto the corresponding 1-mm UFAST image grid
  - flags possible bilateral tumors for review
  - records segmentation, model, geometry, alignment, and source provenance

  It includes restartable Slurm stages for case preparation, inference, finalization, and cohort publication. Publication produces stable tumor-mask paths and a joined manifest containing
  tumor laterality, review flags, and associated skeleton, support-mask, and morphometry paths.

  The shared-window QC renderer keeps enhancement and washout differences visible across DCE phases.